### PR TITLE
OSC/UCX: Fix non-contiguous origin iovec traversal in MINLOC/MAXLOC accumulate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,7 @@ test/simple/mpi_no_op
 test/simple/mpi_spin
 test/simple/multi_abort
 test/simple/ompio_file_info
+test/simple/osc_ucx_noncontig_maxloc
 test/simple/parallel_r8
 test/simple/parallel_r64
 test/simple/parallel_w8

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019-2022 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -130,6 +131,56 @@ static inline int create_iov_list(const void *addr, int count, ompi_datatype_t *
     OBJ_DESTRUCT(&convertor);
 
     return ret;
+}
+
+/*
+ * Reduce a non-contiguous origin buffer into the accumulate staging buffer
+ * with MINLOC/MAXLOC.
+ *
+ * The staging buffer holds stage_count elements of stage_dt separated by
+ * stage_extent bytes, which is not the extent of stage_dt, so ompi_op_reduce
+ * has to be called once per element instead of once for the whole buffer.
+ *
+ * The origin cannot be traversed with an iovec list here.  The list built by
+ * create_iov_list() describes the origin's real-data runs, and those runs do
+ * not have to start on an element boundary: for a type with an internal hole
+ * and no trailing padding, such as MPI_SHORT_INT, the trailing member of one
+ * element and the leading member of the next are adjacent in memory and the
+ * convertor merges them into a single segment.  Copy the origin into a
+ * temporary array of stage_dt instead, which gives every element its own
+ * correctly laid out and correctly aligned slot whatever the origin's shape.
+ */
+static int reduce_noncontig_origin(ompi_op_t *op, const void *origin_addr,
+                                   size_t origin_count, ompi_datatype_t *origin_dt,
+                                   void *stage_addr, size_t stage_count,
+                                   ompi_datatype_t *stage_dt, ptrdiff_t stage_extent) {
+    ptrdiff_t lb, extent;
+    char *unpacked;
+    size_t i;
+    int ret;
+
+    ompi_datatype_get_extent(stage_dt, &lb, &extent);
+
+    unpacked = malloc((size_t)extent * stage_count);
+    if (unpacked == NULL) {
+        return OMPI_ERR_TEMP_OUT_OF_RESOURCE;
+    }
+
+    ret = ompi_datatype_sndrcv(origin_addr, origin_count, origin_dt,
+                               unpacked, stage_count, stage_dt);
+    if (ret != OMPI_SUCCESS) {
+        free(unpacked);
+        return ret;
+    }
+
+    for (i = 0; i < stage_count; i++) {
+        ompi_op_reduce(op, unpacked + i * extent,
+                       (char *)stage_addr + i * stage_extent, 1, stage_dt);
+    }
+
+    free(unpacked);
+
+    return OMPI_SUCCESS;
 }
 
 static inline int ddt_put_get(ompi_osc_ucx_module_t *module,
@@ -768,10 +819,13 @@ int accumulate_req(const void *origin_addr, size_t origin_count,
 
         if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
             ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
-        } else {
+        } else if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
+                   ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
             ucx_iovec_t *origin_ucx_iov = NULL;
             uint32_t origin_ucx_iov_count = 0;
             uint32_t origin_ucx_iov_idx = 0;
+            char *curr_temp_addr = (char *)temp_addr;
+            size_t temp_size;
 
             ret = create_iov_list(origin_addr, origin_count, origin_dt,
                                   &origin_ucx_iov, &origin_ucx_iov_count);
@@ -780,35 +834,23 @@ int accumulate_req(const void *origin_addr, size_t origin_count,
                 return ret;
             }
 
-            if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
-                ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
-                size_t temp_size;
-                char *curr_temp_addr = (char *)temp_addr;
-                ompi_datatype_type_size(temp_dt, &temp_size);
-                while (origin_ucx_iov_idx < origin_ucx_iov_count) {
-                    int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
-                    ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
-                                   curr_temp_addr, curr_count, temp_dt);
-                    curr_temp_addr += curr_count * temp_size;
-                    origin_ucx_iov_idx++;
-                }
-            } else {
-                int i;
-                void *curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                for (i = 0; i < (int)temp_count; i++) {
-                    ompi_op_reduce(op, curr_origin_addr,
-                                   (void *)((char *)temp_addr + i * temp_extent),
-                                   1, temp_dt);
-                    curr_origin_addr = (void *)((char *)curr_origin_addr + temp_extent);
-                    origin_ucx_iov_idx++;
-                    if (curr_origin_addr >= (void *)((char *)origin_ucx_iov[origin_ucx_iov_idx].addr + origin_ucx_iov[origin_ucx_iov_idx].len)) {
-                        origin_ucx_iov_idx++;
-                        curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                    }
-                }
+            ompi_datatype_type_size(temp_dt, &temp_size);
+            while (origin_ucx_iov_idx < origin_ucx_iov_count) {
+                int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
+                ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
+                               curr_temp_addr, curr_count, temp_dt);
+                curr_temp_addr += curr_count * temp_size;
+                origin_ucx_iov_idx++;
             }
 
             free(origin_ucx_iov);
