### PR TITLE
Fix TOCTOU races and symlink following in opal_os_dirpath

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -937,10 +937,16 @@ static bool check_file(const char *root, const char *path)
      *  - non-zero files starting with "output-"
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
-        fullpath = opal_os_path(false, &fullpath, root, path, NULL);
-        stat(fullpath, &st);
+        int rc;
+
+        fullpath = opal_os_path(false, root, path, NULL);
+        if (NULL == fullpath) {
+            return true;
+        }
+        rc = stat(fullpath, &st);
         free(fullpath);
-        if (0 == st.st_size) {
+        if (0 != rc || 0 == st.st_size) {
+            /* cannot stat it, or it is empty: allow removal */
             return true;
         }
         return false;

--- a/opal/util/help-opal-util.txt
+++ b/opal/util/help-opal-util.txt
@@ -114,3 +114,16 @@ A call to mkdir was unable to create the desired directory:
 
 Please check to ensure you have adequate permissions to perform
 the desired operation.
+#
+[dir-owner]
+A directory that Open MPI needs to use already exists, but is owned
+by a different user.  For safety, Open MPI will not use it:
+
+  Directory:  %s
+  Owner UID:  %lu
+  Our UID:    %lu
+
+This can happen when a stale directory with the same name is left
+over from another user's job, or when the directory was deliberately
+pre-created.  Please remove the directory, or use a different
+location (e.g., by setting the TMPDIR environment variable).

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,6 +23,7 @@
 #include "opal_config.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
@@ -46,9 +48,65 @@
 
 static const char path_sep[] = OPAL_PATH_SEP;
 
-int opal_os_dirpath_create(const char *path, const mode_t mode)
+/**
+ * The named directory already exists (or should): open it and make
+ * sure it carries (at least) the requested mode bits, adjusting them
+ * if needed.  All checks and the chmod operate on the descriptor, so
+ * the object that was inspected is the object that is modified --
+ * a path-based stat()/chmod() pair is the classic TOCTOU race, where
+ * the path can be swapped (e.g., for a symlink to another file)
+ * between the two calls.
+ *
+ * O_NOFOLLOW: refuse a symlink at the final component.  The
+ * ownership check below inspects the object the descriptor refers
+ * to, so following a link would validate the link's *target* -- and
+ * a planted symlink pointing at a directory the victim owns (e.g.,
+ * their home directory) would pass that check and be adopted (and,
+ * eventually, recursively destroyed).
+ *
+ * Returns OPAL_ERR_NOT_FOUND -- without displaying an error -- if
+ * the path cannot be opened as a directory; the caller is expected
+ * to (re)try creating it and report the resulting error.
+ */
+static int dirpath_ensure_mode(const char *path, const mode_t mode)
 {
     struct stat buf;
+    int fd, ret;
+
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        return OPAL_ERR_NOT_FOUND;
+    }
+    if (0 != fstat(fd, &buf)) {
+        close(fd);
+        return OPAL_ERROR;
+    }
+    /* Never adopt (or chmod) a directory owned by another user: the
+       only production paths that come through here are session
+       directories with predictable names under a world-writable
+       root, so an existing directory with the right name but the
+       wrong owner is at best stale and at worst planted */
+    if (buf.st_uid != geteuid()) {
+        close(fd);
+        opal_show_help("help-opal-util.txt", "dir-owner", true, path, (unsigned long) buf.st_uid,
+                       (unsigned long) geteuid());
+        return OPAL_ERR_PERM;
+    }
+    if (mode == (mode & buf.st_mode)) { /* already has correct mode */
+        close(fd);
+        return OPAL_SUCCESS;
+    }
+    ret = fchmod(fd, (buf.st_mode | mode));
+    close(fd);
+    if (0 == ret) {
+        return OPAL_SUCCESS;
+    }
+    opal_show_help("help-opal-util.txt", "dir-mode", true, path, mode, strerror(errno));
+    return OPAL_ERR_PERM; /* can't set correct mode */
+}
+
+int opal_os_dirpath_create(const char *path, const mode_t mode)
+{
     char **parts, *tmp;
     int i, len;
     int ret;
@@ -57,20 +115,18 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         return (OPAL_ERR_BAD_PARAM);
     }
 
