### PR TITLE
OSHMEM/SCOLL/UCC: Advertise ep_map field for team caching

### DIFF
--- a/oshmem/mca/scoll/ucc/scoll_ucc_module.c
+++ b/oshmem/mca/scoll/ucc/scoll_ucc_module.c
@@ -362,8 +362,9 @@ int mca_scoll_ucc_team_create(mca_scoll_ucc_module_t *ucc_module,
             sizeof(osh_group->proc_vpids[0]);
     map.array.map                 = (void *)osh_group->proc_vpids;
     ucc_team_params_t team_params = {
-        .mask = UCC_TEAM_PARAM_FIELD_EP | UCC_TEAM_PARAM_FIELD_EP_RANGE |
-                UCC_TEAM_PARAM_FIELD_OOB | UCC_TEAM_PARAM_FIELD_FLAGS,
+        .mask = UCC_TEAM_PARAM_FIELD_EP_MAP | UCC_TEAM_PARAM_FIELD_EP |
+                UCC_TEAM_PARAM_FIELD_EP_RANGE | UCC_TEAM_PARAM_FIELD_OOB |
+                UCC_TEAM_PARAM_FIELD_FLAGS,
         .oob =
             {
                 .allgather = oob_allgather,


### PR DESCRIPTION
UCC team caching matches teams by their endpoint map. The OSHMEM SCOLL/UCC
module was not setting `UCC_TEAM_PARAM_FIELD_EP_MAP` in `ucc_team_params.mask`,
so UCC never received the ep_map for OSHMEM teams and could not cache or reuse
them.

Add the field to the mask so UCC can populate and match the endpoint map on
each team creation, enabling team reuse across collective calls.

### Testing

`oshmem/mca/scoll/ucc` is off by default (`scoll_ucc_enable` defaults to 0), so
this path is only reached when it is explicitly enabled. Verified with
`--mca scoll ucc,basic,mpi --mca scoll_ucc_enable 1 --mca scoll_ucc_priority 100`
that the team-create path still executes and builds a team
(`UCC_LOG_LEVEL=info` shows the COLL_SCORE_MAP for the new team), and that
`hello_oshmem`, `oshmem_max_reduction` and `oshmem_circular_shift` all produce
correct results, identical to an unpatched build.

No test is added: the change only makes teams *eligible* for UCC's team cache,
which is not observable through the OpenSHMEM API.
