### PR TITLE
OSC/UCX: Defer nonblocking-accumulate finalize to top-level progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,9 @@ test/simple/mpi_no_op
 test/simple/mpi_spin
 test/simple/multi_abort
 test/simple/ompio_file_info
+test/simple/osc_ucx_nb_accumulate
+test/simple/osc_ucx_nb_accumulate_mt
+test/simple/osc_ucx_nb_accumulate_noflush
 test/simple/parallel_r8
 test/simple/parallel_r64
 test/simple/parallel_w8

--- a/ompi/mca/osc/ucx/osc_ucx.h
+++ b/ompi/mca/osc/ucx/osc_ucx.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
  * Copyright (c) 2025      Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,9 +47,17 @@ typedef struct ompi_osc_ucx_component {
     unsigned int priority;
     /* directory where to place backing files */
     char *backing_directory;
+    opal_list_t pending_acc_ops;
+    int drain_depth; /* current nesting level of the pending-acc drain */
+    opal_mutex_t pending_acc_lock;
 } ompi_osc_ucx_component_t;
 
 OMPI_DECLSPEC extern ompi_osc_ucx_component_t mca_osc_ucx_component;
+
+/* Maximum nesting of ompi_osc_ucx_drain_pending_acc().  Nested drains are
+ * needed so that a blocking wait entered from a drain can still complete other
+ * parked requests, but the depth is capped to keep the recursion bounded. */
+#define OSC_UCX_MAX_DRAIN_DEPTH 8
 
 #define OSC_UCX_INCREMENT_OUTSTANDING_NB_OPS(_module)                               \
     do {                                                                            \

--- a/ompi/mca/osc/ucx/osc_ucx_comm.c
+++ b/ompi/mca/osc/ucx/osc_ucx_comm.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2019-2022 High Performance Computing Center Stuttgart,
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,6 +12,8 @@
  */
 
 #include "ompi_config.h"
+
+#include <stddef.h>
 
 #include "ompi/mca/osc/osc.h"
 #include "ompi/mca/osc/base/base.h"
@@ -638,6 +641,13 @@ static inline int ompi_osc_ucx_acc_lock(ompi_osc_ucx_module_t *module, int targe
             }
 
             opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);
+            /* The accumulate lock held by a nonblocking accumulate is released
+             * by ompi_osc_ucx_nonblocking_ops_finalize(), which only runs from
+             * ompi_osc_ucx_process_acc_completion() on the drain path.  It is
+             * not reachable from ucp_worker_progress(), so progressing the
+             * worker alone would spin here forever.  Drain the parked requests
+             * as well so the holder of the lock can actually release it. */
+            ompi_osc_ucx_drain_pending_acc();
         }
 
         *lock_acquired = true;
@@ -1718,188 +1728,252 @@ static inline int ompi_osc_ucx_nonblocking_ops_finalize(ompi_osc_ucx_module_t *m
     return ret;
 }
 
