### PR TITLE
Fix CodeQL snprintf/scanf alerts in monitoring, tuned, and comm_method

### DIFF
--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
@@ -447,8 +447,9 @@ static int ompi_coll_tuned_read_rules_config_file_classic (char *fname, ompi_col
         goto on_file_error;
     }
 
-    /* consume the optional version identifier */
-    if (0 == fscanf(fptr, "rule-file-version-%d", &version)) {
+    /* consume the optional version identifier; fscanf() returns EOF
+       (not 0) if the file is empty */
+    if (1 != fscanf(fptr, "rule-file-version-%d", &version)) {
         version = 1;
     }
 

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
@@ -27,6 +27,7 @@
 #include "ompi_config.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "mpi.h"
 #include "ompi/mca/mca.h"
@@ -76,7 +77,7 @@ static int coll_tuned_read_alg(const opal_json_t *msg_rule, ompi_coll_msg_rule_t
     } else if (rc_as_int == OPAL_SUCCESS) {
         rc_validation = coll_tuned_alg_to_str( coll_id, int_val, NULL );
         if (rc_validation != OPAL_SUCCESS) {
-            snprintf(int_as_str, 23, "%ld", int_val);
+            snprintf(int_as_str, 23, "%" PRId64, int_val);
             int_as_str[23] = '\0';
             string_buf = int_as_str;
         } else {

--- a/ompi/mca/common/monitoring/common_monitoring_coll.c
+++ b/ompi/mca/common/monitoring/common_monitoring_coll.c
@@ -78,11 +78,29 @@ static inline void mca_common_monitoring_coll_cache(mca_monitoring_coll_data_t*d
             tmp_procs[0] = '\0';
             /* Build procs list */
             for(i = 0; i < size; ++i) {
-                if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, data->p_comm->c_remote_group, &world_rank) )
-                    pos += snprintf(&tmp_procs[pos], bufsize - pos, "%d,", world_rank);
+                if( OPAL_SUCCESS == mca_common_monitoring_get_world_rank(i, data->p_comm->c_remote_group, &world_rank) ) {
+                    int written = snprintf(&tmp_procs[pos], bufsize - pos, "%d,", world_rank);
+                    if( 0 > written || written >= bufsize - pos ) {
+                        /* The buffer is full; drop the partial entry
+                           and stop appending */
+                        tmp_procs[pos] = '\0';
+                        break;
+                    }
+                    pos += written;
+                }
             }
-            tmp_procs[pos - 1] = '\0'; /* Remove final coma */
-            data->procs = realloc(tmp_procs, pos * sizeof(char)); /* Adjust to size required */
+            /* This block may be re-entered if the cached string is
+               still empty; release any previously cached buffer */
+            free(data->procs);
+            if( 0 == pos ) {
+                /* No entry fit in the buffer; keep the empty string */
+                data->procs = tmp_procs;
+            } else {
+                char*shrunk;
+                tmp_procs[pos - 1] = '\0'; /* Remove final coma */
+                shrunk = realloc(tmp_procs, pos * sizeof(char)); /* Adjust to size required */
+                data->procs = (NULL != shrunk) ? shrunk : tmp_procs;
+            }
         }
     }
 }

--- a/ompi/mca/hook/comm_method/hook_comm_method_fns.c
+++ b/ompi/mca/hook/comm_method/hook_comm_method_fns.c
@@ -611,21 +611,27 @@ ompi_report_comm_methods(int called_from_location)
             FILE *fp;
             int setting;
             fp = fopen(mca_hook_comm_method_fakefile, "r");
-            for (i=0; i<nleaderranks; ++i) {
-                for (k=0; k<nleaderranks; ++k) {
-                    if (fscanf(fp, "%d", &setting) != 1) {
+            if (NULL == fp) {
+                printf("Unable to open comm_method fakefile %s\n",
+                       mca_hook_comm_method_fakefile);
+            } else {
+                for (i=0; i<nleaderranks; ++i) {
+                    for (k=0; k<nleaderranks; ++k) {
+                        if (fscanf(fp, "%d", &setting) != 1) {
+                            break;
+                        }
+                        // let -1 mean "use existing (real) setting"
+                        if (setting != -1) {
+                            method[i * nleaderranks + k] = setting;
+                        }
+                    }
+                    // a whitespace-only directive returns 0 or EOF; stop at EOF
+                    if (EOF == fscanf(fp, "\n")) {
                         break;
                     }
-                    // let -1 mean "use existing (real) setting"
-                    if (setting != -1) {
-                        method[i * nleaderranks + k] = setting;
-                    }
                 }
-                if (fscanf(fp, "\n") != 0) {
-                    break;
-                }
+                fclose(fp);
             }
-            fclose(fp);
         }
     }
 


### PR DESCRIPTION
This fixes the three remaining small CodeQL code scanning alerts, plus two adjacent bugs found while fixing them.  Four commits:

**common/monitoring** ([alert 41](https://github.com/open-mpi/ompi/security/code-scanning/41), `cpp/overflowing-snprintf`): the cached proc-list loop accumulated `snprintf()` return values without checking for truncation.  The buffer is sized for the worst case today so this cannot currently trigger, but nothing enforced that; each return is now checked.  Also fixes an adjacent unflagged bug: when no world rank could be resolved, the trailing-comma removal wrote to `tmp_procs[-1]`, one byte before the buffer.

**coll/tuned** ([alert 29](https://github.com/open-mpi/ompi/security/code-scanning/29), `cpp/incorrectly-checked-scanf`): the optional rule-file version header check compared `fscanf()` against 0 only, but an empty rules file returns EOF, leaving `version` uninitialized instead of defaulting to 1.

**hook/comm_method** ([alert 30](https://github.com/open-mpi/ompi/security/code-scanning/30), `cpp/incorrectly-checked-scanf`): the fakefile `fscanf(fp, "\n")` result is now compared against EOF explicitly (behavior unchanged — a whitespace-only directive only returns 0 or EOF, and breaking at EOF was the intent — but the intent is now explicit and the alert resolves).  Also adds the missing NULL check on the fakefile `fopen()`, which previously crashed on an unreadable path.

**coll/tuned drive-by**: printing an `int64_t` with `%ld` in the JSON rules parser draws `-Wformat` from clang on macOS (where `int64_t` is `long long`) and is wrong on 32-bit `long` platforms; use `PRId64`.  This was a pre-existing warning, not introduced by this PR.

Verified with a clean build of all three components on macOS (no warnings).  Backports: all four commits cherry-pick cleanly onto `v6.0.x`.  On `v5.0.x` only the hook/comm_method commit applies cleanly — the monitoring and tuned code there predates the current shape of these files — so this PR is labeled for v6.0.x only; a v5.0.x backport would need manual adaptation (and may be worth only the hook fix).