+        } else {
+            ret = reduce_noncontig_origin(op, origin_addr, origin_count, origin_dt,
+                                          temp_addr, temp_count, temp_dt, temp_extent);
+            if (ret != OMPI_SUCCESS) {
+                free(temp_addr);
+                return ret;
+            }
         }
 
         ret = ompi_osc_ucx_put(temp_addr, (int)temp_count, temp_dt, target, target_disp,
@@ -1401,10 +1443,13 @@ int get_accumulate_req(const void *origin_addr, size_t origin_count,
 
             if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
                 ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
-            } else {
+            } else if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
+                       ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
                 ucx_iovec_t *origin_ucx_iov = NULL;
                 uint32_t origin_ucx_iov_count = 0;
                 uint32_t origin_ucx_iov_idx = 0;
+                char *curr_temp_addr = (char *)temp_addr;
+                size_t temp_size;
 
                 ret = create_iov_list(origin_addr, origin_count, origin_dt,
                                       &origin_ucx_iov, &origin_ucx_iov_count);
@@ -1412,34 +1457,22 @@ int get_accumulate_req(const void *origin_addr, size_t origin_count,
                     return ret;
                 }
 
-                if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
-                    ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
-                    size_t temp_size;
-                    char *curr_temp_addr = (char *)temp_addr;
-                    ompi_datatype_type_size(temp_dt, &temp_size);
-                    while (origin_ucx_iov_idx < origin_ucx_iov_count) {
-                        int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
-                        ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
-                                       curr_temp_addr, curr_count, temp_dt);
-                        curr_temp_addr += curr_count * temp_size;
-                        origin_ucx_iov_idx++;
-                    }
-                } else {
-                    int i;
-                    void *curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                    for (i = 0; i < (int)temp_count; i++) {
-                        ompi_op_reduce(op, curr_origin_addr,
-                                       (void *)((char *)temp_addr + i * temp_extent),
-                                       1, temp_dt);
-                        curr_origin_addr = (void *)((char *)curr_origin_addr + temp_extent);
-                        origin_ucx_iov_idx++;
-                        if (curr_origin_addr >= (void *)((char *)origin_ucx_iov[origin_ucx_iov_idx].addr + origin_ucx_iov[origin_ucx_iov_idx].len)) {
-                            origin_ucx_iov_idx++;
-                            curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                        }
-                    }
+                ompi_datatype_type_size(temp_dt, &temp_size);
+                while (origin_ucx_iov_idx < origin_ucx_iov_count) {
+                    int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
+                    ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
+                                   curr_temp_addr, curr_count, temp_dt);
+                    curr_temp_addr += curr_count * temp_size;
+                    origin_ucx_iov_idx++;
                 }
+
                 free(origin_ucx_iov);