-void ompi_osc_ucx_req_completion(void *request) {
-    ompi_osc_ucx_generic_request_t *ucx_req = (ompi_osc_ucx_generic_request_t *)request;
+static void ompi_osc_ucx_process_acc_completion(ompi_osc_ucx_accumulate_request_t *req) {
     int ret = OMPI_SUCCESS;
-    ompi_osc_ucx_module_t *module = ucx_req->super.module;
-    if (ucx_req->super.request_type == ACCUMULATE_REQ) {
-        /* This is an accumulate request */
-        ompi_osc_ucx_accumulate_request_t *req = (ompi_osc_ucx_accumulate_request_t *)request;
-        assert(req->phase != ACC_INIT);
-        void *free_addr = NULL;
-        bool release_lock = false;
-        ptrdiff_t temp_extent, temp_lb;
-        const void *origin_addr = req->origin_addr;
-        int origin_count = req->origin_count;
-        struct ompi_datatype_t *origin_dt = req->origin_dt;
-        void *temp_addr = req->stage_addr;
-        int temp_count = req->stage_count;
-        struct ompi_datatype_t *temp_dt = req->stage_dt;
-        int target = req->target;
-        int target_count = req->target_count;
-        int target_disp = req->target_disp;
-        struct ompi_datatype_t *target_dt = req->target_dt;
-        struct ompi_win_t *win = req->win;
-        struct ompi_op_t *op = req->op;
+    ompi_osc_ucx_module_t *module = req->super.module;
+    assert(req->phase != ACC_INIT);
+    void *free_addr = NULL;
+    bool release_lock = false;
+    ptrdiff_t temp_extent, temp_lb;
+    const void *origin_addr = req->origin_addr;
+    int origin_count = req->origin_count;
+    struct ompi_datatype_t *origin_dt = req->origin_dt;
+    void *temp_addr = req->stage_addr;
+    int temp_count = req->stage_count;
+    struct ompi_datatype_t *temp_dt = req->stage_dt;
+    int target = req->target;
+    int target_count = req->target_count;
+    int target_disp = req->target_disp;
+    struct ompi_datatype_t *target_dt = req->target_dt;
+    struct ompi_win_t *win = req->win;
+    struct ompi_op_t *op = req->op;
 
-        if (req->phase != ACC_FINALIZE) {
-            /* Avoid calling flush while we are already in progress */
-            module->mem->skip_periodic_flush = true;
-            module->state_mem->skip_periodic_flush = true;
+    if (req->phase != ACC_FINALIZE) {
+        /* Avoid calling flush while we are already in progress */
+        module->mem->skip_periodic_flush = true;
+        module->state_mem->skip_periodic_flush = true;
+    }
+
+    switch (req->phase) {
+        case ACC_FINALIZE:
+        {
+            if (req->free_ptr != NULL) {
+                free(req->free_ptr);
+                req->free_ptr = NULL;
+            }
+            if (origin_dt != NULL && !ompi_datatype_is_predefined(origin_dt)) {
+                OBJ_RELEASE(origin_dt);
+            }
+            if (target_dt != NULL && !ompi_datatype_is_predefined(target_dt)) {
+                OBJ_RELEASE(target_dt);
+            }
+            if (temp_dt != NULL && !ompi_datatype_is_predefined(temp_dt)) {
+                OBJ_RELEASE(temp_dt);
+            }
+            break;
         }
-
-        switch (req->phase) {
-            case ACC_FINALIZE:
-            {
-                if (req->free_ptr != NULL) {
-                    free(req->free_ptr);
-                    req->free_ptr = NULL;
-                }
-                if (origin_dt != NULL && !ompi_datatype_is_predefined(origin_dt)) {
-                    OBJ_RELEASE(origin_dt);
-                }
-                if (target_dt != NULL && !ompi_datatype_is_predefined(target_dt)) {
-                    OBJ_RELEASE(target_dt);
-                }
-                if (temp_dt != NULL && !ompi_datatype_is_predefined(temp_dt)) {
-                    OBJ_RELEASE(temp_dt);
-                }
-                break;
-            }
-            case ACC_GET_RESULTS_DATA:
-            {
-                /* This is a get-accumulate operation */
-                if (op == &ompi_mpi_op_no_op.op) {
-                    /* Done with reading the target data, so release the
-                     * acc lock and return */
-                    release_lock = true;
-                } else if (op == &ompi_mpi_op_replace.op) {
-                    assert(target_dt != NULL && origin_dt != NULL);
-                    /* Now that we have the results data, replace the target
-                     * buffer with origin buffer and then release the lock  */
-                    ret = ompi_osc_ucx_acc_rputget(NULL, 0, NULL, target, target_disp,
-                            target_count, target_dt, op, win, 0, origin_addr, origin_count,
-                            origin_dt, true, -1, NONE);
-                    if (ret != OMPI_SUCCESS) {
-                        OSC_UCX_ERROR("ompi_osc_ucx_acc_rputget failed ret= %d\n", ret);
-                        free(temp_addr);
-                        abort();
-                    }
-                    release_lock = true;
-                }
-                break;
-            }
-
-            case ACC_PUT_TARGET_DATA:
-            {
-                /* This is an accumulate (not get-accumulate) operation */
-                assert(op == &ompi_mpi_op_replace.op);
+        case ACC_GET_RESULTS_DATA:
+        {
+            /* This is a get-accumulate operation */
+            if (op == &ompi_mpi_op_no_op.op) {
+                /* Done with reading the target data, so release the
+                 * acc lock and return */
                 release_lock = true;
-                break;
-            }
-
-            case ACC_GET_STAGE_DATA:
-            {
-                assert(op != &ompi_mpi_op_replace.op && op != &ompi_mpi_op_no_op.op);
-                assert(origin_dt != NULL && temp_dt != NULL);
-
-                bool is_origin_contig =
-                    ompi_datatype_is_contiguous_memory_layout(origin_dt, origin_count);
-            
-                if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
-                    ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
-                } else {
-                    ucx_iovec_t *origin_ucx_iov = NULL;
-                    uint32_t origin_ucx_iov_count = 0;
-                    uint32_t origin_ucx_iov_idx = 0;
-
-                    ret = create_iov_list(origin_addr, origin_count, origin_dt,
-                                          &origin_ucx_iov, &origin_ucx_iov_count);
-                    if (ret != OMPI_SUCCESS) {
-                        OSC_UCX_ERROR("create_iov_list failed ret= %d\n", ret);
-                        free(temp_addr);
-                        abort();
-                    }
-
-                    if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
-                        ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
-                        size_t temp_size;
-                        char *curr_temp_addr = (char *)temp_addr;
-                        ompi_datatype_type_size(temp_dt, &temp_size);
-                        while (origin_ucx_iov_idx < origin_ucx_iov_count) {
-                            int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
-                            ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
-                                           curr_temp_addr, curr_count, temp_dt);
-                            curr_temp_addr += curr_count * temp_size;
-                            origin_ucx_iov_idx++;
-                        }
-                    } else {
-                        int i;
-                        void *curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                        ompi_datatype_get_true_extent(temp_dt, &temp_lb, &temp_extent);
-                        for (i = 0; i < (int)temp_count; i++) {
-                            ompi_op_reduce(op, curr_origin_addr,
-                                           (void *)((char *)temp_addr + i * temp_extent),
-                                           1, temp_dt);
-                            curr_origin_addr = (void *)((char *)curr_origin_addr + temp_extent);
-                            origin_ucx_iov_idx++;
-                            if (curr_origin_addr >= (void *)((char
-                                            *)origin_ucx_iov[origin_ucx_iov_idx].addr
-                                        +
-                                        origin_ucx_iov[origin_ucx_iov_idx].len))
-                            {
-                                origin_ucx_iov_idx++;
-                                curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
-                            }
-                        }
-                    }
-
-                    free(origin_ucx_iov);
-                }
-            
-                if (req->acc_type == GET_ACCUMULATE) {
-                    /* Do fence to make sure target results are received before
-                     * writing into target */
-                    ret = opal_common_ucx_wpmem_fence(module->mem);
-                    if (ret != OMPI_SUCCESS) {
-                        OSC_UCX_ERROR("opal_common_ucx_mem_fence failed: %d", ret);
-                        abort();
-                    }
-                }
-
+            } else if (op == &ompi_mpi_op_replace.op) {
+                assert(target_dt != NULL && origin_dt != NULL);
+                /* Now that we have the results data, replace the target
+                 * buffer with origin buffer and then release the lock  */
                 ret = ompi_osc_ucx_acc_rputget(NULL, 0, NULL, target, target_disp,
-                        target_count, target_dt, op, win, 0, temp_addr, temp_count,
-                        temp_dt, true, -1, NONE);
+                        target_count, target_dt, op, win, 0, origin_addr, origin_count,
+                        origin_dt, true, -1, NONE);
                 if (ret != OMPI_SUCCESS) {
                     OSC_UCX_ERROR("ompi_osc_ucx_acc_rputget failed ret= %d\n", ret);
                     free(temp_addr);
                     abort();
                 }
                 release_lock = true;
-                free_addr = temp_addr;
-                break;
+            }
+            break;
+        }
+
+        case ACC_PUT_TARGET_DATA:
+        {
+            /* This is an accumulate (not get-accumulate) operation */
+            assert(op == &ompi_mpi_op_replace.op);
+            release_lock = true;
+            break;
+        }
+
+        case ACC_GET_STAGE_DATA:
+        {
+            assert(op != &ompi_mpi_op_replace.op && op != &ompi_mpi_op_no_op.op);
+            assert(origin_dt != NULL && temp_dt != NULL);
+
+            bool is_origin_contig =
+                ompi_datatype_is_contiguous_memory_layout(origin_dt, origin_count);
+
+            if (ompi_datatype_is_predefined(origin_dt) || is_origin_contig) {
+                ompi_op_reduce(op, (void *)origin_addr, temp_addr, (int)temp_count, temp_dt);
+            } else {
+                ucx_iovec_t *origin_ucx_iov = NULL;
+                uint32_t origin_ucx_iov_count = 0;
+                uint32_t origin_ucx_iov_idx = 0;
+
+                ret = create_iov_list(origin_addr, origin_count, origin_dt,
+                                      &origin_ucx_iov, &origin_ucx_iov_count);
+                if (ret != OMPI_SUCCESS) {
+                    OSC_UCX_ERROR("create_iov_list failed ret= %d\n", ret);
+                    free(temp_addr);
+                    abort();
+                }
+
+                if ((op != &ompi_mpi_op_maxloc.op && op != &ompi_mpi_op_minloc.op) ||
+                    ompi_datatype_is_contiguous_memory_layout(temp_dt, temp_count)) {
+                    size_t temp_size;
+                    char *curr_temp_addr = (char *)temp_addr;
+                    ompi_datatype_type_size(temp_dt, &temp_size);
+                    while (origin_ucx_iov_idx < origin_ucx_iov_count) {
+                        int curr_count = origin_ucx_iov[origin_ucx_iov_idx].len / temp_size;
+                        ompi_op_reduce(op, origin_ucx_iov[origin_ucx_iov_idx].addr,
+                                       curr_temp_addr, curr_count, temp_dt);
+                        curr_temp_addr += curr_count * temp_size;
+                        origin_ucx_iov_idx++;
+                    }
+                } else {
+                    int i;
+                    void *curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
+                    ompi_datatype_get_true_extent(temp_dt, &temp_lb, &temp_extent);
+                    for (i = 0; i < (int)temp_count; i++) {
+                        ompi_op_reduce(op, curr_origin_addr,
+                                       (void *)((char *)temp_addr + i * temp_extent),
+                                       1, temp_dt);
+                        curr_origin_addr = (void *)((char *)curr_origin_addr + temp_extent);
+                        origin_ucx_iov_idx++;
+                        if (curr_origin_addr >= (void *)((char
+                                        *)origin_ucx_iov[origin_ucx_iov_idx].addr
+                                    +
+                                    origin_ucx_iov[origin_ucx_iov_idx].len))
+                        {
+                            origin_ucx_iov_idx++;
+                            curr_origin_addr = origin_ucx_iov[origin_ucx_iov_idx].addr;
+                        }
+                    }
+                }
+
+                free(origin_ucx_iov);
             }
 
-            default:
-            {
-                OSC_UCX_ERROR("accumulate progress failed\n");
+            if (req->acc_type == GET_ACCUMULATE) {
+                /* Do fence to make sure target results are received before
+                 * writing into target */
+                ret = opal_common_ucx_wpmem_fence(module->mem);
+                if (ret != OMPI_SUCCESS) {
+                    OSC_UCX_ERROR("opal_common_ucx_mem_fence failed: %d", ret);
+                    abort();
+                }
+            }
+
+            ret = ompi_osc_ucx_acc_rputget(NULL, 0, NULL, target, target_disp,
+                    target_count, target_dt, op, win, 0, temp_addr, temp_count,
+                    temp_dt, true, -1, NONE);
+            if (ret != OMPI_SUCCESS) {
+                OSC_UCX_ERROR("ompi_osc_ucx_acc_rputget failed ret= %d\n", ret);
+                free(temp_addr);
                 abort();
             }
+            release_lock = true;
+            free_addr = temp_addr;
+            break;
         }
 
-        if (release_lock) {
-            /* Ordering between previous put/get operations and unlock will be realized
-             * through the ucp fence inside the finalize function */
-            ompi_osc_ucx_nonblocking_ops_finalize(module, target,
-                    req->lock_acquired, win, free_addr);
+        default:
+        {
+            OSC_UCX_ERROR("accumulate progress failed\n");
+            abort();
         }
+    }
 
-        if (req->phase != ACC_FINALIZE) {
-            module->mem->skip_periodic_flush = false;
-            module->state_mem->skip_periodic_flush = false;
-        }
+    if (release_lock) {
+        /* Ordering between previous put/get operations and unlock will be realized
+         * through the ucp fence inside the finalize function */
+        ompi_osc_ucx_nonblocking_ops_finalize(module, target,
+                req->lock_acquired, win, free_addr);
+    }
+
+    if (req->phase != ACC_FINALIZE) {
+        module->mem->skip_periodic_flush = false;
+        module->state_mem->skip_periodic_flush = false;
     }
     assert(module->ctx->num_incomplete_req_ops > 0);
     OSC_UCX_DECREMENT_OUTSTANDING_NB_OPS(module);
+    ompi_request_complete(&(req->super.super), true);
+    assert(module->ctx->num_incomplete_req_ops >= 0);
+}
+
+void ompi_osc_ucx_req_completion(void *request) {
+    ompi_osc_ucx_generic_request_t *ucx_req = (ompi_osc_ucx_generic_request_t *)request;
+    ompi_osc_ucx_module_t *module = ucx_req->super.module;
+
+    if (ucx_req->super.request_type == ACCUMULATE_REQ) {
+        ompi_osc_ucx_accumulate_request_t *req =
+            (ompi_osc_ucx_accumulate_request_t *)request;
+        assert(req->phase != ACC_INIT);
+        if (req->phase != ACC_FINALIZE) {
+            opal_mutex_lock(&mca_osc_ucx_component.pending_acc_lock);
+            opal_list_append(&mca_osc_ucx_component.pending_acc_ops,
+                             &req->pending_item);
+            opal_mutex_unlock(&mca_osc_ucx_component.pending_acc_lock);
+            return;
+        }
+        ompi_osc_ucx_process_acc_completion(req);
+        return;
+    }
+
+    assert(module->ctx->num_incomplete_req_ops > 0);
+    OSC_UCX_DECREMENT_OUTSTANDING_NB_OPS(module);
     ompi_request_complete(&(ucx_req->super.super), true);
+}
+
+int ompi_osc_ucx_drain_pending_acc(void) {
+    opal_list_item_t *item;
+    int completed = 0;
+
+    /* ompi_osc_ucx_process_acc_completion() can issue new operations that
+     * block waiting for an accumulate lock, and those wait loops drain again,
+     * so this function is re-entrant.  A nested call must be allowed to
+     * complete requests that the outer call has not popped yet, otherwise the
+     * nested waiter can never make progress.  Bound the nesting instead of
+     * refusing it outright so the recursion cannot run away. */
+    opal_mutex_lock(&mca_osc_ucx_component.pending_acc_lock);
+    if (OSC_UCX_MAX_DRAIN_DEPTH <= mca_osc_ucx_component.drain_depth) {
+        opal_mutex_unlock(&mca_osc_ucx_component.pending_acc_lock);
+        return 0;
+    }
+    mca_osc_ucx_component.drain_depth++;
+
+    /* Pop one request at a time and process it with the lock dropped.  Holding
+     * pending_acc_lock across ompi_osc_ucx_process_acc_completion() would nest
+     * it inside the winfo mutex taken by the fence, and would hide the rest of
+     * the list from a nested drain. */
+    for (;;) {
+        ompi_osc_ucx_accumulate_request_t *req;
+
+        item = opal_list_remove_first(&mca_osc_ucx_component.pending_acc_ops);
+        if (NULL == item) {
+            break;
+        }
+        opal_mutex_unlock(&mca_osc_ucx_component.pending_acc_lock);
+
+        req = (ompi_osc_ucx_accumulate_request_t *)((char *)item -
+                offsetof(ompi_osc_ucx_accumulate_request_t, pending_item));
+        ompi_osc_ucx_process_acc_completion(req);
+        completed++;
+
+        opal_mutex_lock(&mca_osc_ucx_component.pending_acc_lock);
+    }
+
+    mca_osc_ucx_component.drain_depth--;
+    opal_mutex_unlock(&mca_osc_ucx_component.pending_acc_lock);
+
+    return completed;
 }

--- a/ompi/mca/osc/ucx/osc_ucx_component.c
+++ b/ompi/mca/osc/ucx/osc_ucx_component.c
@@ -6,6 +6,7 @@
  *
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * Copyright (c) 2025      Stony Brook University.  All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,6 +46,11 @@ static void _osc_ucx_init_unlock(void)
 }
 
 static bool enable_nonblocking_accumulate = false;
+
+static inline bool osc_ucx_use_nb_accumulate(void)
+{
+    return enable_nonblocking_accumulate && !opal_using_threads();
+}
 
 static int component_open(void);
 static int component_close(void);
@@ -201,8 +207,14 @@ static int component_register(void) {
                                            description_str, MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_GROUP, &mca_osc_ucx_component.acc_single_intrinsic);
 
-    opal_asprintf(&description_str, "Enable nonblocking MPI_Accumulate and MPI_Get_accumulate  (default: %s)",
-                                           enable_nonblocking_accumulate  ? "true" : "false");
+    opal_asprintf(&description_str, "Enable nonblocking MPI_Accumulate and MPI_Get_accumulate. "
+                                    "EXPERIMENTAL: safe only for a single thread that flushes "
+                                    "after each accumulate. Piling up multiple accumulates before "
+                                    "a flush, or tearing a window down (MPI_Win_free) with "
+                                    "un-flushed accumulates outstanding, can deadlock. It is "
+                                    "automatically disabled (falls back to blocking accumulate) "
+                                    "under MPI_THREAD_MULTIPLE  (default: %s)",
+                                    enable_nonblocking_accumulate  ? "true" : "false");
     (void) mca_base_component_var_register(&mca_osc_ucx_component.super.osc_version, "enable_nonblocking_accumulate",
                                            description_str, MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0, OPAL_INFO_LVL_5,
                                            MCA_BASE_VAR_SCOPE_GROUP, &enable_nonblocking_accumulate);
@@ -244,6 +256,10 @@ static int progress_callback(void) {
         opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);
     }
     return 0;
+}
+
+static int drain_acc_callback(void) {
+    return ompi_osc_ucx_drain_pending_acc();
 }
 
 static int ucp_context_init(bool enable_mt, int proc_world_size) {
@@ -367,6 +383,17 @@ static int component_finalize(void) {
     }
     opal_common_ucx_mca_deregister();
     if (mca_osc_ucx_component.env_initialized) {
+        /* Windows drain their parked accumulate requests in
+         * ompi_osc_ucx_free(), while the module they reference is still
+         * valid, so nothing should be left here.  Do not assert on it:
+         * an empty list is not something the user can be trusted to
+         * guarantee, and aborting is worse than reporting. */
+        if (!opal_list_is_empty(&mca_osc_ucx_component.pending_acc_ops)) {
+            OSC_UCX_VERBOSE(1, "%d accumulate request(s) still pending at finalize",
+                            (int) opal_list_get_size(&mca_osc_ucx_component.pending_acc_ops));
+        }
+        OBJ_DESTRUCT(&mca_osc_ucx_component.pending_acc_ops);
+        OBJ_DESTRUCT(&mca_osc_ucx_component.pending_acc_lock);
         opal_common_ucx_wpool_finalize(mca_osc_ucx_component.wpool);
         OBJ_DESTRUCT(&mca_osc_ucx_component.accumulate_requests);
         OBJ_DESTRUCT(&mca_osc_ucx_component.requests);
@@ -442,6 +469,12 @@ static void ompi_osc_ucx_unregister_progress()
         ret = opal_progress_unregister(progress_callback);
         if (OMPI_SUCCESS != ret) {
             OSC_UCX_VERBOSE(1, "opal_progress_unregister failed: %d", ret);
+        }
+        if (osc_ucx_use_nb_accumulate()) {
+            ret = opal_progress_unregister(drain_acc_callback);
+            if (OMPI_SUCCESS != ret) {
+                OSC_UCX_VERBOSE(1, "opal_progress_unregister failed: %d", ret);
+            }
         }
     }
 
@@ -619,6 +652,9 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, pt
             mca_osc_ucx_component.comm_world_size = ompi_proc_world_size();
             mca_osc_ucx_component.endpoints = calloc(mca_osc_ucx_component.comm_world_size, sizeof(ucp_ep_h));
         }