-    if (0 == (ret = stat(path, &buf))) {    /* already exists */
-        if (mode == (mode & buf.st_mode)) { /* has correct mode */
-            return (OPAL_SUCCESS);
-        }
-        if (0 == (ret = chmod(path, (buf.st_mode | mode)))) { /* successfully change mode */
-            return (OPAL_SUCCESS);
-        }
-        opal_show_help("help-opal-util.txt", "dir-mode", true, path, mode, strerror(errno));
-        return (OPAL_ERR_PERM); /* can't set correct mode */
-    }
-
     /* quick -- try to make directory */
     if (0 == mkdir(path, mode)) {
         return (OPAL_SUCCESS);
+    }
+    if (EEXIST == errno) {
+        ret = dirpath_ensure_mode(path, mode);
+        if (OPAL_ERR_NOT_FOUND != ret) {
+            return ret;
+        }
+        /* The path exists but could not be opened as a directory
+           (or vanished); fall through and build the tree, which
+           will produce a proper error message */
     }
 
     /* didn't work, so now have to build our way down the tree */
@@ -113,17 +169,32 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         /* Now that we have the name, try to create it */
         mkdir(tmp, mode);
         ret = errno; // save the errno for an error msg, if needed
-        if (0 != stat(tmp, &buf)) {
-            opal_show_help("help-opal-util.txt", "mkdir-failed", true, tmp, strerror(ret));
-            opal_argv_free(parts);
-            free(tmp);
-            return OPAL_ERROR;
-        } else if (i == (len - 1) && (mode != (mode & buf.st_mode))
-                   && (0 > chmod(tmp, (buf.st_mode | mode)))) {
-            opal_show_help("help-opal-util.txt", "dir-mode", true, tmp, mode, strerror(errno));
-            opal_argv_free(parts);
-            free(tmp);
-            return (OPAL_ERR_PERM); /* can't set correct mode */
+        if (i == (len - 1)) {
+            /* Ensure the final component has the requested mode (and
+               is ours); intermediate components need only exist */
+            int err = dirpath_ensure_mode(tmp, mode);
+            if (OPAL_ERR_NOT_FOUND == err) {
+                opal_show_help("help-opal-util.txt", "mkdir-failed", true, tmp, strerror(ret));
+                err = OPAL_ERROR;
+            }
+            if (OPAL_SUCCESS != err) {
+                opal_argv_free(parts);
+                free(tmp);
+                return err;
+            }
+        } else {
+            /* Intermediate components need only exist: probe with
+               stat(), which (unlike open()) requires only search
+               permission on the ancestors, not read permission on
+               the component itself (an 0711 traverse-only
+               intermediate directory is legitimate) */
+            struct stat buf;
+            if (0 != stat(tmp, &buf)) {
+                opal_show_help("help-opal-util.txt", "mkdir-failed", true, tmp, strerror(ret));
+                opal_argv_free(parts);
+                free(tmp);
+                return OPAL_ERROR;
+            }
         }
     }
 

--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -213,31 +213,33 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
  * removed.  If the callback returns non-zero, then no removal is
  * done.
  */
