### PR TITLE
OSC/UCX: Honor origin datatype true_lb in accumulate reduce fast-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,7 @@ test/simple/mpi_no_op
 test/simple/mpi_spin
 test/simple/multi_abort
 test/simple/ompio_file_info
+test/simple/osc_ucx_bottom_accumulate
 test/simple/parallel_r8
 test/simple/parallel_r64
 test/simple/parallel_w8

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019-2022 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +42,27 @@ typedef struct ucx_iovec {
 } ucx_iovec_t;
 
 size_t ompi_osc_ucx_outstanding_ops_flush_threshold = 64;
+
+/*
+ * Return the address of the first byte of origin data described by
+ * origin_dt.  For a type with a non-zero true_lb the data starts at
+ * origin_addr + true_lb rather than at origin_addr itself; the classic
+ * case is an absolute-displacement type used with MPI_BOTTOM, where
+ * origin_addr is NULL and true_lb carries the real buffer address.
+ *
+ * The offset is computed in uintptr_t rather than as pointer arithmetic
+ * because adding an integer to a null pointer is undefined behavior.
+ * Constness is preserved: the result feeds ompi_op_reduce(), whose
+ * source argument is a const void *.
+ */
+static inline const void *osc_ucx_origin_true_lb_ptr(const void *origin_addr,
+                                                     ompi_datatype_t *origin_dt)
+{
+    ptrdiff_t true_lb, true_extent;
+
+    ompi_datatype_get_true_extent(origin_dt, &true_lb, &true_extent);
+    return (const void *)((uintptr_t)origin_addr + (uintptr_t)true_lb);
+}
 
 static inline int check_sync_state(ompi_osc_ucx_module_t *module, int target,
                                    bool is_req_ops) {
@@ -767,7 +789,8 @@ int accumulate_req(const void *origin_addr, size_t origin_count,
         }
 
         if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
-            ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
+            ompi_op_reduce(op, osc_ucx_origin_true_lb_ptr(origin_addr, origin_dt),
+                           temp_addr, (int)temp_count, temp_dt);
         } else {
             ucx_iovec_t *origin_ucx_iov = NULL;
             uint32_t origin_ucx_iov_count = 0;
@@ -1400,7 +1423,8 @@ int get_accumulate_req(const void *origin_addr, size_t origin_count,
             }
 
             if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
-                ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
+                ompi_op_reduce(op, osc_ucx_origin_true_lb_ptr(origin_addr, origin_dt),
+                               temp_addr, (int)temp_count, temp_dt);
             } else {
                 ucx_iovec_t *origin_ucx_iov = NULL;
                 uint32_t origin_ucx_iov_count = 0;
@@ -1807,7 +1831,8 @@ void ompi_osc_ucx_req_completion(void *request) {
                     ompi_datatype_is_contiguous_memory_layout(origin_dt, origin_count);
             
                 if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
-                    ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
+                    ompi_op_reduce(op, osc_ucx_origin_true_lb_ptr(origin_addr, origin_dt),
+                                   temp_addr, (int)temp_count, temp_dt);
                 } else {
                     ucx_iovec_t *origin_ucx_iov = NULL;
                     uint32_t origin_ucx_iov_count = 0;

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -6,7 +6,8 @@ PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort 
 		debugger singleton_client_server intercomm_create spawn_tree init-exit77 mpi_info \
 		info_spawn server client ring binding badcoll attach xlib ompio_file_info \
 		no-disconnect nonzero interlib pinterlib add_host \
-		buffer_attach_detach_f08
+		buffer_attach_detach_f08 \
+		osc_ucx_bottom_accumulate
 
 all: $(PROGS)
 

--- a/test/simple/osc_ucx_bottom_accumulate.c
+++ b/test/simple/osc_ucx_bottom_accumulate.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+
+#define N 16
+
+/*
+ * Collectively zero the window buffer on rank 0.  The fences use no
+ * assertions: an epoch that follows immediately afterwards does issue
+ * RMA, so MPI_MODE_NOSUCCEED / MPI_MODE_NOPRECEDE would be untrue here.
+ */
+static void reset_win(MPI_Win win, double *winbuf, int rank)
+{
+    int i;
+
+    MPI_Win_fence(0, win);
+    if (rank == 0) {
+        for (i = 0; i < N; i++) {
+            winbuf[i] = 0.0;
+        }
+    }
+    MPI_Win_fence(0, win);
+}
+
+/*
+ * Verify on rank 0 that every window element accumulated the sum over all
+ * ranks.  Returns the number of mismatches found.
+ */
+static int check_win(const char *tag, const double *winbuf, int rank,
+                     double sum_of_ranks)
+{
+    int i, errs = 0;
+    double expect;
+
+    if (rank != 0) {
+        return 0;
+    }
+
+    for (i = 0; i < N; i++) {
+        expect = (double)(i + 1) * sum_of_ranks;
+        if (winbuf[i] != expect) {
+            fprintf(stderr, "%s MISMATCH at %d: got %g exp %g\n", tag,
+                    i, winbuf[i], expect);
+            errs++;
+        }
+    }
+
+    return errs;
+}
+
+int main(int argc, char **argv)
+{
+    int rank, size, i, errs = 0;
+    MPI_Win win;
+    double *winbuf, origin[N], result[N];
+    MPI_Datatype abs_dt;
+    MPI_Aint disp;
+    int blocklen = N;
+    double sum_of_ranks;
+    MPI_Request req;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Win_allocate(N * sizeof(double), sizeof(double), MPI_INFO_NULL,
+                     MPI_COMM_WORLD, &winbuf, &win);
+    for (i = 0; i < N; i++) {
+        origin[i] = (double)(rank + 1) * (i + 1);
+    }
+
+    /* Absolute-address origin: block at its own address, passed as MPI_BOTTOM. */
+    MPI_Get_address(&origin[0], &disp);
+    MPI_Type_create_hindexed(1, &blocklen, &disp, MPI_DOUBLE, &abs_dt);
+    MPI_Type_commit(&abs_dt);
+
+    sum_of_ranks = (double)size * (size + 1) / 2.0;
+
+    reset_win(win, winbuf, rank);
+    MPI_Win_fence(0, win);
+    MPI_Accumulate(MPI_BOTTOM, 1, abs_dt, 0, 0, N, MPI_DOUBLE, MPI_SUM, win);
+    MPI_Win_fence(0, win);
+    errs += check_win("accumulate", winbuf, rank, sum_of_ranks);
+
+    reset_win(win, winbuf, rank);
+    MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+    MPI_Raccumulate(MPI_BOTTOM, 1, abs_dt, 0, 0, N, MPI_DOUBLE, MPI_SUM, win,
+                    &req);
+    MPI_Wait(&req, MPI_STATUS_IGNORE);
+    MPI_Win_unlock(0, win);
+    MPI_Barrier(MPI_COMM_WORLD);
+    errs += check_win("raccumulate", winbuf, rank, sum_of_ranks);
+
+    reset_win(win, winbuf, rank);
+    for (i = 0; i < N; i++) {
+        result[i] = -1.0;
+    }
+    MPI_Win_fence(0, win);
+    MPI_Get_accumulate(MPI_BOTTOM, 1, abs_dt, result, N, MPI_DOUBLE, 0, 0, N,
+                       MPI_DOUBLE, MPI_SUM, win);
+    MPI_Win_fence(0, win);
+    errs += check_win("get_accumulate", winbuf, rank, sum_of_ranks);
+
+    reset_win(win, winbuf, rank);
+    MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+    MPI_Rget_accumulate(MPI_BOTTOM, 1, abs_dt, result, N, MPI_DOUBLE, 0, 0, N,
+                        MPI_DOUBLE, MPI_SUM, win, &req);
+    MPI_Wait(&req, MPI_STATUS_IGNORE);
+    MPI_Win_unlock(0, win);
+    MPI_Barrier(MPI_COMM_WORLD);
+    errs += check_win("rget_accumulate", winbuf, rank, sum_of_ranks);
+
+    if (rank == 0 && errs == 0) {
+        printf("PASS: MPI_BOTTOM absolute-datatype accumulate (all four APIs) "
+               "correct\n");
+    }
+
+    MPI_Type_free(&abs_dt);
+    MPI_Win_free(&win);
+    MPI_Finalize();
+    return errs ? 1 : 0;
+}


### PR DESCRIPTION
The three reduce fast-paths in `osc_ucx_comm.c` (in `accumulate_req`,
`get_accumulate_req`, and `ompi_osc_ucx_req_completion`) passed `origin_addr`
directly to `ompi_op_reduce`. For predefined types `true_lb == 0`, so this
is correct. For absolute-address hindexed types where `true_lb != 0`, the
actual origin buffer starts at `origin_addr + true_lb`, not at `origin_addr`.

ARMCI calls `MPI_Accumulate` with `origin_addr = MPI_BOTTOM` (address zero)
and a hindexed datatype whose `true_lb` encodes the actual buffer address as
an absolute byte offset. Passing `origin_addr` without adjustment meant
passing `NULL` to `ompi_op_reduce`, which read from address zero and caused
a SIGSEGV.

Add a static inline helper `osc_ucx_origin_true_lb_ptr` that applies the
`true_lb` offset using `uintptr_t` arithmetic to avoid undefined behavior
when `origin_addr` is `NULL`, and use it at all three reduce sites. For the
common case of predefined types the helper is a no-op.

The non-contiguous and `replace` paths go through convertors that apply
`true_lb` themselves, so they correctly need no change.

### Testing

New regression test `test/simple/osc_ucx_bottom_accumulate.c` exercises all
four accumulate APIs (`MPI_Accumulate`, `MPI_Raccumulate`,
`MPI_Get_accumulate`, `MPI_Rget_accumulate`) with an `MPI_BOTTOM`-based
hindexed type.

Verified A/B against this PR's merge base: the test **SIGSEGVs at `(nil)`**
inside `ompi_osc_ucx_accumulate` on unpatched `main`, and passes with the
fix applied. `mpirun --np 2 ./ring_c` and a full `make` in `examples/` are
clean on the patched tree, with no new compiler warnings.

Tested over UCX shm/tcp/self only — no RDMA hardware was available, so
device-transport-specific behavior in osc/ucx is untested.

### Related PRs

Part of a set of independent `ompi/mca/osc/ucx` accumulate fixes, each
reviewable and mergeable on its own:

- #14260 — OSC/UCX: Fix accumulate staging buffer overflow for padded types
- #14262 — OSC/UCX: Fix non-contiguous origin iovec traversal in MINLOC/MAXLOC accumulate
- #14263 — OSC/UCX: Defer nonblocking-accumulate finalize to top-level progress (draft)

Whichever lands later needs a `test/simple/Makefile` `PROGS` rebase.

**A word of caution on #14263.** It relocates the entire `ACC_*` switch block
out of `ompi_osc_ucx_req_completion()` into a new function — and that block is
exactly the region this PR and its two siblings patch. As a pure code move it
faithfully preserves whatever is in that block at the time, so if #14263 is
rebased across an already-merged fix here, a careless conflict resolution can
silently reinstate the old, unfixed code. Whoever resolves that conflict should
confirm the fixes from the other PRs survive the move.
