### PR TITLE
Accept a zero-length value in MPI_Info_set

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,12 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- ``MPI_Info_set`` now accepts a zero-length (empty) value string.  It
+  previously raised ``MPI_ERR_INFO_VALUE`` for an empty value, but
+  MPI-5.0 chapter 10 only limits the *maximum* length of an info
+  value, and gives the empty string a defined meaning for the
+  ``mpi_memory_alloc_kinds`` info key.  Empty *keys* remain invalid.
+
 - Partitioned communication fixes:
 
   - ``MPI_Parrived`` now returns ``flag = true`` for a null request

--- a/ompi/info/info_memkind.c
+++ b/ompi/info/info_memkind.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC.  All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,7 +47,7 @@ static void ompi_info_memkind_dump (const char *var_name, int num_memkinds, ompi
 }
 #endif
 
-static void ompi_info_memkind_extract (const char* memkind_str, int *num_memkinds, ompi_memkind_t **memkinds)
+static int ompi_info_memkind_extract (const char* memkind_str, int *num_memkinds, ompi_memkind_t **memkinds)
 {
     /* The memkind string is a comma-separated list of memkinds, which can have two forms:
     **   - standalone memkind type, which implies that all restrictors of the memkind are requested
@@ -56,15 +57,35 @@ static void ompi_info_memkind_extract (const char* memkind_str, int *num_memkind
     **    memkind_a:restrictor_1,memkind_a:restrictor_2;
     */
 
+    /* A NULL or empty memkind_str -- or one consisting only of
+     * delimiters, which yields no tokens -- is a request for no memory
+     * allocation kinds */
+    if (NULL == memkind_str ||
+        strspn(memkind_str, ",") == strlen(memkind_str)) {
+        *num_memkinds = 0;
+        *memkinds = NULL;
+        return OMPI_SUCCESS;
+    }
+
     /* Separate requested_str into an array of individual entries */
     int current_max = 0;
     char **memkind_combos = opal_argv_split(memkind_str, ',');
+    if (NULL == memkind_combos) {
+        /* memkind_str has at least one token, so a NULL here can only
+         * mean an allocation failure in the split */
+        *num_memkinds = 0;
+        *memkinds = NULL;
+        return OMPI_ERR_OUT_OF_RESOURCE;
+    }
     int max_num_memkinds = opal_argv_count(memkind_combos);
 
     ompi_memkind_t *memkind_arr = NULL;
     memkind_arr = (ompi_memkind_t *) malloc(max_num_memkinds * sizeof(ompi_memkind_t));
     if (NULL == memkind_arr) {
-        goto err_exit;
+        opal_argv_free(memkind_combos);
+        *num_memkinds = 0;
+        *memkinds = NULL;
+        return OMPI_ERR_OUT_OF_RESOURCE;
     }
     for (int i = 0; i < max_num_memkinds; i++) {
         memkind_arr[i].im_num_restrictors = 0;
@@ -120,12 +141,12 @@ static void ompi_info_memkind_extract (const char* memkind_str, int *num_memkind
         opal_argv_free(tmp_str);
         m = memkind_combos[++iter];
     }
+    opal_argv_free(memkind_combos);
 
- err_exit:
     *num_memkinds = current_max;
     *memkinds = memkind_arr;
 
-    return;
+    return OMPI_SUCCESS;
 }
 
 static int ompi_info_memkind_get_available(int *num_memkinds, ompi_memkind_t **memkinds)
@@ -246,9 +267,14 @@ static int ompi_info_memkind_remove_unsupported (int num_requested, ompi_memkind
     bool have_system_memkind = false;
     bool have_mpi_memkind = false;
     int pos = 0;
-    int *apos = malloc (num_requested *sizeof(int));
-    if (NULL == apos) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
+    int *apos = NULL;
+    /* malloc(0) is allowed to return NULL, so only allocate (and check)
+     * when there are requested memkinds to track */
+    if (num_requested > 0) {
+        apos = malloc (num_requested *sizeof(int));
+        if (NULL == apos) {
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
     }
 
     /*
@@ -399,14 +425,22 @@ static bool ompi_info_memkind_validate (const char *assert_str, const char *pare
     ompi_memkind_t *parent_memkinds = NULL;
     bool ret;
 
-    ompi_info_memkind_extract (assert_str, &num_assert_memkinds, &assert_memkinds);
+    ret = (OMPI_SUCCESS == ompi_info_memkind_extract (assert_str, &num_assert_memkinds,
+                                                      &assert_memkinds));
+    if (!ret) {
+        goto exit;
+    }
     ret = ompi_info_memkind_is_subset (num_assert_memkinds, assert_memkinds,
                                        ompi_info_memkind_num_available, ompi_info_memkind_available);
     if (!ret) {
         goto exit;
     }
 
-    ompi_info_memkind_extract (parent_str, &num_parent_memkinds, &parent_memkinds);
+    ret = (OMPI_SUCCESS == ompi_info_memkind_extract (parent_str, &num_parent_memkinds,
+                                                      &parent_memkinds));
+    if (!ret) {
+        goto exit;
+    }
     ret = ompi_info_memkind_is_subset (num_assert_memkinds, assert_memkinds,
                                        num_parent_memkinds, parent_memkinds);
 
@@ -445,9 +479,14 @@ static bool ompi_info_memkind_check_no_accel_from_string (char *mstring)
     int num_memkinds;
     ompi_memkind_t *memkinds = NULL;
 
-    ompi_info_memkind_extract (mstring, &num_memkinds, &memkinds);
+    if (OMPI_SUCCESS != ompi_info_memkind_extract (mstring, &num_memkinds, &memkinds)) {
+        return false;
+    }
+
+    /* Note that an empty set of memkinds (num_memkinds == 0) trivially
+     * contains no accelerator kinds, i.e., returns true */
+    ret = ompi_info_memkind_check_no_accel (num_memkinds, memkinds);
     if (NULL != memkinds) {
-        ret = ompi_info_memkind_check_no_accel (num_memkinds, memkinds);
         ompi_info_memkind_free(num_memkinds, memkinds);
     }
 
@@ -470,7 +509,10 @@ int ompi_info_memkind_process (const char* requested_str, char **provided_str,
         return OMPI_SUCCESS;
     }
 
-    ompi_info_memkind_extract (requested_str, &num_requested_memkinds, &requested_memkinds);
+    err = ompi_info_memkind_extract (requested_str, &num_requested_memkinds, &requested_memkinds);
+    if (OMPI_SUCCESS != err) {
+        goto exit;
+    }
     err = ompi_info_memkind_get_available (&num_available_memkinds, &available_memkinds);
     if (OMPI_SUCCESS != err) {
         goto exit;

--- a/ompi/mpi/c/info_set.c.in
+++ b/ompi/mpi/c/info_set.c.in
@@ -16,6 +16,7 @@
  * Copyright (c) 2018 IBM Corporation. All rights reserved.
  * Copyright (c) 2018-2024 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -84,7 +85,7 @@ PROTOTYPE ERROR_CLASS info_set(INFO info, STRING key, STRING value)
         }
 
         value_length = (value) ? (int)strlen (value) : 0;
-        if ((NULL == value) || (0 == value_length) ||
+        if ((NULL == value) ||
             (MPI_MAX_INFO_VAL <= value_length)) {
             return OMPI_ERRHANDLER_INVOKE (MPI_COMM_WORLD, MPI_ERR_INFO_VALUE,
                                            FUNC_NAME);

--- a/ompi/test/general/info_mpi.c
+++ b/ompi/test/general/info_mpi.c
@@ -27,6 +27,7 @@
 
 #include "ompi/constants.h"
 #include "ompi/info/info_memkind.h"
+#include "ompi/runtime/params.h"
 
 #include "mpi.h"
 
@@ -140,18 +141,23 @@ static void test_info_empty_value(void)
                 MPI_SUCCESS == rc && 1 == flag);
     test_verify("valuelen of empty value is 0", 0 == vlen);
 
-    /* An empty key must still be rejected */
-    rc = MPI_Info_set(info, "", "value");
-    test_verify("Info_set still rejects an empty key",
-                MPI_ERR_INFO_KEY == rc);
+    /* The rejection tests below only apply when MPI parameter
+     * checking is active (it can be disabled at configure time or at
+     * run time) */
+    if (ompi_mpi_param_check) {
+        /* An empty key must still be rejected */
+        rc = MPI_Info_set(info, "", "value");
+        test_verify("Info_set still rejects an empty key",
+                    MPI_ERR_INFO_KEY == rc);
 
-    /* An over-long value must still be rejected */
-    char big[MPI_MAX_INFO_VAL + 8];
-    memset(big, 'x', sizeof(big) - 1);
-    big[sizeof(big) - 1] = '\0';
-    rc = MPI_Info_set(info, "emptyval", big);
-    test_verify("Info_set still rejects an over-long value",
-                MPI_ERR_INFO_VALUE == rc);
+        /* An over-long value must still be rejected */
+        char big[MPI_MAX_INFO_VAL + 8];
+        memset(big, 'x', sizeof(big) - 1);
+        big[sizeof(big) - 1] = '\0';
+        rc = MPI_Info_set(info, "emptyval", big);
+        test_verify("Info_set still rejects an over-long value",
+                    MPI_ERR_INFO_VALUE == rc);
+    }
 
     MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
 
@@ -205,6 +211,18 @@ static void test_memkind_process(void)
     test_verify("memkind_process(NULL) succeeds", OMPI_SUCCESS == rc);
     test_verify("memkind_process(NULL) -> NULL provided", NULL == provided);
     test_verify("memkind_process(NULL) -> UNDEFINED", OMPI_INFO_MEMKIND_ASSERT_UNDEFINED == type);
+
+    /* "" (no kinds requested; settable since MPI_Info_set accepts an
+     * empty value, see GitHub issue #14246) -> provided still contains
+     * the always-supported system and mpi; NO_ACCEL */
+    provided = NULL;
+    rc = ompi_info_memkind_process("", &provided, &type);
+    test_verify("memkind_process(\"\") succeeds", OMPI_SUCCESS == rc);
+    check_has("empty request: provided contains system", provided, "system");
+    check_has("empty request: provided contains mpi", provided, "mpi");
+    test_verify("empty request is NO_ACCEL",
+                OMPI_INFO_MEMKIND_ASSERT_NO_ACCEL == type);
+    free(provided);
 
     /* "system" -> provided contains system and mpi; NO_ACCEL */
     provided = NULL;

--- a/ompi/test/general/info_mpi.c
+++ b/ompi/test/general/info_mpi.c
@@ -34,6 +34,7 @@ static int argc_saved;
 static char **argv_saved;
 
 static void test_info_api(void);
+static void test_info_empty_value(void);
 static void test_info_env(void);
 static void test_memkind_process(void);
 
@@ -48,6 +49,7 @@ int main(int argc, char *argv[])
     test_verify("MPI_Init succeeds", MPI_SUCCESS == rc);
 
     test_info_api();
+    test_info_empty_value();
     test_info_env();
     test_memkind_process();
 
@@ -98,6 +100,62 @@ static void test_info_api(void)
     test_verify("Info_free succeeds", MPI_SUCCESS == rc);
     test_verify("Info_free NULLs the handle", MPI_INFO_NULL == info);
     MPI_Info_free(&dup);
+}
+
+/* ------------------------------------------------------------------ */
+
+/* An empty string is a valid info value: MPI-5.0 chapter 10 only
+ * limits the *maximum* length of a value, and gives the empty string
+ * a defined meaning for the "mpi_memory_alloc_kinds" info key.  Empty
+ * keys and over-long values must still be rejected.  This exercises
+ * the parameter checks in the MPI_Info_set binding itself (see GitHub
+ * issue #14246), which is why the checks go through the public MPI
+ * API and not the ompi/opal back-end functions. */
+static void test_info_empty_value(void)
+{
+    MPI_Info info = MPI_INFO_NULL;
+    int rc = MPI_Info_create(&info);
+    test_verify("Info_create succeeds (empty value)",
+                MPI_SUCCESS == rc && MPI_INFO_NULL != info);
+
+    /* The error checks below must not abort the test program */
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    rc = MPI_Info_set(info, "emptyval", "");
+    test_verify("Info_set accepts an empty value", MPI_SUCCESS == rc);
+
+    char value[9] = "sentinel";
+    int buflen = sizeof(value);
+    int flag = 0;
+    rc = MPI_Info_get_string(info, "emptyval", &buflen, value, &flag);
+    test_verify("get_string of empty value succeeds", MPI_SUCCESS == rc);
+    test_verify("get_string finds the key", 1 == flag);
+    test_verify("returned value is the empty string", 0 == strcmp(value, ""));
+    test_verify("required buflen is 1 (just the \\0)", 1 == buflen);
+
+    int vlen = -1;
+    flag = 0;
+    rc = MPI_Info_get_valuelen(info, "emptyval", &vlen, &flag);
+    test_verify("get_valuelen of empty value succeeds",
+                MPI_SUCCESS == rc && 1 == flag);
+    test_verify("valuelen of empty value is 0", 0 == vlen);
+
+    /* An empty key must still be rejected */
+    rc = MPI_Info_set(info, "", "value");
+    test_verify("Info_set still rejects an empty key",
+                MPI_ERR_INFO_KEY == rc);
+
+    /* An over-long value must still be rejected */
+    char big[MPI_MAX_INFO_VAL + 8];
+    memset(big, 'x', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    rc = MPI_Info_set(info, "emptyval", big);
+    test_verify("Info_set still rejects an over-long value",
+                MPI_ERR_INFO_VALUE == rc);
+
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
+
+    MPI_Info_free(&info);
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/util/opal_info.c
+++ b/test/util/opal_info.c
@@ -48,6 +48,7 @@
 
 static void test_set_and_get(void);
 static void test_set_cstring(void);
+static void test_empty_value(void);
 static void test_get_missing_key(void);
 static void test_overwrite(void);
 static void test_delete(void);
@@ -72,6 +73,7 @@ int main(int argc, char *argv[])
 
     test_set_and_get();
     test_set_cstring();
+    test_empty_value();
     test_get_missing_key();
     test_overwrite();
     test_delete();
@@ -142,6 +144,62 @@ static void test_set_cstring(void)
     test_verify("flag is 1 after set_cstring", 1 == flag);
     test_verify("value matches cstring content",
                 NULL != val && 0 == strcmp(val->string, "cstring_val"));
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    OBJ_RELEASE(info);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * An empty string is a valid info value (MPI-5.0 chapter 10 only
+ * limits the *maximum* length of a value, and gives the empty string
+ * a defined meaning for the "mpi_memory_alloc_kinds" info key).
+ */
+static void test_empty_value(void)
+{
+    opal_info_t *info = OBJ_NEW(opal_info_t);
+
+    /* Set a key with an empty value and read it back */
+    int rc = opal_info_set(info, "emptykey", "");
+    test_verify("set with empty value returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+
+    opal_cstring_t *val = NULL;
+    int flag = 0;
+    rc = opal_info_get(info, "emptykey", &val, &flag);
+    test_verify("get of empty value returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for empty value", 1 == flag);
+    test_verify("empty value string matches",
+                NULL != val && 0 == strcmp(val->string, ""));
+    test_verify("empty value length is 0", NULL != val && 0 == val->length);
+    if (NULL != val) {
+        OBJ_RELEASE(val);
+    }
+
+    int vlen = 999;
+    flag = 0;
+    rc = opal_info_get_valuelen(info, "emptykey", &vlen, &flag);
+    test_verify("get_valuelen of empty value returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+    test_verify("flag is 1 for empty value (valuelen)", 1 == flag);
+    test_verify("valuelen is 0 for empty value", 0 == vlen);
+
+    /* Overwrite a non-empty value with an empty one */
+    rc = opal_info_set(info, "emptykey2", "nonempty");
+    test_verify("set non-empty value returns OPAL_SUCCESS", OPAL_SUCCESS == rc);
+    rc = opal_info_set(info, "emptykey2", "");
+    test_verify("overwrite with empty value returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    val = NULL;
+    flag = 0;
+    rc = opal_info_get(info, "emptykey2", &val, &flag);
+    test_verify("get after overwrite-with-empty succeeds", OPAL_SUCCESS == rc);
+    test_verify("flag is 1 after overwrite-with-empty", 1 == flag);
+    test_verify("value is empty after overwrite-with-empty",
+                NULL != val && 0 == val->length && 0 == strcmp(val->string, ""));
     if (NULL != val) {
         OBJ_RELEASE(val);
     }


### PR DESCRIPTION
MPI_Info_set raised MPI_ERR_INFO_VALUE for an empty value string, but the MPI-5.0 standard (chapter 10, MPI_INFO_SET) only specifies an error for values *longer* than the maximum length. Indeed, MPI-5.0 gives the empty string a defined meaning for the reserved `mpi_memory_alloc_kinds` info key ("A value corresponding to the empty string represents no memory allocation kinds"), so it must be settable. This PR removes the zero-length value check from the MPI_Info_set parameter checks (empty *keys* remain invalid), and extends the info tests in `make check` to verify the new behavior through the public bindings as well as in the opal_info back end.

The second commit fixes a segfault that accepting empty values made reachable: `ompi_info_memkind_extract()` dereferenced the NULL that `opal_argv_split()` returns for an empty string, so passing an info object with `mpi_memory_alloc_kinds` set to `""` to `MPI_Session_init` would crash. An empty (or all-delimiter) memkind string is now treated as a request for no memory allocation kinds; the provided kinds still contain the always-supported `system` and `mpi`, matching how a request naming only unrecognized kinds is handled. While at it, that code path was hardened: the extractor now returns a status code so an allocation failure is distinguishable from an empty request, no longer leaks the split string array, and a zero-length request no longer relies on `malloc(0)` returning non-NULL. The new `make check` test case segfaults without this fix.

Fixes #14246. Thanks to Erik Schnetter for the report and the analysis, which was exactly right.