+        OBJ_CONSTRUCT(&mca_osc_ucx_component.pending_acc_ops, opal_list_t);
+        OBJ_CONSTRUCT(&mca_osc_ucx_component.pending_acc_lock, opal_mutex_t);
+        mca_osc_ucx_component.drain_depth = 0;
         /* Make sure that all memory updates performed above are globally
          * observable before (mca_osc_ucx_component.env_initialized = true)
          */
@@ -634,9 +670,19 @@ static int component_select(struct ompi_win_t *win, void **base, size_t size, pt
      */
     OSC_UCX_ASSERT(mca_osc_ucx_component.num_modules > 0);
     if (1 == mca_osc_ucx_component.num_modules) {
+        if (osc_ucx_use_nb_accumulate()) {
+            ret = opal_progress_register(drain_acc_callback);
+            if (OMPI_SUCCESS != ret) {
+                OSC_UCX_VERBOSE(1, "opal_progress_register failed: %d", ret);
+                goto select_unlock;
+            }
+        }
         ret = opal_progress_register(progress_callback);
         if (OMPI_SUCCESS != ret) {
             OSC_UCX_VERBOSE(1, "opal_progress_register failed: %d", ret);
+            if (osc_ucx_use_nb_accumulate()) {
+                opal_progress_unregister(drain_acc_callback);
+            }
             goto select_unlock;
         }
     }
@@ -658,7 +704,7 @@ select_unlock:
     memcpy(module, &ompi_osc_ucx_module_template, sizeof(ompi_osc_base_module_t));
 
     /* TODO Provide support for nonblocking operations with dynamic windows */
-    if (enable_nonblocking_accumulate && flavor != MPI_WIN_FLAVOR_DYNAMIC) {
+    if (osc_ucx_use_nb_accumulate() && flavor != MPI_WIN_FLAVOR_DYNAMIC) {
         module->super.osc_accumulate = ompi_osc_ucx_accumulate_nb;
         module->super.osc_get_accumulate = ompi_osc_ucx_get_accumulate_nb;
     }
@@ -1008,6 +1054,8 @@ error_nomem:
     if (env_initialized == true) {
         opal_common_ucx_wpool_finalize(mca_osc_ucx_component.wpool);
         OBJ_DESTRUCT(&mca_osc_ucx_component.requests);
+        OBJ_DESTRUCT(&mca_osc_ucx_component.pending_acc_ops);
+        OBJ_DESTRUCT(&mca_osc_ucx_component.pending_acc_lock);
         mca_osc_ucx_component.env_initialized = false;
     }
 
@@ -1211,10 +1259,17 @@ int ompi_osc_ucx_free(struct ompi_win_t *win) {
     }
     OBJ_DESTRUCT(&module->pending_posts);
 
-    ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
-    if (OPAL_SUCCESS != ret) {
-        return ret;
-    }
+    /* Complete any accumulate requests that the completion callback parked:
+     * they reference this module, and once the window is gone there is
+     * nothing left that can complete them.  Processing a request can issue
+     * the next phase of the same accumulate, so alternate flushing and
+     * draining until a drain finds nothing left to do. */
+    do {
+        ret = opal_common_ucx_ctx_flush(module->ctx, OPAL_COMMON_UCX_SCOPE_WORKER, 0);
+        if (OPAL_SUCCESS != ret) {
+            return ret;
+        }
+    } while (ompi_osc_ucx_drain_pending_acc() > 0);
 
     ret = module->comm->c_coll->coll_barrier(module->comm,
                                              module->comm->c_coll->coll_barrier_module);

--- a/ompi/mca/osc/ucx/osc_ucx_request.c
+++ b/ompi/mca/osc/ucx/osc_ucx_request.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +46,21 @@ static void request_construct(ompi_osc_ucx_generic_request_t *request)
     request->super.super.req_cancel = request_cancel;
 }
 
+static void acc_request_construct(ompi_osc_ucx_accumulate_request_t *request)
+{
+    /* Layout-compatible: both request types start with the same
+     * ompi_osc_ucx_request_t super member, which is all request_construct
+     * touches. */
+    request_construct((ompi_osc_ucx_generic_request_t *) request);
+    OBJ_CONSTRUCT(&request->pending_item, opal_list_item_t);
+}
+
+static void acc_request_destruct(ompi_osc_ucx_accumulate_request_t *request)
+{
+    OBJ_DESTRUCT(&request->pending_item);
+}
+
 OBJ_CLASS_INSTANCE(ompi_osc_ucx_generic_request_t, ompi_request_t,
                    request_construct, NULL);
 OBJ_CLASS_INSTANCE(ompi_osc_ucx_accumulate_request_t, ompi_request_t,
-                   request_construct, NULL);
+                   acc_request_construct, acc_request_destruct);