+            } else {
+                ret = reduce_noncontig_origin(op, origin_addr, origin_count, origin_dt,
+                                              temp_addr, temp_count, temp_dt, temp_extent);
+                if (ret != OMPI_SUCCESS) {
+                    return ret;
+                }
             }
 
             ret = ompi_osc_ucx_put(temp_addr, (int)temp_count, temp_dt, target, target_disp,
@@ -1808,10 +1841,13 @@ void ompi_osc_ucx_req_completion(void *request) {
             
                 if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
                     ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
-                } else {
+                } else if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
+                           ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
                     ucx_iovec_t *origin_ucx_iov = NULL;
                     uint32_t origin_ucx_iov_count = 0;
                     uint32_t origin_ucx_iov_idx = 0;
+                    char *curr_temp_addr = (char *)temp_addr;
+                    size_t temp_size;
 
                     ret = create_iov_list(origin_addr, origin_count, origin_dt,
                                           &origin_ucx_iov, &origin_ucx_iov_count);
@@ -1821,40 +1857,25 @@ void ompi_osc_ucx_req_completion(void *request) {
                         abort();
                     }
 
-                    if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
-                        ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
-                        size_t temp_size;
-                        char *curr_temp_addr = (char *)temp_addr;
-                        ompi_datatype_type_size(temp_dt, &temp_size);
-                        while (origin_ucx_iov_idx < origin_ucx_iov_count) {
-                            int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
-                            ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
-                                           curr_temp_addr, curr_count, temp_dt);
-                            curr_temp_addr += curr_count * temp_size;
-                            origin_ucx_iov_idx++;
-                        }
-                    } else {
-                        int i;
-                        void *curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                        ompi_datatype_get_true_extent(temp_dt, &temp_lb, &temp_extent);
-                        for (i = 0; i < (int)temp_count; i++) {
-                            ompi_op_reduce(op, curr_origin_addr,
-                                           (void *)((char *)temp_addr + i * temp_extent),
-                                           1, temp_dt);
-                            curr_origin_addr = (void *)((char *)curr_origin_addr + temp_extent);
-                            origin_ucx_iov_idx++;
-                            if (curr_origin_addr >= (void *)((char
-                                            *)origin_ucx_iov[origin_ucx_iov_idx].addr
-                                        +
-                                        origin_ucx_iov[origin_ucx_iov_idx].len))
-                            {
-                                origin_ucx_iov_idx++;
-                                curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                            }
-                        }
+                    ompi_datatype_type_size(temp_dt, &temp_size);
+                    while (origin_ucx_iov_idx < origin_ucx_iov_count) {
+                        int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
+                        ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
+                                       curr_temp_addr, curr_count, temp_dt);
+                        curr_temp_addr += curr_count * temp_size;
+                        origin_ucx_iov_idx++;
                     }
 
                     free(origin_ucx_iov);
