### PR TITLE
Exclude test directories from CodeQL C/C++ alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -156,7 +156,9 @@ jobs:
       # bundled third-party projects, which gives CodeQL complete build
       # context but can also produce alerts in code we do not maintain.
       # For C/C++ only, write SARIF locally, remove alerts whose primary
-      # locations are under 3rd-party/, and then upload the filtered SARIF.
+      # locations are under 3rd-party/ or the test directories (mirroring
+      # the config sidecar's paths-ignore), and then upload the filtered
+      # SARIF.
       - name: Perform CodeQL Analysis
         if: matrix.language == 'c-cpp'
         uses: github/codeql-action/analyze@v4
@@ -186,6 +188,8 @@ jobs:
           patterns: |
             -3rd-party/**
             -**/3rd-party/**
+            -test/**
+            -**/test/**
           input: ${{ steps.cpp_sarif.outputs.file }}
           output: ${{ steps.cpp_sarif.outputs.file }}
 
@@ -280,7 +284,9 @@ jobs:
       # bundled third-party projects, which gives CodeQL complete build
       # context but can also produce alerts in code we do not maintain.
       # For C/C++ only, write SARIF locally, remove alerts whose primary
-      # locations are under 3rd-party/, and then upload the filtered SARIF.
+      # locations are under 3rd-party/ or the test directories (mirroring
+      # the config sidecar's paths-ignore), and then upload the filtered
+      # SARIF.
       - name: Perform CodeQL Analysis
         if: matrix.language == 'c-cpp'
         uses: github/codeql-action/analyze@v4
@@ -317,6 +323,8 @@ jobs:
           patterns: |
             -3rd-party/**
             -**/3rd-party/**
+            -test/**
+            -**/test/**
           input: ${{ steps.cpp_sarif.outputs.file }}
           output: ${{ steps.cpp_sarif.outputs.file }}
 


### PR DESCRIPTION
The CodeQL config sidecar excludes test directories via `paths-ignore`, but that setting does not filter C/C++ code compiled by a manual build — the same gap that already required the workflow to post-filter the C/C++ SARIF for `3rd-party/`.  As a result, three alerts are currently open against `ompi/test/monitoring` code ([350](https://github.com/open-mpi/ompi/security/code-scanning/350), [351](https://github.com/open-mpi/ompi/security/code-scanning/351), [352](https://github.com/open-mpi/ompi/security/code-scanning/352)).

This adds the test-directory patterns to the `filter-sarif` step in both the event-driven and scheduled jobs, matching what `paths-ignore` already declares.  The three test-code alerts will auto-close on the next C/C++ scan of each branch.

No backport needed: the workflow file exists only on `main`, and the scheduled job — which is what scans the release branches — always runs from main's copy.