--- a/ompi/mca/osc/ucx/osc_ucx_request.h
+++ b/ompi/mca/osc/ucx/osc_ucx_request.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (C) Mellanox Technologies Ltd. 2001-2017. ALL RIGHTS RESERVED.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +16,7 @@
 #define OMPI_OSC_UCX_REQUEST_H
 
 #include "ompi/request/request.h"
+#include "opal/class/opal_list.h"
 
 
 enum req_type {
@@ -50,6 +52,7 @@ typedef struct ompi_osc_ucx_generic_request {
 
 typedef struct ompi_osc_ucx_accumulate_request {
     ompi_osc_ucx_request_t super;
+    opal_list_item_t pending_item;
     struct ompi_op_t *op;
     int phase;
     int acc_type;
@@ -102,6 +105,11 @@ OBJ_CLASS_DECLARATION(ompi_osc_ucx_accumulate_request_t);
                 if (module->ctx->num_incomplete_req_ops > 0) {                          \
                     opal_common_ucx_wpool_progress(mca_osc_ucx_component.wpool);        \
                 }                                                                       \
+                /* Complete parked accumulate requests before re-checking the           \
+                 * free list.  Drain directly instead of going through                  \
+                 * opal_progress(), which has no recursion guard and may                \
+                 * already be on the stack when this macro runs. */                     \
+                ompi_osc_ucx_drain_pending_acc();                                       \
             }                                                                           \
         } while (item == NULL);                                                         \
         req = (ompi_osc_ucx_accumulate_request_t*) item;                                \
@@ -143,5 +151,9 @@ OBJ_CLASS_DECLARATION(ompi_osc_ucx_accumulate_request_t);
     } while (0)
 
 void ompi_osc_ucx_req_completion(void *request);
