### PR TITLE
Fix CodeQL double-free alert in mca_base_var_build_env()

### DIFF
--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -1084,11 +1084,17 @@ int mca_base_var_build_env(char ***env, int *num_env, bool internal)
         switch (var->mbv_source) {
         case MCA_BASE_VAR_SOURCE_FILE:
         case MCA_BASE_VAR_SOURCE_OVERRIDE:
-            opal_asprintf(&str, "%sSOURCE_%s=FILE:%s", mca_prefix, var->mbv_full_name,
-                          mca_base_var_source_file(var));
+            ret = opal_asprintf(&str, "%sSOURCE_%s=FILE:%s", mca_prefix, var->mbv_full_name,
+                                mca_base_var_source_file(var));
+            if (0 > ret) {
+                goto cleanup;
+            }
             break;
         case MCA_BASE_VAR_SOURCE_COMMAND_LINE:
-            opal_asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", mca_prefix, var->mbv_full_name);
+            ret = opal_asprintf(&str, "%sSOURCE_%s=COMMAND_LINE", mca_prefix, var->mbv_full_name);
+            if (0 > ret) {
+                goto cleanup;
+            }
             break;
         case MCA_BASE_VAR_SOURCE_ENV:
         case MCA_BASE_VAR_SOURCE_SET:

--- a/opal/mca/base/mca_base_var.c
+++ b/opal/mca/base/mca_base_var.c
@@ -1079,6 +1079,7 @@ int mca_base_var_build_env(char ***env, int *num_env, bool internal)
 
         opal_argv_append(num_env, env, str);
         free(str);
+        str = NULL;
 
         switch (var->mbv_source) {
         case MCA_BASE_VAR_SOURCE_FILE:


### PR DESCRIPTION
This resolves [CodeQL code scanning alert 34](https://github.com/open-mpi/ompi/security/code-scanning/34), a potential double free in `mca_base_var_build_env()`.

The alert is technically a false positive: the flagged path would require `opal_asprintf()` to fail while leaving the output pointer pointing at already-freed memory, but `opal_vasprintf()` explicitly guarantees that the output pointer is set to NULL on failure (that guarantee is the reason the wrapper exists).  However, that reasoning is non-local -- it depends on a property of the wrapper that neither static analysis nor a human reader can see at the call site.  The first commit sets `str` to NULL immediately after the `free()`, making the no-double-free property locally obvious and resolving the alert.

The second commit is a small drive-by cleanup in the same loop: the two `opal_asprintf()` calls that build the `SOURCE_` environment strings ignored their return values, silently omitting the variable's source information on failure.  They now bail out to `cleanup` on failure, matching the error handling of the earlier `opal_asprintf()` call in the same loop.

Verified with a clean VPATH build on macOS: `mca_base_var.c` compiles with no warnings and `libopen-pal` links.  Both commits cherry-pick cleanly onto the current tips of `v5.0.x` and `v6.0.x`.
