### PR TITLE
Fix Coverity CIDs 1697469 and 1697459

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -994,8 +994,11 @@ static int ompi_comm_split_type_get_nvlink_domain(
     }
 
     rc = mca_base_var_get_value(var_id, &value, NULL, NULL);
-    if (OMPI_SUCCESS != rc || NULL == value) {
+    if (OMPI_SUCCESS != rc) {
         return rc;
+    }
+    if (NULL == value || NULL == *value) {
+        return OMPI_ERR_NOT_FOUND;
     }
 
     return ompi_comm_split_type_parse_nvlink_domain(*value, domain);

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -1099,7 +1099,11 @@ int ompi_comm_get_remote_cid_from_pmix (ompi_communicator_t *comm, int dest, uin
     }
 
     if (val->type != PMIX_SIZE) {
-        OPAL_OUTPUT_VERBOSE((10, ompi_comm_output, "PMIx_Get failed for PMIX_GROUP_LOCAL_CID type mismatch - %s", PMIx_Value_string(val)));
+#if OPAL_ENABLE_DEBUG
+        char *val_string = PMIx_Value_string(val);
+        OPAL_OUTPUT_VERBOSE((10, ompi_comm_output, "PMIx_Get failed for PMIX_GROUP_LOCAL_CID type mismatch - %s", val_string));
+        free(val_string);
+#endif
         rc = OMPI_ERR_TYPE_MISMATCH;
         goto done;
     }


### PR DESCRIPTION
This PR fixes two issues found by Coverity, one commit per CID:

* **CID 1697469** (comm.c): `ompi_comm_split_type_get_nvlink_domain()` lumped the "get_value failed" and "no value available" cases into a single return statement that returned `OMPI_SUCCESS` in the latter case even though no NVLink domain had been parsed. Split the two checks and return `OMPI_ERR_NOT_FOUND` when the MCA variable has no backing value (the sole caller ignores the return code and relies on the default no-device domain, so this is behavior-safe). The simplified control flow should also resolve Coverity's DEADCODE claim that the final return statement is unreachable.
* **CID 1697459** (comm_cid.c): `PMIx_Value_string()` returns an allocated string that the caller must free; `ompi_comm_get_remote_cid_from_pmix()` called it inside `OPAL_OUTPUT_VERBOSE()` on the type-mismatch error path and leaked the result. Save the string and free it after emitting the output, guarded by `OPAL_ENABLE_DEBUG` so non-debug builds (where `OPAL_OUTPUT_VERBOSE` compiles to nothing) do not pay for constructing the string at all.

## Why these fixes are main-only (no backport)

Neither commit cherry-picks cleanly to v6.0.x, because in both cases the code being fixed does not exist there — meaning the bugs themselves do not exist on v6.0.x and no backport is needed:

* The CID 1697469 fix modifies `ompi_comm_split_type_get_nvlink_domain()`, which was added by commit 4a4262e822 ("comm: add NVLink-domain communicator split support", PR #13894). That feature is not on v6.0.x; the fix would only apply cleanly if PR #13894 were backported first.
* The CID 1697459 fix modifies the `PMIx_Value_string(val)` debug output added by commit 629d6eff45 ("Comm create from group: improve debug statements", PR #13748). On v6.0.x the type-mismatch message is a plain string with no `PMIx_Value_string()` call, so there is nothing to leak; the fix would only apply cleanly if PR #13748 were backported first.

(For completeness: none of this scan batch applies to v5.0.x either — the NVLink code, the `PMIx_Value_string()` call, and the han persist-buffer machinery are all absent there, and v5.0.x's `PMIx_Group_destruct(tag, NULL, 0)` never constructs a timeout info in the first place.)