+
+/* Complete any accumulate requests parked by the completion callback.
+ * Returns the number of requests completed. */
+int ompi_osc_ucx_drain_pending_acc(void);
 
 #endif /* OMPI_OSC_UCX_REQUEST_H */

--- a/test/simple/Makefile
+++ b/test/simple/Makefile
@@ -6,11 +6,16 @@ PROGS = mpi_no_op mpi_barrier hello hello_nodename abort multi_abort comm_abort 
 		debugger singleton_client_server intercomm_create spawn_tree init-exit77 mpi_info \
 		info_spawn server client ring binding badcoll attach xlib ompio_file_info \
 		no-disconnect nonzero interlib pinterlib add_host \
-		buffer_attach_detach_f08
+		buffer_attach_detach_f08 \
+		osc_ucx_nb_accumulate osc_ucx_nb_accumulate_mt \
+		osc_ucx_nb_accumulate_noflush
 
 all: $(PROGS)
 
 # These guys need additional -I flags
+
+osc_ucx_nb_accumulate_mt: osc_ucx_nb_accumulate_mt.c
+	$(CC) $(CFLAGS) $^ -o $@ -pthread
 
 hello_output: hello_output.c
 	$(CC) $(CFLAGS) $(CFLAGS_INTERNAL) $^ -o $@