+                } else {
+                    ompi_datatype_get_true_extent(temp_dt, &temp_lb, &temp_extent);
+                    ret = reduce_noncontig_origin(op, origin_addr, origin_count, origin_dt,
+                                                  temp_addr, temp_count, temp_dt, temp_extent);
+                    if (ret != OMPI_SUCCESS) {
+                        OSC_UCX_ERROR("reduce_noncontig_origin failed ret= %d\n", ret);
+                        free(temp_addr);
+                        abort();
+                    }
                 }
             
                 if (req->acc_type == GET_ACCUMULATE) {

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -6,7 +6,8 @@ PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort 
 		debugger singleton_client_server intercomm_create spawn_tree init-exit77 mpi_info \
 		info_spawn server client ring binding badcoll attach xlib ompio_file_info \
 		no-disconnect nonzero interlib pinterlib add_host \
-		buffer_attach_detach_f08
+		buffer_attach_detach_f08 \
+		osc_ucx_noncontig_maxloc
 
 all: $(PROGS)
 

--- a/test/simple/osc_ucx_noncontig_maxloc.c
+++ b/test/simple/osc_ucx_noncontig_maxloc.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * MINLOC/MAXLOC accumulate with a derived origin datatype.
+ *
+ * The osc/ucx accumulate path stages the target data in a temporary buffer
+ * and reduces the origin into it.  When the origin datatype is derived, that
+ * reduction used to walk the origin through an iovec list, which only works
+ * if every element happens to start on an iovec segment boundary.  The three
+ * pair datatype shapes below all have to work:
+ *
+ *   - trailing padding, no internal hole (MPI_DOUBLE_INT, MPI_LONG_INT,
+ *     MPI_LONG_DOUBLE_INT): one segment per element, with gaps in between
+ *   - internal hole, no trailing padding (MPI_SHORT_INT): consecutive
+ *     elements are adjacent in memory, so segments merge across element
+ *     boundaries
+ *   - neither (MPI_FLOAT_INT, MPI_2INT): one single contiguous segment
+ *
+ * Each shape is exercised with a contiguous derived origin and with a strided
+ * (MPI_Type_vector) origin, for several counts, and through the blocking,
+ * request based and fetching entry points.  Every byte of the origin that the
+ * datatype does not select is poisoned, and the poison value wins MAXLOC, so
+ * any stray read shows up in the result.
+ *
+ * Run with at least two ranks.  With no arguments every case runs; the
+ * optional arguments "type count stride" restrict the run to one case, which
+ * is useful when a failing case takes the whole job down with it.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define POISON_BYTE 0xAA
+#define POISON_VAL  9000 /* beats every legal contribution under MAXLOC */
+#define POISON_LOC  424242
+#define WIN_INIT_VAL (-9000)
+#define WIN_INIT_LOC (-1)
+#define UNTOUCHED_VAL (-7000)
+#define UNTOUCHED_LOC (-77)
+
+#define MAX_COUNT 8
+#define STRIDE 2
+
+/* The C structs matching the MPI pair datatypes. */
+typedef struct { short v; int loc; } short_int_t;
+typedef struct { int v; int loc; } two_int_t;
+typedef struct { long v; int loc; } long_int_t;
+typedef struct { float v; int loc; } float_int_t;
+typedef struct { double v; int loc; } double_int_t;
+typedef struct { long double v; int loc; } long_double_int_t;
+
+#define DEFINE_PAIR_ACCESSORS(tag, type)                      \
+    static void tag##_set(void *p, long v, int loc) {         \
+        type *e = (type *) p;                                 \
+        e->v = v;                                             \
+        e->loc = loc;                                         \
+    }                                                         \
+    static void tag##_get(const void *p, long *v, int *loc) { \
+        const type *e = (const type *) p;                     \
+        *v = (long) e->v;                                     \
+        *loc = e->loc;                                        \
+    }
+
+DEFINE_PAIR_ACCESSORS(short_int, short_int_t)
+DEFINE_PAIR_ACCESSORS(two_int, two_int_t)
+DEFINE_PAIR_ACCESSORS(long_int, long_int_t)
+DEFINE_PAIR_ACCESSORS(float_int, float_int_t)
+DEFINE_PAIR_ACCESSORS(double_int, double_int_t)
+DEFINE_PAIR_ACCESSORS(long_double_int, long_double_int_t)
+
+typedef struct {
+    const char *name;
+    MPI_Datatype dt;
+    void (*set)(void *p, long v, int loc);
+    void (*get)(const void *p, long *v, int *loc);
+} pair_type_t;
+
+static pair_type_t types[6];
+
+static void init_types(void)
+{
+    pair_type_t t[] = {
+        {"MPI_SHORT_INT", MPI_SHORT_INT, short_int_set, short_int_get},
+        {"MPI_2INT", MPI_2INT, two_int_set, two_int_get},
+        {"MPI_LONG_INT", MPI_LONG_INT, long_int_set, long_int_get},
+        {"MPI_FLOAT_INT", MPI_FLOAT_INT, float_int_set, float_int_get},
+        {"MPI_DOUBLE_INT", MPI_DOUBLE_INT, double_int_set, double_int_get},
+        {"MPI_LONG_DOUBLE_INT", MPI_LONG_DOUBLE_INT, long_double_int_set,
+         long_double_int_get},
+    };
+
+    memcpy(types, t, sizeof(t));
+}
+
+/*
+ * The value rank r contributes for element k.  Distinct per rank and per
+ * element, and small enough to be exact in a short and in a float.
+ */
+static long contrib_val(int k, int rank)
+{
+    return 1000 + 10 * k + rank;
+}
+
+static int check_elem(const pair_type_t *type, const char *what, int count,
+                      const char *mode, int k, const void *got, long exp_v,
+                      int exp_loc)
+{
+    long got_v;
+    int got_loc;
+
+    type->get(got, &got_v, &got_loc);
+    if (got_v == exp_v && got_loc == exp_loc) {
+        return 0;
+    }
+
+    fprintf(stderr,
+            "FAIL %s %s count=%d origin=%s element %d: got (v=%ld,loc=%d), "
+            "expected (v=%ld,loc=%d)%s\n",
+            type->name, what, count, mode, k, got_v, got_loc, exp_v, exp_loc,
+            got_v == POISON_VAL ? " [read a poisoned datatype gap]" : "");
+    return 1;
+}
+
+static void win_init(const pair_type_t *type, char *winbuf, int count,
+                     MPI_Aint extent)
+{
+    int k;
+
+    for (k = 0; k < count; k++) {
+        type->set(winbuf + (size_t) k * extent, WIN_INIT_VAL, WIN_INIT_LOC);
+    }
+}
+
+/*
+ * One (type, count, origin shape) case.  "sf" is the origin's element stride
+ * factor: 1 builds a contiguous derived type, anything larger builds a
+ * strided vector with sf - 1 poisoned elements between the real ones.
+ */
+static int run_case(const pair_type_t *type, int count, int sf, MPI_Win win,
+                    char *winbuf, int rank, int size)
+{
+    const char *mode = (sf == 1) ? "contig" : "vector";
+    MPI_Aint lb, extent;
+    MPI_Datatype origin_dt;
+    MPI_Request req;
+    char *origin, *result;
+    int errs = 0;
+    int k;
+
+    MPI_Type_get_extent(type->dt, &lb, &extent);
+
+    /* Poison every byte, then write the real elements. */
+    origin = malloc((size_t) count * sf * extent);
+    result = malloc((size_t) count * extent);
+    memset(origin, POISON_BYTE, (size_t) count * sf * extent);
+    memset(result, POISON_BYTE, (size_t) count * extent);
+    for (k = 0; k < count * sf; k++) {
+        type->set(origin + (size_t) k * extent, POISON_VAL, POISON_LOC);
+    }
+    for (k = 0; k < count; k++) {
+        type->set(origin + (size_t) k * sf * extent, contrib_val(k, rank), rank);
+    }
+    for (k = 0; k < count; k++) {
+        type->set(result + (size_t) k * extent, UNTOUCHED_VAL, UNTOUCHED_LOC);
+    }
+
+    MPI_Type_vector(count, 1, sf, type->dt, &origin_dt);
+    MPI_Type_commit(&origin_dt);
+
+    /* --- MPI_Accumulate: every rank contributes, rank size-1 wins. --- */
+    if (rank == 0) {
+        win_init(type, winbuf, count, extent);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+    MPI_Accumulate(origin, 1, origin_dt, 0, 0, count, type->dt, MPI_MAXLOC, win);
+    MPI_Win_unlock(0, win);
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0) {
+        for (k = 0; k < count; k++) {
+            errs += check_elem(type, "MPI_Accumulate", count, mode, k,
+                               winbuf + (size_t) k * extent,
+                               contrib_val(k, size - 1), size - 1);
+        }
+        win_init(type, winbuf, count, extent);
+    }
+
+    /* --- MPI_Raccumulate: same, through the request based path. --- */
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+    MPI_Raccumulate(origin, 1, origin_dt, 0, 0, count, type->dt, MPI_MAXLOC, win,
+                    &req);
+    MPI_Wait(&req, MPI_STATUS_IGNORE);
+    MPI_Win_unlock(0, win);
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0) {
+        for (k = 0; k < count; k++) {
+            errs += check_elem(type, "MPI_Raccumulate", count, mode, k,
+                               winbuf + (size_t) k * extent,
+                               contrib_val(k, size - 1), size - 1);
+        }
+        win_init(type, winbuf, count, extent);
+    }
+
+    /*
+     * --- MPI_Get_accumulate: only the last rank contributes, so both the
+     * window and the fetched data are deterministic. ---
+     */
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == size - 1) {
+        MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+        MPI_Get_accumulate(origin, 1, origin_dt, result, count, type->dt, 0, 0,
+                           count, type->dt, MPI_MAXLOC, win);
+        MPI_Win_unlock(0, win);
+        for (k = 0; k < count; k++) {
+            errs += check_elem(type, "MPI_Get_accumulate result", count, mode, k,
+                               result + (size_t) k * extent, WIN_INIT_VAL,
+                               WIN_INIT_LOC);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0) {
+        for (k = 0; k < count; k++) {
+            errs += check_elem(type, "MPI_Get_accumulate target", count, mode, k,
+                               winbuf + (size_t) k * extent,
+                               contrib_val(k, size - 1), size - 1);
+        }
+    }
+
+    MPI_Type_free(&origin_dt);
+    free(origin);
+    free(result);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    return errs;
+}
+
+int main(int argc, char **argv)
+{
+    static const int counts[] = {1, 3, MAX_COUNT};
+    const char *only_type = NULL;
+    int only_count = 0, only_sf = 0;
+    int rank, size, errs = 0, total = 0;
+    MPI_Aint max_extent = 0, lb, extent;
+    MPI_Win win;
+    char *winbuf;
+    size_t ti, ci;
+    int sf;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (argc > 1) {
+        only_type = argv[1];
+    }
+    if (argc > 2) {
+        only_count = atoi(argv[2]);
+    }
+    if (argc > 3) {
+        only_sf = atoi(argv[3]);
+    }
+
+    if (size < 2) {
+        if (rank == 0) {
+            fprintf(stderr, "this test needs at least 2 ranks\n");
+        }
+        MPI_Finalize();
+        return 1;
+    }
+
+    init_types();
+    for (ti = 0; ti < sizeof(types) / sizeof(types[0]); ti++) {
+        MPI_Type_get_extent(types[ti].dt, &lb, &extent);
+        if (extent > max_extent) {
+            max_extent = extent;
+        }
+    }
+
+    MPI_Win_allocate(rank == 0 ? MAX_COUNT * max_extent : 0, 1, MPI_INFO_NULL,
+                     MPI_COMM_WORLD, &winbuf, &win);
+
+    for (ti = 0; ti < sizeof(types) / sizeof(types[0]); ti++) {
+        if (only_type != NULL && strcmp(only_type, types[ti].name) != 0) {
+            continue;
+        }
+        for (ci = 0; ci < sizeof(counts) / sizeof(counts[0]); ci++) {
+            if (only_count != 0 && only_count != counts[ci]) {
+                continue;
+            }
+            for (sf = 1; sf <= STRIDE; sf++) {
+                if (only_sf != 0 && only_sf != sf) {
+                    continue;
+                }
+                errs += run_case(&types[ti], counts[ci], sf, win, winbuf, rank,
+                                 size);
+            }
+        }
+    }
+
+    MPI_Allreduce(&errs, &total, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (rank == 0) {
+        if (total == 0) {
+            printf("PASS: derived origin MAXLOC accumulate\n");
+        } else {
+            printf("FAIL: derived origin MAXLOC accumulate, %d errors\n", total);
+        }
+    }
+
+    MPI_Win_free(&win);
+    MPI_Finalize();
+    return total ? 1 : 0;
+}


### PR DESCRIPTION
The three MINLOC/MAXLOC reduce loops in `osc_ucx_comm.c` walked the origin
buffer through the iovec list built by `create_iov_list()`, stepping an absolute
pointer by the staging buffer's element stride and handing raw segment addresses
to `ompi_op_reduce()`. That is only valid when every element is contiguous **and**
starts on a segment boundary — which is not true in general, because
`opal_convertor_raw()` produces a *packed byte stream* whose segment boundaries
need not be element boundaries.

Two distinct failure shapes follow:

- **Trailing padding, no internal hole** (`MPI_DOUBLE_INT`, `MPI_LONG_INT`,
  `MPI_LONG_DOUBLE_INT`): a strided origin gives one segment per element with a
  gap between them. The walk stepped into the gap instead of moving to the next
  element, reducing gap contents into the target, and on the last element it
  indexed past the end of the list.
- **Internal hole, no trailing padding** (`MPI_SHORT_INT`): the last member of
  one element and the first member of the next are adjacent, so the convertor
  *merges* them into a single segment starting in the middle of an element. No
  pointer walk over such a list can recover the element boundaries.

### The fix

Stop walking the iovec list for this reduction. Copy the origin into a temporary
array of the staging datatype with `ompi_datatype_sndrcv()` — which lays every
element out correctly whatever the origin's shape, alignment or hole layout — and
reduce from that array one element at a time. The iovec list is now built only by
the traversal that still uses it, so the MINLOC/MAXLOC path no longer allocates
one at all.

Applied at all three sites: `accumulate_req`, `get_accumulate_req`, and
`ompi_osc_ucx_req_completion`.

> [!NOTE]
> An earlier revision of this PR tried to repair the pointer walk in place. It
> fixed the padded-type case but **regressed `MPI_SHORT_INT`**, which works on
> `main` — the merged-segment shape above is not repairable that way. That
> approach was abandoned in favour of the copy-based one.

### Testing

`test/simple/osc_ucx_noncontig_maxloc.c` is table-driven: 6 pair types
(`MPI_SHORT_INT`, `MPI_2INT`, `MPI_LONG_INT`, `MPI_FLOAT_INT`, `MPI_DOUBLE_INT`,
`MPI_LONG_DOUBLE_INT`) x counts {1, 3, 8} x origin {contiguous derived,
`MPI_Type_vector` stride 2} x {`MPI_Accumulate`, `MPI_Raccumulate`,
`MPI_Get_accumulate`} = **36 cases**. The whole origin is memset to `0xAA` so
internal holes and trailing padding are poisoned, gap elements carry a
MAXLOC-winning poison value, and every element's **value and loc** field is
checked for exact equality.

A/B across four builds — `BASE` = pinned `main`, `SX` = +#14260, `THIS` = this PR
alone, `BOTH` = both:

| case | BASE | SX | THIS | BOTH |
|---|---|---|---|---|
| `MPI_SHORT_INT` contig + vector (1/3/8) | pass | pass | **pass** | **pass** |
| `MPI_2INT`, `MPI_FLOAT_INT` (all) | pass | pass | pass | pass |
| `MPI_DOUBLE_INT` **vector** 3/8 | crash | **fail (wrong values)** | crash | **pass** |
| `MPI_LONG_INT` vector 3/8 | crash | fail | crash | **pass** |
| `MPI_LONG_DOUBLE_INT` vector 3/8 | crash (SIGSEGV) | fail | crash | **pass** |
| count = 1 (all types, both modes) | pass | pass | pass | pass |
| **not-PASS / 36** | 12 | 6 | **12** | **0** |

`THIS`'s not-PASS set is **identical to `BASE`'s** — nothing that passed
regressed. The residual crashes in that column are the separate staging-buffer
overflow fixed by #14260, which this PR does not claim to fix.

Also verified: `--enable-debug` with assertions on, 36/36 pass at np=2 and np=3,
no assertion fires; compiler warnings identical to baseline (2 pre-existing, from
UCX headers); test file compiles `-Wall -Wextra` warning-free;
`mpirun -np 2 ./ring_c` clean.

**Sensitivity check** — rebuilding the *old, regressing* revision plus #14260 and
running this test reproduces the regression exactly (4 `MPI_SHORT_INT` cases
fail, e.g. `element 1: got (v=1,loc=-1431698445), expected (v=1011,loc=1)`), so
the test genuinely catches what it exists to prevent.

> [!IMPORTANT]
> **This PR's test needs #14260 to run its padded-type cases.** `MPI_DOUBLE_INT`
> and friends trip the staging-buffer overflow fixed there, so those cases crash
> on this branch alone exactly as they do on `main`. Applied together, all 36
> pass. The two fixes are independent in the C code and can land in either order.

Tested at np=2/3/4 over UCX shm/tcp/self only — no RDMA hardware was available,
so multi-node and real RDMA transports are unverified. The test's struct layout
assumptions mirror how Open MPI defines these datatypes but were only exercised
on one architecture.

### Related PRs

- #14260 — OSC/UCX: Fix accumulate staging buffer overflow for padded types
- #14261 — OSC/UCX: Honor origin datatype true_lb in accumulate reduce fast-path
- #14263 — OSC/UCX: Defer nonblocking-accumulate finalize to top-level progress

Whichever lands later needs a `test/simple/Makefile` `PROGS` rebase. Note that
#14263 relocates the `ACC_*` switch block this PR patches into a new function; if
it is rebased after this merges, the conflict resolution must preserve this fix
rather than reinstating the moved-but-stale copy.
