### PR TITLE
Fix CodeQL integer-multiplication overflow alerts

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -41,6 +41,8 @@
 #include <string.h>
 #include <stdio.h>
 
+#include "opal_stdint.h"
+
 #include "ompi/constants.h"
 #include "opal/mca/accelerator/accelerator.h"
 #include "opal/mca/base/mca_base_var.h"
@@ -2196,7 +2198,7 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
     /*
      * append the pmix CONTEXT_ID obtained when creating the leader comm as discriminator
      */
-    opal_asprintf (&sub_tag, "%s-%ld", tag, data[1]);
+    opal_asprintf (&sub_tag, "%s-%" PRIu64, tag, data[1]);
     if (OPAL_UNLIKELY(NULL == sub_tag)) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -2393,18 +2393,18 @@ static int ompi_comm_allgather_emulate_intra( void *inbuf, int incount,
 
     /* Step 1: the gather-step */
     if ( 0 == rank ) {
-        tmpbuf = (int *) malloc (rsize*outcount*sizeof(int));
+        tmpbuf = (int *) malloc ((size_t) rsize * outcount * sizeof(int));
         if ( NULL == tmpbuf ) {
             return (OMPI_ERR_OUT_OF_RESOURCE);
         }
-        req = (MPI_Request *)malloc (rsize*outcount*sizeof(MPI_Request));
+        req = (MPI_Request *)malloc ((size_t) rsize * outcount * sizeof(MPI_Request));
         if ( NULL == req ) {
             free ( tmpbuf );
             return (OMPI_ERR_OUT_OF_RESOURCE);
         }
 
         for ( i=0; i<rsize; i++) {
-            rc = MCA_PML_CALL(irecv( &tmpbuf[outcount*i], outcount, outtype, i,
+            rc = MCA_PML_CALL(irecv( &tmpbuf[(size_t) outcount * i], outcount, outtype, i,
                                      OMPI_COMM_ALLGATHER_TAG, comm, &req[i] ));
             if ( OMPI_SUCCESS != rc ) {
                 goto exit;
@@ -2430,7 +2430,7 @@ static int ompi_comm_allgather_emulate_intra( void *inbuf, int incount,
     }
 
     /* Step 2: the inter-bcast step */
-    rc = MCA_PML_CALL(irecv (outbuf, size*outcount, outtype, 0,
+    rc = MCA_PML_CALL(irecv (outbuf, (size_t) size * outcount, outtype, 0,
                              OMPI_COMM_ALLGATHER_TAG, comm, &sendreq));
     if ( OMPI_SUCCESS != rc ) {
         goto exit;
@@ -2438,7 +2438,7 @@ static int ompi_comm_allgather_emulate_intra( void *inbuf, int incount,
 
     if ( 0 == rank ) {
         for ( i=0; i < rsize; i++ ){
-            rc = MCA_PML_CALL(send (tmpbuf, rsize*outcount, outtype, i,
+            rc = MCA_PML_CALL(send (tmpbuf, (size_t) rsize * outcount, outtype, i,
                                     OMPI_COMM_ALLGATHER_TAG,
                                     MCA_PML_BASE_SEND_STANDARD, comm));
             if ( OMPI_SUCCESS != rc ) {

--- a/ompi/debuggers/ompi_common_dll.c
+++ b/ompi/debuggers/ompi_common_dll.c
@@ -630,7 +630,7 @@ int ompi_fetch_opal_pointer_array_item(mqs_process *proc, mqs_taddr_t addr,
                               addr + i_info->opal_pointer_array_t.offset.addr,
                               p_info);
     *item = ompi_fetch_pointer(proc,
-                               base + index * p_info->sizes.pointer_size,
+                               base + (mqs_taddr_t) index * p_info->sizes.pointer_size,
                                p_info);
 
     return mqs_ok;

--- a/ompi/debuggers/ompi_msgq_dll.c
+++ b/ompi/debuggers/ompi_msgq_dll.c
@@ -646,7 +646,7 @@ static int rebuild_communicator_list (mqs_process *proc)
         /* Get the communicator pointer */
         comm_ptr =
             ompi_fetch_pointer( proc,
-                                comm_addr_base + i * p_info->sizes.pointer_size,
+                                comm_addr_base + (mqs_taddr_t) i * p_info->sizes.pointer_size,
                                 p_info );
         DEBUG(VERBOSE_GENERAL,("Fetch communicator pointer 0x%llx\n", (long long)comm_ptr));
         if( 0 == comm_ptr ) continue;

--- a/ompi/mca/coll/adapt/coll_adapt_ireduce.c
+++ b/ompi/mca/coll/adapt/coll_adapt_ireduce.c
@@ -611,7 +611,7 @@ int ompi_coll_adapt_ireduce_generic(const void *sbuf, void *rbuf, size_t count,
     if (tree->tree_nextsize > 0) {
         size_t num_allocate_elems = mca_coll_adapt_component.adapt_inbuf_free_list_min;
         if (((size_t) tree->tree_nextsize * num_segs) < num_allocate_elems) {
-            num_allocate_elems = tree->tree_nextsize * num_segs;
+            num_allocate_elems = (size_t) tree->tree_nextsize * num_segs;
         }
         opal_free_list_init(&con->inbuf_list,
                             sizeof(ompi_coll_adapt_inbuf_t) + real_seg_size,

--- a/ompi/mca/coll/base/coll_base_bcast.c
+++ b/ompi/mca/coll/base/coll_base_bcast.c
@@ -93,7 +93,7 @@ ompi_coll_base_bcast_intra_generic( void* buffer,
         sendcount = count_by_segment;
         for( segindex = 0; segindex < num_segments; segindex++ ) {
             if( segindex == (num_segments - 1) ) {
-                sendcount = original_count - segindex * count_by_segment;
+                sendcount = original_count - (size_t) segindex * count_by_segment;
             }
             for( i = 0; i < tree->tree_nextsize; i++ ) {
                 err = MCA_PML_CALL(isend(tmpbuf, sendcount, datatype,

--- a/ompi/mca/coll/han/coll_han_allreduce.c
+++ b/ompi/mca/coll/han/coll_han_allreduce.c
@@ -148,7 +148,7 @@ mca_coll_han_allreduce_intra(const void *sbuf,
     mca_coll_han_allreduce_args_t *t = malloc(sizeof(mca_coll_han_allreduce_args_t));
     mca_coll_han_set_allreduce_args(t, t0, (char *) sbuf, (char *) rbuf, seg_count, dtype, op,
                                     root_up_rank, root_low_rank, up_comm, low_comm, num_segments, 0,
-                                    w_rank, count - (num_segments - 1) * seg_count,
+                                    w_rank, count - (size_t) (num_segments - 1) * seg_count,
                                     low_rank != root_low_rank, NULL, completed);
     /* Init t0 task */
     init_task(t0, mca_coll_han_allreduce_t0_task, (void *) (t));

--- a/ompi/mca/coll/han/coll_han_bcast.c
+++ b/ompi/mca/coll/han/coll_han_bcast.c
@@ -132,7 +132,7 @@ mca_coll_han_bcast_intra(void *buf,
     mca_coll_han_bcast_args_t *t = malloc(sizeof(mca_coll_han_bcast_args_t));
     mca_coll_han_set_bcast_args(t, t0, (char *)buf, seg_count, dtype,
                                 root_up_rank, root_low_rank, up_comm, low_comm,
-                                num_segments, 0, w_rank, count - (num_segments - 1) * seg_count,
+                                num_segments, 0, w_rank, count - (size_t) (num_segments - 1) * seg_count,
                                 low_rank != root_low_rank);
     /* Init the first task */
     init_task(t0, mca_coll_han_bcast_t0_task, (void *) t);

--- a/ompi/mca/coll/han/coll_han_reduce.c
+++ b/ompi/mca/coll/han/coll_han_reduce.c
@@ -161,7 +161,7 @@ mca_coll_han_reduce_intra(const void *sbuf,
     mca_coll_han_reduce_args_t *t = malloc(sizeof(mca_coll_han_reduce_args_t));
     mca_coll_han_set_reduce_args(t, t0, (char *) sbuf, (char *) tmp_rbuf, seg_count, dtype,
                                  op, root_up_rank, root_low_rank, up_comm, low_comm,
-                                 num_segments, 0, w_rank, count - (num_segments - 1) * seg_count,
+                                 num_segments, 0, w_rank, count - (size_t) (num_segments - 1) * seg_count,
                                  low_rank != root_low_rank, is_tmp_rbuf);
     /* Init the first task */
     init_task(t0, mca_coll_han_reduce_t0_task, (void *) t);

--- a/ompi/mca/coll/han/coll_han_scatter.c
+++ b/ompi/mca/coll/han/coll_han_scatter.c
@@ -360,7 +360,7 @@ mca_coll_han_scatter_intra_simple(const void *sbuf, size_t scount,
 {
     int w_rank, w_size;
     struct ompi_datatype_t * dtype;
-    int count;
+    size_t count;
 
     w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);

--- a/ompi/mca/coll/han/coll_han_topo.c
+++ b/ompi/mca/coll/han/coll_han_topo.c
@@ -199,7 +199,7 @@ mca_coll_han_topo_init(struct ompi_communicator_t *comm,
     }
 
     /* broadcast topology from node leaders to remaining ranks */
-    low_comm->c_coll->coll_bcast(topo, num_topo_level*size, MPI_INT, 0,
+    low_comm->c_coll->coll_bcast(topo, (size_t) num_topo_level * size, MPI_INT, 0,
                                 low_comm, low_comm->c_coll->coll_bcast_module);
     free(my_low_rank_map);
     han_module->cached_topo = topo;

--- a/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
+++ b/ompi/mca/fcoll/dynamic_gen2/fcoll_dynamic_gen2_file_write_all.c
@@ -271,7 +271,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     }
     else {
         total_bytes_per_process = (MPI_Aint*)malloc
-            (dynamic_gen2_num_io_procs * fh->f_procs_per_group*sizeof(MPI_Aint));
+            ((size_t) dynamic_gen2_num_io_procs * fh->f_procs_per_group * sizeof(MPI_Aint));
         if (NULL == total_bytes_per_process) {
             opal_output (1, "OUT OF MEMORY\n");
             ret = OMPI_ERR_OUT_OF_RESOURCE;
@@ -318,7 +318,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     }
     
 
-    result_counts = (int *) malloc ( dynamic_gen2_num_io_procs * fh->f_procs_per_group * sizeof(int) );
+    result_counts = (int *) malloc ( (size_t) dynamic_gen2_num_io_procs * fh->f_procs_per_group * sizeof(int) );
     if ( NULL == result_counts ) {
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
@@ -552,19 +552,17 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
 #endif
     }    
 
-    reqs1 = (ompi_request_t **)malloc ((fh->f_procs_per_group + 1 )*dynamic_gen2_num_io_procs *sizeof(ompi_request_t *));
-    reqs2 = (ompi_request_t **)malloc ((fh->f_procs_per_group + 1 )*dynamic_gen2_num_io_procs *sizeof(ompi_request_t *));
+    size_t num_reqs = (size_t) (fh->f_procs_per_group + 1 ) * dynamic_gen2_num_io_procs;
+    reqs1 = (ompi_request_t **)malloc (num_reqs * sizeof(ompi_request_t *));
+    reqs2 = (ompi_request_t **)malloc (num_reqs * sizeof(ompi_request_t *));
     if ( NULL == reqs1 || NULL == reqs2 ) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
     }
-    for (l=0,i=0; i < dynamic_gen2_num_io_procs; i++ ) {
-        for ( j=0; j< (fh->f_procs_per_group+1); j++ ) {
-            reqs1[l] = MPI_REQUEST_NULL;
-            reqs2[l] = MPI_REQUEST_NULL;
-            l++;
-        }
+    for (size_t r = 0; r < num_reqs; r++) {
+        reqs1[r] = MPI_REQUEST_NULL;
+        reqs2[r] = MPI_REQUEST_NULL;
     }
 
     curr_reqs = reqs1;
@@ -574,7 +572,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
     if ( cycles > 0 ) {
         for ( i=0; i<dynamic_gen2_num_io_procs; i++ ) {
             ret = shuffle_init ( 0, cycles, aggregators[i], fh->f_rank, aggr_data[i], 
-                                 &curr_reqs[i*(fh->f_procs_per_group + 1)] );
+                                 &curr_reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if ( OMPI_SUCCESS != ret ) {
                 goto exit;
             }
@@ -589,15 +587,14 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
         /* Initialize communication for iteration i */
         for ( i=0; i<dynamic_gen2_num_io_procs; i++ ) {
             ret = shuffle_init ( index, cycles, aggregators[i], fh->f_rank, aggr_data[i], 
-                                 &curr_reqs[i*(fh->f_procs_per_group + 1)] );
+                                 &curr_reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if ( OMPI_SUCCESS != ret ) {
                 goto exit;
             }
         }
 
         /* Finish communication for iteration i-1 */
-        ret = ompi_request_wait_all ( (fh->f_procs_per_group + 1 )*dynamic_gen2_num_io_procs, 
-                                      prev_reqs, MPI_STATUS_IGNORE);
+        ret = ompi_request_wait_all ( num_reqs, prev_reqs, MPI_STATUS_IGNORE);
         if (OMPI_SUCCESS != ret){
             goto exit;
         }
@@ -626,8 +623,7 @@ int mca_fcoll_dynamic_gen2_file_write_all (struct ompio_file_t *fh,
         SWAP_REQUESTS(curr_reqs,prev_reqs);
         SWAP_AGGR_POINTERS(aggr_data,dynamic_gen2_num_io_procs); 
         
-        ret = ompi_request_wait_all ( (fh->f_procs_per_group + 1 )*dynamic_gen2_num_io_procs, 
-                                      prev_reqs, MPI_STATUS_IGNORE);
+        ret = ompi_request_wait_all ( num_reqs, prev_reqs, MPI_STATUS_IGNORE);
         if (OMPI_SUCCESS != ret){
             goto exit;
         }

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_read_all.c
@@ -219,7 +219,7 @@ int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
         }
     }
 
-    result_counts = (int *) malloc (fh->f_num_aggrs * fh->f_procs_per_group * sizeof(int));
+    result_counts = (int *) malloc ((size_t) fh->f_num_aggrs * fh->f_procs_per_group * sizeof(int));
     if (NULL == result_counts) {
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
@@ -439,18 +439,16 @@ int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
 #endif
     }
 
-    reqs = (ompi_request_t **)malloc ((fh->f_procs_per_group + 1 )*fh->f_num_aggrs *sizeof(ompi_request_t *));
+    size_t num_reqs = (size_t) (fh->f_procs_per_group + 1 ) * fh->f_num_aggrs;
+    reqs = (ompi_request_t **)malloc (num_reqs * sizeof(ompi_request_t *));
     if (NULL == reqs) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
     }
 
-    for (l = 0, i = 0; i < fh->f_num_aggrs; i++) {
-        for (j=0; j< (fh->f_procs_per_group+1); j++) {
-            reqs[l] = MPI_REQUEST_NULL;
-            l++;
-        }
+    for (size_t r = 0; r < num_reqs; r++) {
+        reqs[r] = MPI_REQUEST_NULL;
     }
 
     if( (1 == mca_fcoll_vulcan_async_io) ||
@@ -493,7 +491,7 @@ int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
     for (index = 1; index < cycles; index++) {
         for (i = 0; i < fh->f_num_aggrs; i++) {
             ret = shuffle_init (index-1, cycles, fh->f_aggr_list[i], fh->f_rank, aggr_data[i],
-                                &reqs[i*(fh->f_procs_per_group + 1)] );
+                                &reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if (OMPI_SUCCESS != ret) {
                 goto exit;
             }
@@ -518,8 +516,7 @@ int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
 	end_read_time = MPI_Wtime();
 	read_time += end_read_time - start_read_time;
 #endif
-	ret = ompi_request_wait_all ((fh->f_procs_per_group + 1 )*fh->f_num_aggrs,
-                                     reqs, MPI_STATUS_IGNORE);
+	ret = ompi_request_wait_all (num_reqs, reqs, MPI_STATUS_IGNORE);
         if (OMPI_SUCCESS != ret){
             goto exit;
         }
@@ -535,13 +532,12 @@ int mca_fcoll_vulcan_file_read_all (struct ompio_file_t *fh,
     if (cycles > 0) {
         for (i = 0; i < fh->f_num_aggrs; i++) {
             ret = shuffle_init (index-1, cycles, fh->f_aggr_list[i], fh->f_rank, aggr_data[i],
-                                &reqs[i*(fh->f_procs_per_group + 1)] );
+                                &reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if (OMPI_SUCCESS != ret) {
                 goto exit;
             }
         }
-	ret = ompi_request_wait_all ((fh->f_procs_per_group + 1 )*fh->f_num_aggrs,
-                                     reqs, MPI_STATUS_IGNORE);
+	ret = ompi_request_wait_all (num_reqs, reqs, MPI_STATUS_IGNORE);
         if (OMPI_SUCCESS != ret){
             goto exit;
         }

--- a/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
+++ b/ompi/mca/fcoll/vulcan/fcoll_vulcan_file_write_all.c
@@ -228,7 +228,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         }
     }
     
-    result_counts = (int *) malloc ( fh->f_num_aggrs * fh->f_procs_per_group * sizeof(int) );
+    result_counts = (int *) malloc ( (size_t) fh->f_num_aggrs * fh->f_procs_per_group * sizeof(int) );
     if ( NULL == result_counts ) {
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
@@ -451,18 +451,16 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
 #endif
     }
 
-    reqs = (ompi_request_t **)malloc ((fh->f_procs_per_group + 1 )*fh->f_num_aggrs *sizeof(ompi_request_t *));
+    size_t num_reqs = (size_t) (fh->f_procs_per_group + 1 ) * fh->f_num_aggrs;
+    reqs = (ompi_request_t **)malloc (num_reqs * sizeof(ompi_request_t *));
     if ( NULL == reqs ) {
         opal_output (1, "OUT OF MEMORY\n");
         ret = OMPI_ERR_OUT_OF_RESOURCE;
         goto exit;
     }
 
-    for (l=0,i=0; i < fh->f_num_aggrs; i++ ) {
-        for ( j=0; j< (fh->f_procs_per_group+1); j++ ) {
-            reqs[l] = MPI_REQUEST_NULL;
-            l++;
-        }
+    for (size_t r = 0; r < num_reqs; r++) {
+        reqs[r] = MPI_REQUEST_NULL;
     }
 
     // In fact it should be: if ((1 == mca_fcoll_vulcan_async_io) && (NULL != fh->f_fbtl->fbtl_ipwritev))
@@ -475,7 +473,7 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
     if ( cycles > 0 ) {
         for ( i=0; i<fh->f_num_aggrs; i++ ) {
             ret = shuffle_init ( 0, cycles, fh->f_aggr_list[i], fh->f_rank, aggr_data[i],
-                                 &reqs[i*(fh->f_procs_per_group + 1)] );
+                                 &reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if ( OMPI_SUCCESS != ret ) {
                 goto exit;
             }
@@ -486,8 +484,10 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
         }
     }
 
-    ret = ompi_request_wait_all ( (fh->f_procs_per_group + 1 )*fh->f_num_aggrs,
-                                  reqs, MPI_STATUS_IGNORE);
+    ret = ompi_request_wait_all ( num_reqs, reqs, MPI_STATUS_IGNORE);
+    if (OMPI_SUCCESS != ret){
+        goto exit;
+    }
 
     for (index = 1; index < cycles; index++) {
         SWAP_AGGR_POINTERS(aggr_data, fh->f_num_aggrs);
@@ -509,14 +509,13 @@ int mca_fcoll_vulcan_file_write_all (struct ompio_file_t *fh,
 
         for ( i=0; i<fh->f_num_aggrs; i++ ) {
             ret = shuffle_init ( index, cycles, fh->f_aggr_list[i], fh->f_rank, aggr_data[i],
-                                 &reqs[i*(fh->f_procs_per_group + 1)] );
+                                 &reqs[(size_t) i * (fh->f_procs_per_group + 1)] );
             if ( OMPI_SUCCESS != ret ) {
                 goto exit;
             }
         }
 
-        ret = ompi_request_wait_all ( (fh->f_procs_per_group + 1 )*fh->f_num_aggrs,
-                                      reqs, MPI_STATUS_IGNORE);
+        ret = ompi_request_wait_all ( num_reqs, reqs, MPI_STATUS_IGNORE);
         if (OMPI_SUCCESS != ret){
             goto exit;
         }

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -601,9 +601,16 @@ mca_part_persist_parrived(size_t min_part,
                 _flag = _flag && req->flags[i];            
             }
         } else {
-            float convert = ((float)req->real_parts) / ((float)req->req_parts);
+            double convert = ((double)req->real_parts) / ((double)req->req_parts);
+            /* Requested partition p maps onto the real (internal)
+               partitions [convert * p, convert * (p + 1)), so the
+               last real partition overlapping the requested range is
+               ceil(convert * (max_part + 1)) - 1. */
             size_t _min = floor(convert * min_part);
-            size_t _max = ceil(convert * max_part);
+            size_t _max = ceil(convert * (max_part + 1)) - 1;
+            if (_max >= req->real_parts) {
+                _max = req->real_parts - 1;
+            }
             for(i = _min; i <= _max; i++) {
                 _flag = _flag && req->flags[i];
             }

--- a/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
+++ b/ompi/mca/topo/treematch/topo_treematch_dist_graph_create.c
@@ -23,6 +23,8 @@
 
 #include "ompi_config.h"
 
+#include <stdint.h>
+
 #include "opal/constants.h"
 #include "opal/mca/hwloc/base/base.h"
 
@@ -391,13 +393,24 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
          * If weights have been provided take them in account. Otherwise rely
          * solely on HWLOC information.
          */
+        /* All ranks must take the same branch here: size is uniform
+           across the communicator, so this bails out (and falls back
+           to the unreordered communicator) collectively */
+        if ((size_t) size > SIZE_MAX / sizeof(double) / (size_t) size) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto release_and_return;
+        }
         if( 0 == rank ) {
 
             OPAL_OUTPUT_VERBOSE((10, ompi_topo_base_framework.framework_output,
                                  "========== Centralized Reordering ========= \n"));
-            local_pattern = (double *)calloc(size*size,sizeof(double));
+            local_pattern = (double *)calloc((size_t) size * size, sizeof(double));
         } else {
             local_pattern = (double *)calloc(size,sizeof(double));
+        }
+        if (NULL == local_pattern) {
+            err = OMPI_ERR_OUT_OF_RESOURCE;
+            goto release_and_return;
         }
         if( true == topo->weighted ) {
             for(i = 0; i < topo->indegree ; i++)
@@ -646,7 +659,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
 #endif
                 comm_pattern = (double **)malloc(size*sizeof(double *));
                 for(i = 0 ; i < size ; i++)
-                    comm_pattern[i] = local_pattern + i * size;
+                    comm_pattern[i] = local_pattern + (size_t) i * size;
                 /* matrix needs to be symmetric */
                 for( i = 0; i < size ; i++ )
                     for( j = i; j < size ; j++ ) {
@@ -742,7 +755,7 @@ int mca_topo_treematch_dist_graph_create(mca_topo_base_module_t* topo_module,
         if (rank == lindex_to_grank[0]) {
             OPAL_OUTPUT_VERBOSE((10, ompi_topo_base_framework.framework_output,
                                  "========== Partially Distributed Reordering ========= \n"));
-            local_pattern = (double *)calloc(num_procs_in_node * num_procs_in_node, sizeof(double));
+            local_pattern = (double *)calloc((size_t) num_procs_in_node * num_procs_in_node, sizeof(double));
         } else {
             local_pattern = (double *)calloc(num_procs_in_node, sizeof(double));
         }

--- a/ompi/mpiext/affinity/c/mpiext_affinity_str.c
+++ b/ompi/mpiext/affinity/c/mpiext_affinity_str.c
@@ -125,7 +125,7 @@ static int build_map(int *num_sockets_arg, int *num_cores_arg, hwloc_cpuset_t cp
     if (NULL == data) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
-    data[0] = calloc(num_sockets * num_cores, sizeof(int));
+    data[0] = calloc((size_t) num_sockets * num_cores, sizeof(int));
     if (NULL == data[0]) {
         free(data);
         return MPI_ERR_NO_MEM;

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -99,6 +99,10 @@
 #define MCA_BTL_TCP_BTL_BANDWIDTH 100
 #define MCA_BTL_TCP_BTL_LATENCY   100
 
+/* Upper bound for the btl_tcp_links MCA parameter: the number of BTL
+   modules (and sockets) instantiated per usable interface */
+#define MCA_BTL_TCP_MAX_LINKS 32
+
 /*
  * Local functions
  */
@@ -293,6 +297,15 @@ static int mca_btl_tcp_component_register(void)
     /* register TCP component parameters */
     mca_btl_tcp_param_register_uint("links", NULL, 1, OPAL_INFO_LVL_4,
                                     &mca_btl_tcp_component.tcp_num_links);
+    /* tcp_num_links multiplies the number of BTL modules instantiated
+       per interface; an absurdly large value is useless and can
+       overflow the sizing of the module array, so clamp it */
+    if (MCA_BTL_TCP_MAX_LINKS < mca_btl_tcp_component.tcp_num_links) {
+        opal_output(0, "btl/tcp: clamping btl_tcp_links from %u to %u",
+                    mca_btl_tcp_component.tcp_num_links,
+                    (unsigned int) MCA_BTL_TCP_MAX_LINKS);
+        mca_btl_tcp_component.tcp_num_links = MCA_BTL_TCP_MAX_LINKS;
+    }
     mca_btl_tcp_param_register_string(
         "if_include",
         "Comma-delimited list of devices and/or CIDR notation of networks to use for MPI "
@@ -909,7 +922,7 @@ static int mca_btl_tcp_component_create_instances(void)
 
     /* allocate memory for btls */
     mca_btl_tcp_component.tcp_btls = (mca_btl_tcp_module_t **) malloc(
-        mca_btl_tcp_component.tcp_num_links * kif_count * sizeof(mca_btl_tcp_module_t *));
+        (size_t) mca_btl_tcp_component.tcp_num_links * kif_count * sizeof(mca_btl_tcp_module_t *));
     if (NULL == mca_btl_tcp_component.tcp_btls) {
         ret = OPAL_ERR_OUT_OF_RESOURCE;
         goto cleanup;

--- a/opal/util/bipartite_graph.c
+++ b/opal/util/bipartite_graph.c
@@ -756,7 +756,7 @@ static int min_cost_flow_ssp(opal_bp_graph_t *gx, int **flow_out)
     }
 
     /* "flow" is a 2d matrix of current flow values, all initialized to zero */
-    flow = calloc(n * n, sizeof(*flow));
+    flow = calloc((size_t) n * n, sizeof(*flow));
     if (NULL == flow) {
         OPAL_ERROR_LOG(OPAL_ERR_OUT_OF_RESOURCE);
         err = OPAL_ERR_OUT_OF_RESOURCE;


### PR DESCRIPTION
This triages and fixes 34 of the 38 open `cpp/integer-multiplication-cast-to-long` CodeQL code scanning alerts (the remaining 4 are dismissed as bounded by construction — see below).  Every site was individually triaged for whether its operands can realistically overflow 32 bits; the fixes are grouped into seven commits by subsystem.  (Updated after an AI-assisted local review pass; the review's findings are folded into the commits and noted per-bullet below.)

**Real overflows fixed** (operands reachable by user counts, MCA parameters, or large rank counts):

* **coll base/han** (commit 3): the last-segment count computed as `count - (num_segments - 1) * seg_count` in han allreduce/bcast/reduce and the equivalent in base bcast wraps (signed overflow, UB) for MPI-4 bigcount operations whose `size_t` count exceeds 32 bits.  han scatter's local `count` variable is widened from `int` to `size_t`: it is assigned from the `size_t` user counts — and, on the reordered path, from a per-rank *byte* count — so it truncated multi-GB values before any downstream arithmetic.
* **fcoll dynamic_gen2/vulcan** (commit 4): the aggregators-times-ranks products sizing allocations can wrap when `num_aggregators` is pushed toward the rank count on very large jobs, yielding undersized buffers that the aggregation loops overrun; the same wrapped product is passed as the `size_t` count to `ompi_request_wait_all()`, which would walk far past the request array.  Each function now computes a single `size_t num_reqs` shared by the allocation, a `size_t`-indexed initialization loop, and every `wait_all` call, so they can never disagree; the per-aggregator request-array offsets are computed in `size_t` too.  Also adds the missing return-value check on the one `wait_all` in vulcan's write path that lacked it.
* **btl/tcp** (commit 2): `tcp_num_links * kif_count` — `btl_tcp_links` is an unvalidated unsigned MCA parameter, so a large value wraps the `tcp_btls` allocation size while `mca_btl_tcp_create()` still stores the full number of module pointers: heap corruption, not a clean failure.  The allocation is computed in `size_t`, and **`btl_tcp_links` is now clamped to a maximum of 32 at registration** (with a message), since a `size_t` cast alone cannot prevent the wrap on 32-bit platforms and huge values are useless anyway.
* **topo/treematch** (commit 6): the centralized reordering path squares the full communicator size in `int` — UB at 46341 ranks, and at exactly 65536 ranks the product wraps to zero, so `calloc()` returns a minimal block that the subsequent gathers overrun.  Sizes and row offsets are computed in `size_t`, an explicit overflow guard covers platforms where `size_t` is itself 32 bits (evaluated uniformly on all ranks, so the bail-out is collectively consistent), and the pattern-matrix allocation is NULL-checked; both failure paths degrade to the existing unreordered-communicator fallback instead of corrupting memory.
* **part/persist** (commit 5, the two `float` oddball alerts): the partition-index conversion factor was computed in `float` (24-bit mantissa), and a ratio that rounds upward makes `ceil()` produce an index one past the end of `req->flags[]` — an out-of-bounds read.  Computed in `double` now.  **Fixing this exposed that the upper-bound mapping itself was wrong**: requested partition p overlaps real partitions `[convert*p, convert*(p+1))`, so the inclusive upper index is `ceil(convert * (max_part + 1)) - 1` (clamped), not `ceil(convert * max_part)`.  The old bound could let `MPI_Parrived` report completion before all corresponding real partitions had arrived — this commit therefore changes (corrects) observable `MPI_Parrived` behavior when the requested and internal partitioning differ.

**Benign but widened anyway** (commit 1): the communicator-allgather emulation (count is always 2, and the adjacent `tmpbuf` index arithmetic is widened to match), the debugger DLL pointer-array indexing, the affinity extension's sockets×cores, and the bipartite graph's squared NIC count — all bounded far below overflow, but the one-token cast makes them correct by construction and resolves the alerts.

**Drive-by** (commit 7): a pre-existing `-Wformat` warning in `comm.c` (`%ld` for the `uint64_t` PMIx context id) fixed with `PRIu64`.

**Dismissed rather than fixed**: the four alerts against the iovec-growth reallocs in dynamic_gen2/vulcan ([75](https://github.com/open-mpi/ompi/security/code-scanning/75), [76](https://github.com/open-mpi/ompi/security/code-scanning/76), [86](https://github.com/open-mpi/ompi/security/code-scanning/86), [87](https://github.com/open-mpi/ompi/security/code-scanning/87)).  The identical product is stored into an `int` bookkeeping array (`max_lengths`), so `int` is already the binding ceiling there, and casting only the `realloc` size would be misleading; overflow would require a >2^31-entry iovec array that could never have been decoded in the first place.  Fixing these properly means widening the bookkeeping wholesale, which is not warranted for a bounded-by-construction case.

Verified with a clean full VPATH build on macOS; every changed file recompiled with no warnings.  Backports: all seven commits cherry-pick cleanly onto `v6.0.x`.  On `v5.0.x`, five of seven apply; the coll and fcoll commits conflict — and notably v5.0.x's coll code predates bigcount (`int` counts), so the segmentation overflows this PR fixes cannot occur there.  Labeled for v6.0.x only.
