### PR TITLE
Fix Coverity CIDs 1697464, 1697467, 1697457

### DIFF
--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -461,7 +461,7 @@ static int ompi_comm_ext_cid_new_block (ompi_communicator_t *newcomm, ompi_commu
     /* destruct the group */
     PMIX_INFO_CONSTRUCT(&tinfo);
     PMIX_INFO_LOAD(&tinfo, PMIX_TIMEOUT, &ompi_pmix_connect_timeout, PMIX_UINT32);
-    rc = PMIx_Group_destruct (tag, &tinfo, 0);
+    rc = PMIx_Group_destruct (tag, &tinfo, 1);
     PMIX_INFO_DESTRUCT(&tinfo);
     if(PMIX_SUCCESS != rc) {
         OPAL_OUTPUT_VERBOSE((10, ompi_comm_output, "PMIx_Group_destruct failed %s", PMIx_Error_string(rc)));

--- a/ompi/mca/coll/han/coll_han_allgather.c
+++ b/ompi/mca/coll/han/coll_han_allgather.c
@@ -388,8 +388,13 @@ int mca_coll_han_allgather_uag_task(void *task_args)
                                            t->up_comm, t->up_comm->c_coll->coll_allgather_module);
 
         if (t->sbuf_inter_free != NULL) {
-            han_free_frag(&t->han_module->fragment_freelist,
-                          t->inter_frag, t->sbuf_inter_free);
+            if (NULL != t->han_module) {
+                han_free_frag(&t->han_module->fragment_freelist,
+                              t->inter_frag, t->sbuf_inter_free);
+            } else {
+                /* Without a module the buffer came from plain malloc() */
+                free(t->sbuf_inter_free);
+            }
             t->inter_frag = NULL;
             t->sbuf_inter_free = NULL;
         }

--- a/ompi/mca/coll/han/coll_han_alltoall.c
+++ b/ompi/mca/coll/han/coll_han_alltoall.c
@@ -79,7 +79,9 @@ static int alltoall_cache_setup(
     if (c->cached_sbuf == sbuf
         && c->cached_scount == scount
         && c->cached_low_size == low_size
-        && c->low_bufs != NULL) {
+        && NULL != c->low_bufs
+        && NULL != c->map_ctx
+        && NULL != c->gather_buf) {
         *low_bufs_out = c->low_bufs;
         *map_ctx_out = c->map_ctx;
         *gather_buf_out = c->gather_buf;
@@ -96,7 +98,8 @@ static int alltoall_cache_setup(
         }
     }
     /* Allocate/reuse persistent arrays */
-    if (c->cached_low_size < low_size) {
+    if (c->cached_low_size < low_size || NULL == c->low_bufs
+        || NULL == c->map_ctx || NULL == c->gather_buf) {
         free(c->low_bufs);
         free(c->map_ctx);
         free(c->gather_buf);


### PR DESCRIPTION
This PR fixes three issues found by Coverity, one commit per CID:

* **CID 1697464** (comm_cid.c): `ompi_comm_ext_cid_new_block()` constructed a `pmix_info_t` holding `PMIX_TIMEOUT` for the `PMIx_Group_destruct()` call, but passed `ninfo=0`, so the timeout was silently ignored (Coverity flagged the singleton-passed-as-array). Pass the actual info count of 1 so the timeout takes effect.
* **CID 1697467** (coll_han_alltoall.c): `alltoall_cache_setup()` only re-allocated the cached arrays when the cached `low_size` was smaller than requested, then unconditionally `memset()` the arrays; Coverity cannot see the invariant that a non-zero `cached_low_size` implies successful allocation. Make the invariant explicit by also re-allocating when any cached array pointer is NULL.
* **CID 1697457** (coll_han_allgather.c): `mca_coll_han_allgather_uag_task()` freed the inter-node staging buffer via `han_free_frag(&t->han_module->fragment_freelist, ...)` without checking `t->han_module` for NULL, even though the allocation sites explicitly handle a NULL module (plain `malloc()`, no fragment item). Mirror that check on the free side and plain `free()` the buffer when there is no module.

All three commits cherry-pick cleanly to v6.0.x (verified with `git merge-tree`). The remaining two CIDs from the same scan batch (1697469, 1697459) touch code that does not exist on v6.0.x and are submitted separately.