--- a/test/simple/osc_ucx_nb_accumulate.c
+++ b/test/simple/osc_ucx_nb_accumulate.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define MAXN 4096
+#define ITERS 32
+
+int main(int argc, char **argv)
+{
+    int rank, size, i, it, errs = 0;
+    MPI_Win win;
+    double *winbuf, *origin, *result;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Win_allocate(MAXN * sizeof(double), sizeof(double), MPI_INFO_NULL,
+                     MPI_COMM_WORLD, &winbuf, &win);
+    for (i = 0; i < MAXN; i++) {
+        winbuf[i] = 0.0;
+    }
+    origin = malloc(MAXN * sizeof(double));
+    result = malloc(MAXN * sizeof(double));
+    for (i = 0; i < MAXN; i++) {
+        origin[i] = 1.0;
+    }
+
+    /* Flush after each op so the completion callback runs the fenced finalize. */
+    for (it = 0; it < ITERS; it++) {
+        int n = 1 << (it % 13); /* 1 .. 4096 */
+        if (n > MAXN) {
+            n = MAXN;
+        }
+        MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+        MPI_Accumulate(origin, n, MPI_DOUBLE, 0, 0, n, MPI_DOUBLE, MPI_SUM, win);
+        MPI_Win_flush(0, win);
+        MPI_Win_unlock(0, win);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (it = 0; it < ITERS; it++) {
+        MPI_Win_lock(MPI_LOCK_SHARED, 0, 0, win);
+        MPI_Get_accumulate(origin, 1, MPI_DOUBLE, result, 1, MPI_DOUBLE, 0, 0, 1,
+                           MPI_DOUBLE, MPI_SUM, win);
+        MPI_Win_flush(0, win);
+        MPI_Win_unlock(0, win);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        double expect = (double)size * (ITERS + ITERS);
+        if (winbuf[0] != expect) {
+            fprintf(stderr, "MISMATCH at 0: got %g expected %g\n", winbuf[0],
+                    expect);
+            errs++;
+        }
+        if (errs == 0) {
+            printf("PASS: nonblocking accumulate + get-accumulate completed "
+                   "without re-entry\n");
+        }
+    }
+
+    free(origin);
+    free(result);
+    MPI_Win_free(&win);
+    MPI_Finalize();
+    return errs ? 1 : 0;
+}

--- a/test/simple/osc_ucx_nb_accumulate_mt.c
+++ b/test/simple/osc_ucx_nb_accumulate_mt.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <mpi.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NTHREADS 2
+#define LOOPS    200
+
+static MPI_Win        g_win;
+static int            g_rank;
+
+/* Portable start gate (pthread_barrier_t is not available on macOS). */
+static pthread_mutex_t g_gate_mtx  = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_gate_cond = PTHREAD_COND_INITIALIZER;
+static int             g_gate_count;
+
+static void start_gate(void)
+{
+    pthread_mutex_lock(&g_gate_mtx);
+    if (++g_gate_count == NTHREADS) {
+        pthread_cond_broadcast(&g_gate_cond);
+    } else {
+        while (g_gate_count < NTHREADS) {
+            pthread_cond_wait(&g_gate_cond, &g_gate_mtx);
+        }
+    }
+    pthread_mutex_unlock(&g_gate_mtx);
+}
+
+typedef struct {
+    int tid;
+} thread_arg_t;
+
+static void *worker(void *arg)
+{
+    thread_arg_t *ta = (thread_arg_t *)arg;
+    int slot         = g_rank * NTHREADS + ta->tid;
+    double one       = 1.0;
+    int it;
+
+    start_gate();
+
+    for (it = 0; it < LOOPS; it++) {
+        MPI_Accumulate(&one, 1, MPI_DOUBLE, 0, slot, 1, MPI_DOUBLE, MPI_SUM,
+                       g_win);
+        MPI_Win_flush(0, g_win);
+    }
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    int provided, size, i, errs = 0;
+    double *winbuf;
+    pthread_t threads[NTHREADS];
+    thread_arg_t args[NTHREADS];
+
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    if (provided != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "SKIP: MPI_THREAD_MULTIPLE not provided\n");
+        MPI_Finalize();
+        return 77;
+    }
+    MPI_Comm_rank(MPI_COMM_WORLD, &g_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Win_allocate(size * NTHREADS * sizeof(double), sizeof(double),
+                     MPI_INFO_NULL, MPI_COMM_WORLD, &winbuf, &g_win);
+    for (i = 0; i < size * NTHREADS; i++) {
+        winbuf[i] = 0.0;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    MPI_Win_lock_all(0, g_win);
+    for (i = 0; i < NTHREADS; i++) {
+        args[i].tid = i;
+        pthread_create(&threads[i], NULL, worker, &args[i]);
+    }
+    for (i = 0; i < NTHREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    MPI_Win_unlock_all(g_win);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (g_rank == 0) {
+        for (i = 0; i < size * NTHREADS; i++) {
+            if (winbuf[i] != (double)LOOPS) {
+                fprintf(stderr, "MISMATCH at slot %d: got %g expected %d\n", i,
+                        winbuf[i], LOOPS);
+                errs++;
+            }
+        }
+        if (errs == 0) {
+            printf("PASS: THREAD_MULTIPLE concurrent accumulate (feature gated "
+                   "to blocking)\n");
+        }
+    }
+
+    MPI_Win_free(&g_win);
+    MPI_Finalize();
+    return errs ? 1 : 0;
+}

--- a/test/simple/osc_ucx_nb_accumulate_noflush.c
+++ b/test/simple/osc_ucx_nb_accumulate_noflush.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NELEM 64
+#define BURST 16
+
+int main(int argc, char **argv)
+{
+    int rank, size, i, it, errs = 0;
+    MPI_Win win;
+    double *winbuf, *origin;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Win_allocate(NELEM * sizeof(double), sizeof(double), MPI_INFO_NULL,
+                     MPI_COMM_WORLD, &winbuf, &win);
+    for (i = 0; i < NELEM; i++) {
+        winbuf[i] = 0.0;
+    }
+    origin = malloc(NELEM * sizeof(double));
+    for (i = 0; i < NELEM; i++) {
+        origin[i] = 1.0;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Phase 1: shared lock, burst of accumulates with NO flush in between.
+     * Every accumulate after the first has to acquire the remote accumulate
+     * lock that only the deferred finalize of the previous one releases. */
+    MPI_Win_lock_all(0, win);
+    for (it = 0; it < BURST; it++) {
+        MPI_Accumulate(origin, NELEM, MPI_DOUBLE, 0, 0, NELEM, MPI_DOUBLE,
+                       MPI_SUM, win);
+    }
+    MPI_Win_unlock_all(win);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        double expect = (double)size * BURST;
+        for (i = 0; i < NELEM; i++) {
+            if (winbuf[i] != expect) {
+                fprintf(stderr, "MISMATCH at %d: got %g expected %g\n", i,
+                        winbuf[i], expect);
+                errs++;
+            }
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* Phase 2: exclusive lock, same un-flushed burst.  With an exclusive lock
+     * the accumulate lock is skipped, so this exercises the second blocking
+     * site: the overlap bookkeeping loop in check_ops_and_flush(). */
+    for (i = 0; i < size; i++) {
+        MPI_Win_lock(MPI_LOCK_EXCLUSIVE, i, 0, win);
+        for (it = 0; it < BURST; it++) {
+            MPI_Accumulate(origin, NELEM, MPI_DOUBLE, i, 0, NELEM, MPI_DOUBLE,
+                           MPI_SUM, win);
+        }
+        MPI_Win_unlock(i, win);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    {
+        /* Phase 1 only targeted rank 0, phase 2 targeted every rank. */
+        double expect = (rank == 0) ? (double)size * BURST * 2.0
+                                    : (double)size * BURST;
+        for (i = 0; i < NELEM; i++) {
+            if (winbuf[i] != expect) {
+                fprintf(stderr, "MISMATCH at %d after exclusive phase: got %g "
+                        "expected %g\n", i, winbuf[i], expect);
+                errs++;
+            }
+        }
+    }
+
+    if (rank == 0 && errs == 0) {
+        printf("PASS: un-flushed nonblocking accumulate bursts completed "
+               "without deadlock\n");
+    }
+
+    free(origin);
+    MPI_Win_free(&win);
+    MPI_Finalize();
+    return errs ? 1 : 0;
+}


### PR DESCRIPTION
With `osc_ucx_enable_nonblocking_accumulate=1`, accumulate finalize issues
`ucp_worker_fence()` and then calls `ucp_worker_progress()` from inside a UCX
send completion callback, re-entering `ucp_worker_progress`. Some UCX builds
assert on this (`ucp_worker.c: Assertion 'worker->inprogress++ == 0' failed`);
others silently hang.

### The fix

Finalize work moves out of the completion callback:

- It is extracted into `ompi_osc_ucx_process_acc_completion()`. The completion
  callback parks requests with `phase != ACC_FINALIZE` on
  `mca_osc_ucx_component.pending_acc_ops` under `pending_acc_lock` instead of
  running the fence inline. `ACC_FINALIZE` requests (no fence) still run inline.
- A `drain_acc_callback` registered ahead of `progress_callback` drains the list
  at top-level progress, outside the UCX callback stack, returning the number of
  requests completed so OPAL's progress accounting stays accurate.
- The lock is released before each `process_acc_completion()` call, so the fence
  never nests `pending_acc_lock` inside the winfo mutex taken during the fence.
- The freelist-wait macro drains the list directly rather than calling
  `opal_progress()`, which has no recursion guard and may already be on the stack.
- `ompi_osc_ucx_free()` alternates flushing and draining before window teardown,
  so no request is left parked holding a reference to a freed module. The drain
  has to happen here: `ompi_osc_ucx_unregister_progress()` runs *after*
  `free(module)`, and a parked request dereferences `req->super.module`.

Nonblocking accumulate is gated on `!opal_using_threads()`, since
`MPI_THREAD_MULTIPLE` raises separate re-entrancy concerns this does not address.

### Keeping the accumulate lock live

Deferring the finalize also moves the **accumulate-lock release** off the
`ucp_worker_progress()` path, and that needs handling explicitly.

`ompi_osc_ucx_acc_lock()` spins on the remote `state.acc_lock`. That lock is
released by the `UCP_ATOMIC_FETCH_OP_SWAP` issued from
`ompi_osc_ucx_nonblocking_ops_finalize()`, which runs only from
`process_acc_completion()`, which for a parked request runs only from the drain.
The wait loop drove `opal_common_ucx_wpool_progress()` only, so progressing the
worker could never release the lock — a burst of accumulates with no intervening
flush would hang on the second one. (A flush after every accumulate masks this
completely, which is why it is easy to miss.) The wait loop now drives the drain
as well.

Because that wait loop can itself be entered *from* a drain, the drain has to be
re-entrant. The boolean `draining_acc` guard — which made a nested call return 0
without completing anything — is replaced by a bounded `drain_depth` counter. A
nested drain can now complete requests the outer drain has not popped yet. That
also unblocks the `opal_common_ucx_ctx_flush()` loop on `num_incomplete_req_ops`
reached from `ompi_osc_ucx_check_ops_and_flush()` for exclusive-lock windows.
Requests are popped one at a time, so `pending_acc_lock` is never held across
`process_acc_completion()` and the lock ordering is preserved.

Also restores the `assert(num_incomplete_req_ops > 0)` on the non-accumulate path
of `ompi_osc_ucx_req_completion()`, which the refactor had moved into the
accumulate-only helper.

### Testing

Three tests: `osc_ucx_nb_accumulate.c` (flush after each op),
`osc_ucx_nb_accumulate_mt.c` (`THREAD_MULTIPLE` fallback), and
`osc_ucx_nb_accumulate_noflush.c` (bursts of accumulates with **no** intervening
flush — the pattern that deadlocks without the acc-lock fix).

Verified A/B against this PR's merge base. On unpatched `main`:

- `osc_ucx_nb_accumulate` aborts on the UCX re-entrancy assertion —
  `ucp_worker.c:3193 Assertion 'worker->inprogress++ == 0' failed`, inside
  `ucp_worker_fence` called from `ompi_osc_ucx_req_completion`.
- `osc_ucx_nb_accumulate_mt` hangs intermittently — 1 pass / 7 hangs of 8 runs.

The no-flush test was also run against an intermediate build carrying the
deferral but *not* the acc-lock fix, to confirm it actually catches that
deadlock: 3/3 hangs, with the expected backtrace —

```
#2 opal_common_ucx_wpool_progress ()
#3 ompi_osc_ucx_acc_lock.constprop ()
#4 ompi_osc_ucx_get_accumulate_nonblocking ()
#6 PMPI_Accumulate ()
```

and gdb showing `pending_acc_ops` holding one request nobody could drain.

With the full patch: no-flush test 17/17 clean across optimized and
`--enable-debug` builds; `osc_ucx_nb_accumulate` and `..._mt` 17/17 each; window
teardown with un-flushed accumulates outstanding and `MPI_Finalize` with a live
never-freed window 6/6 each. No assertion fires in the debug build. Zero new
compiler warnings in either build vs. a pinned-`main` baseline of zero.
`mpirun --np 2 ./ring_c` and a full `make` in `examples/` are clean.

### Limitations, stated plainly

- The feature remains off by default and documented as experimental.
- The no-flush test's exclusive-lock phase is **coverage, not a demonstrated
  reproducer**: it exercises the second blocking site
  (`check_ops_and_flush()`'s `while (!op_added)` loop, same root cause) but does
  not independently hang at this scale (2 ranks, default
  `outstanding_ops_flush_threshold`). The demonstrated hang is the shared-lock
  phase.
- The UCX in the test environment is not built for multithreading, so the
  `THREAD_MULTIPLE` test verifies the gate falls back to blocking accumulate
  rather than exercising concurrent nonblocking accumulate. The baseline hang it
  exposes is real, though intermittent.
- Tested at np=2 over UCX shm/tcp/self only; no RDMA hardware was available, so
  multi-node and real RDMA transports are unverified.

### Related PRs

Part of a set of independent `ompi/mca/osc/ucx` accumulate fixes:

- #14260 — OSC/UCX: Fix accumulate staging buffer overflow for padded types
- #14261 — OSC/UCX: Honor origin datatype true_lb in accumulate reduce fast-path
- #14262 — OSC/UCX: Fix non-contiguous origin iovec traversal in MINLOC/MAXLOC accumulate (draft, being reworked)

**Interaction worth flagging.** This PR relocates the entire `ACC_*` switch
block out of `ompi_osc_ucx_req_completion()` into a new function, and that block
is exactly the region the PRs above patch. The move is faithful — it carries the
block's contents verbatim, including the still-unfixed `get_true_extent` and
unconditional `origin_ucx_iov_idx++` as they exist on `main` today. So if this PR
is rebased after any of those merge, the conflict resolution must preserve their
fixes rather than reinstating the moved-but-stale copy. Landing this one last, or
resolving carefully, avoids silently reverting them.