-int opal_os_dirpath_destroy(const char *path, bool recursive,
-                            opal_os_dirpath_destroy_callback_fn_t cbfunc)
+/**
+ * Recursively empty the directory that fd refers to.  Takes
+ * ownership of fd (it is closed via closedir() before returning).
+ *
+ * All inspection and removal is descriptor-relative
+ * (fstatat/openat/unlinkat against the open directory), so no entry
+ * can be swapped between the check and the use: the entry that was
+ * classified is the entry that is removed.  AT_SYMLINK_NOFOLLOW and
+ * O_NOFOLLOW ensure symlinks are treated as entries to unlink, never
+ * followed -- following one would send the recursion outside the
+ * tree being destroyed.
+ *
+ * path is the (display) path of the directory, used only for the
+ * user callback and for building child display paths.
+ */
+static int dirpath_destroy_at(int fd, const char *path, bool recursive,
+                              opal_os_dirpath_destroy_callback_fn_t cbfunc)
 {
     int rc, exit_status = OPAL_SUCCESS;
-    bool is_dir = false;
     DIR *dp;
     struct dirent *ep;
-    char *filenm;
     struct stat buf;
 
-    if (NULL == path) { /* protect against error */
-        return OPAL_ERROR;
-    }
-
-    /*
-     * Make sure we have access to the the base directory
-     */
-    if (OPAL_SUCCESS != (rc = opal_os_dirpath_access(path, 0))) {
-        exit_status = rc;
-        goto cleanup;
-    }
-
-    /* Open up the directory */
-    dp = opendir(path);
+    /* fdopendir() takes ownership of fd; closedir() closes it */
+    dp = fdopendir(fd);
     if (NULL == dp) {
+        close(fd);
         return OPAL_ERROR;
     }
 
@@ -249,78 +251,94 @@ int opal_os_dirpath_destroy(const char *path, bool recursive,
             continue;
         }
 
-        /* Check to see if it is a directory */
-        is_dir = false;
-
-        /* Create a pathname.  This is not always needed, but it makes
-         * for cleaner code just to create it here.  Note that we are
-         * allocating memory here, so we need to free it later on.
-         */
-        filenm = opal_os_path(false, path, ep->d_name, NULL);
-
-        rc = stat(filenm, &buf);
-        if (0 > rc) {
-            /* Handle a race condition. filenm might have been deleted by an
+        if (0 != fstatat(dirfd(dp), ep->d_name, &buf, AT_SYMLINK_NOFOLLOW)) {
+            /* Handle a race condition. The entry might have been deleted by an
              * other process running on the same node. That typically occurs
              * when one task is removing the job_session_dir and an other task
              * is still removing its proc_session_dir.
              */
-            free(filenm);
             continue;
-        }
-        if (S_ISDIR(buf.st_mode)) {
-            is_dir = true;
         }
 
         /*
          * If not recursively descending, then if we find a directory then fail
          * since we were not told to remove it.
          */
-        if (is_dir && !recursive) {
+        if (S_ISDIR(buf.st_mode) && !recursive) {
             /* Set the error indicating that we found a directory,
              * but continue removing files
              */
             exit_status = OPAL_ERROR;
-            free(filenm);
             continue;
         }
 
         /* Will the caller allow us to remove this file/directory? */
-        if (NULL != cbfunc) {
+        if (NULL != cbfunc && !cbfunc(path, ep->d_name)) {
             /*
              * Caller does not wish to remove this file/directory,
              * continue with the rest of the entries
              */
-            if (!(cbfunc(path, ep->d_name))) {
-                free(filenm);
+            continue;
+        }
+
+        /* Directories are recursively destroyed */
+        if (S_ISDIR(buf.st_mode)) {
+            char *filenm;
+            int childfd = openat(dirfd(dp), ep->d_name,
+                                 O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+            if (0 > childfd) {
+                if (ENOENT != errno) {
+                    /* The entry was swapped for something that is no
+                     * longer an ordinary directory; leave it alone */
+                    exit_status = OPAL_ERROR;
+                }
                 continue;
             }
-        }
-        /* Directories are recursively destroyed */
-        if (is_dir) {
-            rc = opal_os_dirpath_destroy(filenm, recursive, cbfunc);
+            filenm = opal_os_path(false, path, ep->d_name, NULL);
+            rc = dirpath_destroy_at(childfd, filenm, recursive, cbfunc);
             free(filenm);
             if (OPAL_SUCCESS != rc) {
                 exit_status = rc;
-                closedir(dp);
-                goto cleanup;
+                break;
             }
+            /* Remove the now-empty subdirectory.  This fails
+             * (harmlessly) if the callback preserved any entries */
+            unlinkat(dirfd(dp), ep->d_name, AT_REMOVEDIR);
         } else {
-            /* Files are removed right here */
-            if (0 != (rc = unlink(filenm))) {
+            /* Files (and symlinks) are removed right here; unlinkat
+             * removes a link itself, never its target */
+            if (0 != unlinkat(dirfd(dp), ep->d_name, 0)) {
                 exit_status = OPAL_ERROR;
             }
-            free(filenm);
         }
     }
 
     /* Done with this directory */
     closedir(dp);
 
-cleanup:
+    return exit_status;
+}
+
+int opal_os_dirpath_destroy(const char *path, bool recursive,
+                            opal_os_dirpath_destroy_callback_fn_t cbfunc)
+{
+    int fd, exit_status;
+
+    if (NULL == path) { /* protect against error */
+        return OPAL_ERROR;
+    }
+
+    /* O_NOFOLLOW: never destroy through a symlinked base path */
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        return (ENOENT == errno) ? OPAL_ERR_NOT_FOUND : OPAL_ERROR;
+    }
+
+    exit_status = dirpath_destroy_at(fd, path, recursive, cbfunc);
 
     /*
-     * If the directory is empty, them remove it
+     * If the directory is empty, them remove it (rmdir() does not
+     * follow symlinks)
      */
     if (opal_os_dirpath_is_empty(path)) {
         rmdir(path);

--- a/test/util/opal_os_dirpath.c
+++ b/test/util/opal_os_dirpath.c
@@ -108,6 +108,12 @@ static void test_access_exists_no_match(void);
 static void test_destroy_recursive_no_callback(void);
 static void test_destroy_recursive_with_callback(void);
 static void test_destroy_nonexistent(void);
+static void test_create_on_file(void);
+static void test_create_on_symlink(void);
+static void test_destroy_does_not_follow_symlink(void);
+static void test_destroy_symlink_base(void);
+static void test_destroy_nonrecursive_with_subdir(void);
+static void test_destroy_callback_veto_in_subdir(void);
 
 /* ------------------------------------------------------------------ */
 /* main                                                                */
@@ -129,6 +135,12 @@ int main(int argc, char *argv[])
     test_destroy_recursive_no_callback();
     test_destroy_recursive_with_callback();
     test_destroy_nonexistent();
+    test_create_on_file();
+    test_create_on_symlink();
+    test_destroy_does_not_follow_symlink();
+    test_destroy_symlink_base();
+    test_destroy_nonrecursive_with_subdir();
+    test_destroy_callback_veto_in_subdir();
 
     int r = test_finalize();
     opal_finalize_util();
@@ -414,4 +426,249 @@ static void test_destroy_nonexistent(void)
                                     true, NULL);
     test_verify("destroy on non-existent path returns OPAL_ERR_NOT_FOUND",
                 OPAL_ERR_NOT_FOUND == rc);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * A pre-existing regular file at the requested path must be an
+ * error: it cannot be used as a directory (previously it was
+ * silently chmod'ed and reported as success).
+ */
+static void test_create_on_file(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_create_on_file: mkdtemp failed");
+        return;
+    }
+    char *file = path_join(base, "iamafile");
+
+    if (0 != create_file(file)) {
+        test_failure("test_create_on_file: create_file failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_create(file, S_IRWXU);
+    test_verify("create on existing regular file returns error", OPAL_SUCCESS != rc);
+
+out:
+    unlink(file);
+    rmdir(base);
+    free(file);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * A symlink planted at the requested path must be refused, even when
+ * it points at a directory the caller owns: following it would make
+ * the ownership/mode checks inspect the link's target, and the
+ * adopted path would later be recursively destroyed.
+ */
+static void test_create_on_symlink(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_create_on_symlink: mkdtemp failed");
+        return;
+    }
+    char *target = path_join(base, "target");
+    char *link = path_join(base, "link");
+
+    if (0 != mkdir(target, S_IRWXU) || 0 != symlink(target, link)) {
+        test_failure("test_create_on_symlink: setup failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_create(link, S_IRWXU);
+    test_verify("create on symlink-to-own-dir returns error", OPAL_SUCCESS != rc);
+
+    struct stat buf;
+    test_verify("symlink target still exists", 0 == stat(target, &buf));
+
+out:
+    unlink(link);
+    rmdir(target);
+    rmdir(base);
+    free(target);
+    free(link);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Recursive destroy must not follow a symlink inside the tree: the
+ * link itself is removed, but the directory it points to (and that
+ * directory's contents) must survive.
+ */
+static void test_destroy_does_not_follow_symlink(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_does_not_follow_symlink: mkdtemp failed");
+        return;
+    }
+    char *victim = path_join(base, "victim");
+    char *vfile = path_join(victim, "precious");
+    char *doomed = path_join(base, "doomed");
+    char *link = path_join(doomed, "escape");
+
+    if (0 != mkdir(victim, S_IRWXU) || 0 != create_file(vfile)
+        || 0 != mkdir(doomed, S_IRWXU) || 0 != symlink(victim, link)) {
+        test_failure("test_destroy_does_not_follow_symlink: setup failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_destroy(doomed, true, NULL);
+    test_verify("destroy of dir containing symlink returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    struct stat buf;
+    test_verify("symlink was removed", 0 != lstat(link, &buf));
+    test_verify("destroyed dir is gone", 0 != stat(doomed, &buf));
+    test_verify("symlink target dir survives", 0 == stat(victim, &buf));
+    test_verify("file inside symlink target survives", 0 == stat(vfile, &buf));
+
+out:
+    unlink(vfile);
+    rmdir(victim);
+    unlink(link);
+    rmdir(doomed);
+    rmdir(base);
+    free(victim);
+    free(vfile);
+    free(doomed);
+    free(link);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Destroy must refuse a symlink as its base path: the link's target
+ * (and the target's contents) must be untouched, and the link itself
+ * must remain (destroy errored out, it did not "destroy the link").
+ */
+static void test_destroy_symlink_base(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_symlink_base: mkdtemp failed");
+        return;
+    }
+    char *victim = path_join(base, "victim");
+    char *vfile = path_join(victim, "precious");
+    char *link = path_join(base, "link");
+
+    if (0 != mkdir(victim, S_IRWXU) || 0 != create_file(vfile)
+        || 0 != symlink(victim, link)) {
+        test_failure("test_destroy_symlink_base: setup failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_destroy(link, true, NULL);
+    test_verify("destroy on symlink base returns error", OPAL_SUCCESS != rc);
+
+    struct stat buf;
+    test_verify("symlink target dir untouched", 0 == stat(victim, &buf));
+    test_verify("file inside target untouched", 0 == stat(vfile, &buf));
+
+out:
+    unlink(link);
+    unlink(vfile);
+    rmdir(victim);
+    rmdir(base);
+    free(victim);
+    free(vfile);
+    free(link);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Non-recursive destroy of a directory that contains a subdirectory:
+ * files are removed, the subdirectory survives, and OPAL_ERROR is
+ * returned (we found a directory but were not told to remove it).
+ * The top directory survives because it is not empty.
+ */
+static void test_destroy_nonrecursive_with_subdir(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_nonrecursive_with_subdir: mkdtemp failed");
+        return;
+    }
+    char *sub = path_join(base, "sub");
+    char *file = path_join(base, "afile");
+
+    if (0 != mkdir(sub, S_IRWXU) || 0 != create_file(file)) {
+        test_failure("test_destroy_nonrecursive_with_subdir: setup failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_destroy(base, false /* not recursive */, NULL);
+    test_verify("non-recursive destroy with subdir returns error",
+                OPAL_SUCCESS != rc);
+
+    struct stat buf;
+    test_verify("file was still removed", 0 != stat(file, &buf));
+    test_verify("subdir survives non-recursive destroy", 0 == stat(sub, &buf));
+    test_verify("top dir survives (not empty)", 0 == stat(base, &buf));
+
+out:
+    unlink(file);
+    rmdir(sub);
+    rmdir(base);
+    free(sub);
+    free(file);
+}
+
+/* ------------------------------------------------------------------ */
+
+/*
+ * Callback veto on a file inside a subdirectory: the subdirectory
+ * cannot be removed (it still holds the protected file), which must
+ * be harmless -- overall destroy still succeeds, the protected file
+ * and its parent dir survive, and unprotected siblings are removed.
+ */
+static void test_destroy_callback_veto_in_subdir(void)
+{
+    char tmpl[] = "/tmp/opal_test_XXXXXX";
+    char *base = mkdtemp(tmpl);
+    if (NULL == base) {
+        test_failure("test_destroy_callback_veto_in_subdir: mkdtemp failed");
+        return;
+    }
+    char *sub = path_join(base, "sub");
+    char *prot = path_join3(base, "sub", "protected");
+    char *remo = path_join3(base, "sub", "removable");
+
+    if (0 != mkdir(sub, S_IRWXU) || 0 != create_file(prot)
+        || 0 != create_file(remo)) {
+        test_failure("test_destroy_callback_veto_in_subdir: setup failed");
+        goto out;
+    }
+
+    int rc = opal_os_dirpath_destroy(base, true, cb_protect);
+    test_verify("destroy with nested veto returns OPAL_SUCCESS",
+                OPAL_SUCCESS == rc);
+
+    struct stat buf;
+    test_verify("nested protected file survives", 0 == stat(prot, &buf));
+    test_verify("nested removable file was removed", 0 != stat(remo, &buf));
+    test_verify("subdir holding protected file survives", 0 == stat(sub, &buf));
+
+out:
+    unlink(prot);
+    unlink(remo);
+    rmdir(sub);
+    rmdir(base);
+    free(sub);
+    free(prot);
+    free(remo);
 }


### PR DESCRIPTION
This resolves the last three open CodeQL code scanning alerts — the `cpp/toctou-race-condition` findings in `opal/util/os_dirpath.c` ([104](https://github.com/open-mpi/ompi/security/code-scanning/104), [105](https://github.com/open-mpi/ompi/security/code-scanning/105), [106](https://github.com/open-mpi/ompi/security/code-scanning/106)) — plus hardening found while auditing the callers.  Context that shaped the fix: the only production caller of `opal_os_dirpath_create()`/`destroy()` is the singleton/direct-launch session-directory setup in `ompi_rte.c` (under `mpirun`, PMIx supplies the directories), always mode 0700, with a fully predictable name (`ompi.<node>.<pid>.<uid>`) under a world-writable default root (`/tmp`) — so the check-then-use races there are not just theoretical.  (Updated after AI-assisted local and PR review passes, whose findings are folded in.)

**Commit 1 — rework `opal_os_dirpath_create()`** (alerts 105, 106): `mkdir()` first with `EEXIST` as the existence probe, and all inspection/mode adjustment of an existing directory done through a descriptor (`open(O_DIRECTORY | O_NOFOLLOW)`/`fstat`/`fchmod`) so the object checked is the object modified.  Four deliberate behavior changes, all hardening: a pre-existing *file* at the requested path is now an error (previously it was chmod'ed and reported as success); a *symlink* at the requested path is refused rather than followed (following one would make the ownership check validate the link's target — which an attacker can choose to be something the victim owns); an existing directory owned by another user is refused with a new help message (previously any pre-created directory whose mode was a superset of the request — e.g. an attacker-owned 0777 directory at the predictable session path — was silently adopted); and an existing directory the user owns but cannot read is reported as a permission error (`OPAL_ERR_PERM`) and refused rather than repaired (there is no portable way to get a descriptor to it that `fchmod()` accepts, and a path-based `chmod()` fallback would reintroduce the race).  Intermediate path components keep a plain `stat()` existence probe, so traverse-only (0711) intermediate directories continue to work.

**Commit 2 — rework `opal_os_dirpath_destroy()` with descriptor-relative traversal** (alert 104): the old traversal was path-based end to end — the `stat()` classifying each entry followed symlinks (so a symlink inside a session directory pointing outside the tree would send the recursive destroy through the link), and any entry could be swapped between classification and the subsequent `opendir()`/`unlink()` on the rebuilt path.  The traversal is now descriptor-relative throughout: the base is opened once (`O_DIRECTORY | O_NOFOLLOW` — a symlinked base path is refused outright), entries are classified with `fstatat(AT_SYMLINK_NOFOLLOW)` and removed with `unlinkat()`, and subdirectories are entered via `openat(O_NOFOLLOW)` on the held descriptor and removed with `unlinkat(AT_REMOVEDIR)`.  The object classified is always the object acted on; symlinks are unlinked, never followed.  Before recursing, the opened subdirectory's `st_dev`/`st_ino` are checked against the classified entry (catching a *different directory* swapped in, which `O_NOFOLLOW` alone does not), and the base directory itself is opened and removed relative to a descriptor on its parent (opened `O_SEARCH`/`O_PATH` where available, so the parent need only be searchable) — it is removed at the end only if the parent still holds the directory that was opened and emptied, so nothing is checked or removed by path.  All functions used are POSIX.1-2008.  Callback-veto and non-recursive semantics are preserved; failures that were previously swallowed — `fstatat()` errors other than `ENOENT`, and failing to remove an emptied subdirectory or base directory for any reason other than it vanishing or a callback having preserved something inside it — now return an error.

**Commit 3 — regression tests**, wired into `make check`, covering every new behavior: create-on-file refusal, create-on-symlink refusal (target untouched), create on an owned-but-unreadable directory (`OPAL_ERR_PERM`), destroy not following an in-tree symlink (target and contents survive), destroy refusing a symlinked base, non-recursive destroy with a subdirectory (files removed, subdir preserved, error returned), a callback veto inside a subdirectory (protected file and its parent survive, overall success), destroy returning an error for an unsearchable directory and for an unremovable subdirectory or base directory, and destroy still working with trailing path separators and under a writable, searchable, but unreadable parent.  The permission-based tests skip when run as root.

Verified with clean VPATH builds **on both macOS (clang) and Linux (AlmaLinux 10, gcc 14)**: no new warnings, and the `test/util/opal_os_dirpath` suite (38 assertions) passes on both platforms (verified before the rebase onto current `main`; CI covers the rebased branch).  After the PR review feedback, the updated `os_dirpath.c` and test suite (46 assertions) were compiled warning-free and pass on macOS (clang) and Linux (AlmaLinux 10, gcc 14, non-root, `/tmp` on overlayfs), built against configured trees of `main`; each new test was first confirmed to fail against the pre-feedback code.  (Rebased onto current `main`: a former commit fixing the bogus `opal_os_path(false, &fullpath, ...)` call in `check_file()` in `ompi_rte.c` was dropped, because #14339 fixed the same bug independently and landed first; #14355 carried it to `v6.0.x`.  `v5.0.x` still has that bug and no backport of #14339.)  Backports: all three commits should cherry-pick cleanly onto `v6.0.x`.  On `v5.0.x` the two code commits apply cleanly; the test commit needs manual adaptation (the modernized test file does not exist on that branch).  (Note: `test/util/opal_os_create_dirpath.c` is a dead source file — it still includes `orte_config.h` and is not referenced by `Makefile.am`; left alone here, but it could be deleted in a follow-up.  OpenPMIx's `pmix_os_dirpath.c` — which PRRTE also uses, and which creates session dirs under `mpirun` — has since been reworked upstream along the same descriptor-based lines, and the OpenPMIx submodule pinned on `main` already includes that work; it deliberately omits the owner check, for reasons discussed in the comments below.)
