### PR TITLE
Fix CodeQL snprintf-overflow and format-specifier alerts in coll

### DIFF
--- a/ompi/mca/coll/han/coll_han_component.c
+++ b/ompi/mca/coll/han/coll_han_component.c
@@ -568,20 +568,32 @@ static int han_register(void)
                                        "Collective module to use for %s on %s topological level: ",
                                        mca_coll_base_colltype_to_str(coll),
                                        mca_coll_han_topo_lvl_to_str(topo_lvl));
+            if (param_desc_size >= (int) sizeof(param_desc)) {
+                param_desc_size = (int) sizeof(param_desc) - 1;
+            }
             /*
              * Exhaustive description:
              * 0 = self; 1 = basic; 2 = libnbc; ...
              * FIXME: Do not print component not providing this collective
              */
             for(component = 0 ; component < COMPONENTS_COUNT ; component++) {
+                int written;
+
                 if(HAN == component && GLOBAL_COMMUNICATOR != topo_lvl) {
                     /* Han can only be used on the global communicator */
                     continue;
                 }
-                param_desc_size += snprintf(param_desc+param_desc_size, sizeof(param_desc) - param_desc_size,
-                                            "%d = %s; ",
-                                            component,
-                                            ompi_coll_han_available_components[component].component_name);
+                written = snprintf(param_desc + param_desc_size, sizeof(param_desc) - param_desc_size,
+                                   "%d = %s; ",
+                                   component,
+                                   ompi_coll_han_available_components[component].component_name);
+                if (0 > written || written >= (int) (sizeof(param_desc) - param_desc_size)) {
+                    /* The description does not fit in the buffer; drop
+                       the partial entry and stop appending */
+                    param_desc[param_desc_size] = '\0';
+                    break;
+                }
+                param_desc_size += written;
             }
 
             mca_base_component_var_register(c, param_name, param_desc,

--- a/ompi/mca/coll/libnbc/coll_libnbc_component.c
+++ b/ompi/mca/coll/libnbc/coll_libnbc_component.c
@@ -649,13 +649,13 @@ request_start(size_t count, ompi_request_t ** requests)
         NBC_Schedule *schedule = handle->schedule;
 
         NBC_DEBUG(5, "--------------------------------\n");
-        NBC_DEBUG(5, "schedule %p size %u\n", &schedule, sizeof(schedule));
-        NBC_DEBUG(5, "handle %p size %u\n", &handle, sizeof(handle));
-        NBC_DEBUG(5, "data %p size %u\n", &schedule->data, sizeof(schedule->data));
-        NBC_DEBUG(5, "req_array %p size %u\n", &handle->req_array, sizeof(handle->req_array));
-        NBC_DEBUG(5, "row_offset=%u address=%p size=%u\n", handle->row_offset, &handle->row_offset, sizeof(handle->row_offset));
-        NBC_DEBUG(5, "req_count=%u address=%p size=%u\n", handle->req_count, &handle->req_count, sizeof(handle->req_count));
-        NBC_DEBUG(5, "tmpbuf address=%p size=%u\n", handle->tmpbuf, sizeof(handle->tmpbuf));
+        NBC_DEBUG(5, "schedule %p size %" PRIsize_t "\n", &schedule, sizeof(schedule));
+        NBC_DEBUG(5, "handle %p size %" PRIsize_t "\n", &handle, sizeof(handle));
+        NBC_DEBUG(5, "data %p size %" PRIsize_t "\n", &schedule->data, sizeof(schedule->data));
+        NBC_DEBUG(5, "req_array %p size %" PRIsize_t "\n", &handle->req_array, sizeof(handle->req_array));
+        NBC_DEBUG(5, "row_offset=%li address=%p size=%" PRIsize_t "\n", handle->row_offset, &handle->row_offset, sizeof(handle->row_offset));
+        NBC_DEBUG(5, "req_count=%i address=%p size=%" PRIsize_t "\n", handle->req_count, &handle->req_count, sizeof(handle->req_count));
+        NBC_DEBUG(5, "tmpbuf address=%p size=%" PRIsize_t "\n", handle->tmpbuf, sizeof(handle->tmpbuf));
         NBC_DEBUG(5, "--------------------------------\n");
 
         handle->super.super.req_complete = REQUEST_PENDING;

--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -25,6 +25,7 @@
  * Additional copyrights may follow
  */
 #include "nbc_internal.h"
+#include "opal_stdint.h"
 #include "ompi/mca/coll/base/coll_tags.h"
 #include "ompi/mca/coll/base/coll_base_functions.h"
 #include "ompi/mca/coll/base/coll_base_util.h"
@@ -443,7 +444,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
   ptr = handle->schedule->data + handle->row_offset;
 
   NBC_GET_BYTES(ptr,num);
-  NBC_DEBUG(10, "start_round round at offset %d : posting %i operations\n", handle->row_offset, num);
+  NBC_DEBUG(10, "start_round round at offset %li : posting %i operations\n", handle->row_offset, num);
 
   for (int i = 0 ; i < num ; ++i) {
     int offset = (intptr_t)(ptr - handle->schedule->data);
@@ -451,9 +452,9 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
     memcpy (&type, ptr, sizeof (type));
     switch(type) {
       case SEND:
-        NBC_DEBUG(5,"  SEND (offset %li) ", offset);
+        NBC_DEBUG(5,"  SEND (offset %i) ", offset);
         NBC_GET_BYTES(ptr,sendargs);
-        NBC_DEBUG(5,"*buf: %p, count: %i, type: %p, dest: %i, tag: %i)\n", sendargs.buf,
+        NBC_DEBUG(5,"*buf: %p, count: %" PRIsize_t ", type: %p, dest: %i, tag: %i)\n", sendargs.buf,
                   sendargs.count, sendargs.datatype, sendargs.dest, handle->tag);
         /* get an additional request */
         handle->req_count++;
@@ -477,7 +478,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
                                  MCA_PML_BASE_SEND_STANDARD, sendargs.local?handle->comm->c_local_comm:handle->comm,
                                  handle->req_array+handle->req_count - 1));
         if (OMPI_SUCCESS != res) {
-          NBC_Error ("Error in MPI_Isend(%lu, %i, %p, %i, %i, %lu) (%i)", (unsigned long)buf1, sendargs.count,
+          NBC_Error ("Error in MPI_Isend(%lu, %" PRIsize_t ", %p, %i, %i, %lu) (%i)", (unsigned long)buf1, sendargs.count,
                      sendargs.datatype, sendargs.dest, handle->tag, (unsigned long)handle->comm, res);
           return res;
         }
@@ -486,9 +487,9 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
 #endif
         break;
       case RECV:
-        NBC_DEBUG(5, "  RECV (offset %li) ", offset);
+        NBC_DEBUG(5, "  RECV (offset %i) ", offset);
         NBC_GET_BYTES(ptr,recvargs);
-        NBC_DEBUG(5, "*buf: %p, count: %i, type: %p, source: %i, tag: %i)\n", recvargs.buf, recvargs.count,
+        NBC_DEBUG(5, "*buf: %p, count: %" PRIsize_t ", type: %p, source: %i, tag: %i)\n", recvargs.buf, recvargs.count,
                   recvargs.datatype, recvargs.source, handle->tag);
         /* get an additional request - TODO: req_count NOT thread safe */
         handle->req_count++;
@@ -511,7 +512,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
         res = MCA_PML_CALL(irecv(buf1, recvargs.count, recvargs.datatype, recvargs.source, handle->tag, recvargs.local?handle->comm->c_local_comm:handle->comm,
                                  handle->req_array+handle->req_count-1));
         if (OMPI_SUCCESS != res) {
-          NBC_Error("Error in MPI_Irecv(%lu, %i, %p, %i, %i, %lu) (%i)", (unsigned long)buf1, recvargs.count,
+          NBC_Error("Error in MPI_Irecv(%lu, %" PRIsize_t ", %p, %i, %i, %lu) (%i)", (unsigned long)buf1, recvargs.count,
                     recvargs.datatype, recvargs.source, handle->tag, (unsigned long)handle->comm, res);
           return res;
         }
@@ -520,9 +521,9 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
 #endif
         break;
       case OP:
-        NBC_DEBUG(5, "  OP2  (offset %li) ", offset);
+        NBC_DEBUG(5, "  OP2  (offset %i) ", offset);
         NBC_GET_BYTES(ptr,opargs);
-        NBC_DEBUG(5, "*buf1: %p, buf2: %p, count: %i, type: %p)\n", opargs.buf1, opargs.buf2,
+        NBC_DEBUG(5, "*buf1: %p, buf2: %p, count: %" PRIsize_t ", type: %p)\n", opargs.buf1, opargs.buf2,
                   opargs.count, opargs.datatype);
         /* get buffers */
         if(opargs.tmpbuf1) {
@@ -539,9 +540,9 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
         ompi_op_reduce(opargs.op, buf1, buf2, opargs.count, opargs.datatype);
         break;
       case COPY:
-        NBC_DEBUG(5, "  COPY   (offset %li) ", offset);
+        NBC_DEBUG(5, "  COPY   (offset %i) ", offset);
         NBC_GET_BYTES(ptr,copyargs);
-        NBC_DEBUG(5, "*src: %lu, srccount: %i, srctype: %p, *tgt: %lu, tgtcount: %i, tgttype: %p)\n",
+        NBC_DEBUG(5, "*src: %lu, srccount: %" PRIsize_t ", srctype: %p, *tgt: %lu, tgtcount: %" PRIsize_t ", tgttype: %p)\n",
                   (unsigned long) copyargs.src, copyargs.srccount, copyargs.srctype,
                   (unsigned long) copyargs.tgt, copyargs.tgtcount, copyargs.tgttype);
         /* get buffers */
@@ -562,9 +563,9 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
         }
         break;
       case UNPACK:
-        NBC_DEBUG(5, "  UNPACK   (offset %li) ", offset);
+        NBC_DEBUG(5, "  UNPACK   (offset %i) ", offset);
         NBC_GET_BYTES(ptr,unpackargs);
-        NBC_DEBUG(5, "*src: %lu, srccount: %i, srctype: %p, *tgt: %lu\n", (unsigned long) unpackargs.inbuf,
+        NBC_DEBUG(5, "*src: %lu, srccount: %" PRIsize_t ", srctype: %p, *tgt: %lu\n", (unsigned long) unpackargs.inbuf,
                   unpackargs.count, unpackargs.datatype, (unsigned long) unpackargs.outbuf);
         /* get buffers */
         if(unpackargs.tmpinbuf) {
@@ -585,7 +586,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
 
         break;
       default:
-        NBC_Error ("NBC_Start_round: bad type %li at offset %li", (long)type, offset);
+        NBC_Error ("NBC_Start_round: bad type %li at offset %i", (long)type, offset);
         return OMPI_ERROR;
     }
   }

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -32,6 +32,7 @@
 #include "mpi.h"
 
 #include "coll_libnbc.h"
+#include "opal_stdint.h"
 #include "opal/mca/accelerator/accelerator.h"
 #include "ompi/include/ompi/constants.h"
 #include "ompi/request/request.h"
@@ -279,6 +280,9 @@ int NBC_Create_fortran_handle(int *fhandle, NBC_Handle **handle);
 
 /* some macros */
 
+static inline void NBC_Error (char *format, ...)
+    __opal_attribute_format__(__printf__, 1, 2);
+
 static inline void NBC_Error (char *format, ...) {
   va_list args;
 
@@ -409,27 +413,27 @@ static inline int nbc_get_noop_request(bool persistent, ompi_request_t **request
        case SEND: \
          printf("[%i]  SEND (offset %li) ", myrank, (long)p-(long)schedule); \
          NBC_GET_BYTES(p,sendargs); \
-         printf("*buf: %lu, count: %i, type: %lu, dest: %i)\n", (unsigned long)sendargs.buf, sendargs.count, (unsigned long)sendargs.datatype, sendargs.dest); \
+         printf("*buf: %lu, count: %" PRIsize_t ", type: %lu, dest: %i)\n", (unsigned long)sendargs.buf, sendargs.count, (unsigned long)sendargs.datatype, sendargs.dest); \
          break; \
        case RECV: \
          printf("[%i]  RECV (offset %li) ", myrank, (long)p-(long)schedule); \
          NBC_GET_BYTES(p,recvargs); \
-         printf("*buf: %lu, count: %i, type: %lu, source: %i)\n", (unsigned long)recvargs.buf, recvargs.count, (unsigned long)recvargs.datatype, recvargs.source); \
+         printf("*buf: %lu, count: %" PRIsize_t ", type: %lu, source: %i)\n", (unsigned long)recvargs.buf, recvargs.count, (unsigned long)recvargs.datatype, recvargs.source); \
          break; \
        case OP: \
          printf("[%i]  OP   (offset %li) ", myrank, (long)p-(long)schedule); \
          NBC_GET_BYTES(p,opargs); \
-         printf("*buf1: %lu, buf2: %lu, count: %i, type: %lu)\n", (unsigned long)opargs.buf1, (unsigned long)opargs.buf2, opargs.count, (unsigned long)opargs.datatype); \
+         printf("*buf1: %lu, buf2: %lu, count: %" PRIsize_t ", type: %lu)\n", (unsigned long)opargs.buf1, (unsigned long)opargs.buf2, opargs.count, (unsigned long)opargs.datatype); \
          break; \
        case COPY: \
          printf("[%i]  COPY   (offset %li) ", myrank, (long)p-(long)schedule); \
          NBC_GET_BYTES(p,copyargs); \
-         printf("*src: %lu, srccount: %i, srctype: %lu, *tgt: %lu, tgtcount: %i, tgttype: %lu)\n", (unsigned long)copyargs.src, copyargs.srccount, (unsigned long)copyargs.srctype, (unsigned long)copyargs.tgt, copyargs.tgtcount, (unsigned long)copyargs.tgttype); \
+         printf("*src: %lu, srccount: %" PRIsize_t ", srctype: %lu, *tgt: %lu, tgtcount: %" PRIsize_t ", tgttype: %lu)\n", (unsigned long)copyargs.src, copyargs.srccount, (unsigned long)copyargs.srctype, (unsigned long)copyargs.tgt, copyargs.tgtcount, (unsigned long)copyargs.tgttype); \
          break; \
        case UNPACK: \
          printf("[%i]  UNPACK   (offset %li) ", myrank, (long)p-(long)schedule); \
          NBC_GET_BYTES(p,unpackargs); \
-         printf("*src: %lu, srccount: %i, srctype: %lu, *tgt: %lu\n",(unsigned long)unpackargs.inbuf, unpackargs.count, (unsigned long)unpackargs.datatype, (unsigned long)unpackargs.outbuf); \
+         printf("*src: %lu, srccount: %" PRIsize_t ", srctype: %lu, *tgt: %lu\n",(unsigned long)unpackargs.inbuf, unpackargs.count, (unsigned long)unpackargs.datatype, (unsigned long)unpackargs.outbuf); \
          break; \
        default: \
          printf("[%i] NBC_PRINT_ROUND: bad type %i at offset %li\n", myrank, type, (long)p-sizeof(type)-(long)schedule); \
@@ -463,6 +467,9 @@ static inline int nbc_get_noop_request(bool persistent, ompi_request_t **request
 /*
 #define NBC_DEBUG(level, ...) {}
 */
+
+static inline void NBC_DEBUG(int level, const char *fmt, ...)
+    __opal_attribute_format__(__printf__, 2, 3);
 
 static inline void NBC_DEBUG(int level, const char *fmt, ...)
 {


### PR DESCRIPTION
This fixes four CodeQL code scanning alerts, in two commits.

**Commit 1** resolves [alert 40](https://github.com/open-mpi/ompi/security/code-scanning/40) (`cpp/overflowing-snprintf`) in `coll/han`: the loop building the dynamic-rule MCA parameter description accumulated `snprintf()`'s return value and passed `sizeof(param_desc) - param_desc_size` to the next call.  Since `snprintf()` returns the untruncated length, one truncating iteration pushes `param_desc_size` past the buffer size, after which the size argument underflows and the buffer pointer lands out of bounds.  The fix stops appending once the buffer is full; truncating a human-readable description is harmless.

**Commit 2** resolves [alert 37](https://github.com/open-mpi/ompi/security/code-scanning/37), [alert 38](https://github.com/open-mpi/ompi/security/code-scanning/38), and [alert 39](https://github.com/open-mpi/ompi/security/code-scanning/39) (`cpp/wrong-type-format-argument`, the only error-severity alerts open) in `coll/libnbc`: `NBC_Start_round()` printed `size_t` counts with `%i` (stale since the schedule args were widened for large counts) and an `int` offset with `%li`.  Counts now use OPAL's `PRIsize_t`, per existing convention in coll.  The same mismatches in the neighboring debug-only `NBC_DEBUG()` calls (invisible to CodeQL because they compile away in normal builds) are fixed too, along with a `%d` used for the `long` row_offset.

Verified with a clean full VPATH build on macOS; both files compile with no warnings.  Both commits cherry-pick cleanly onto the current `v5.0.x` and `v6.0.x` tips, and both branches already have `size_t` counts in the NBC args structs, so the format fixes are semantically correct there as well.
