### PR TITLE
fbtl/posix: stop losing nonblocking I/O when the aio queue is full

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,28 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- Nonblocking file I/O no longer loses data when the operating system's
+  asynchronous I/O queue fills, which on macOS it readily does: the
+  ``posix`` ``fbtl`` component sized its batch of concurrent ``aio_write``
+  calls from ``sysconf(_SC_AIO_MAX)``, which there reports the
+  machine-wide ``kern.aiomax`` (90 by default) rather than the
+  ``kern.aioprocmax`` a single process is held to (16).  The component
+  now bounds the batch by the per-process limit, defers requests the
+  queue will not accept instead of discarding them, and reaps the
+  operations it has posted before releasing their control blocks -- an
+  unreaped operation used to cost the process a queue slot permanently,
+  so one refusal disabled nonblocking file I/O for the rest of its life.
+  The new ``fbtl_posix_max_aio_reqs`` MCA parameter overrides the limit.
+  A nonblocking operation the ``fbtl`` cannot post is now reported as
+  ``MPI_ERR_IO``; previously ``MPI_File_iwrite_all`` and ``MPI_Wait``
+  both returned ``MPI_SUCCESS`` for a write that never reached the file.
+
+- Reporting an error for a failed nonblocking file operation no longer
+  crashes the process.  ``MPI_Wait`` and ``MPI_Test`` reach a file's
+  error handler through the request, and a nonblocking file request did
+  not record which file it came from, so invoking the error handler
+  dereferenced a null pointer.
+
 - ``MPI_Info_set`` now accepts a zero-length (empty) value string.  It
   previously raised ``MPI_ERR_INFO_VALUE`` for an empty value, but
   MPI-5.0 chapter 10 only limits the *maximum* length of an info

--- a/ompi/errhandler/errhandler_invoke.c
+++ b/ompi/errhandler/errhandler_invoke.c
@@ -276,12 +276,23 @@ int ompi_errhandler_request_invoke(int count,
                                       mpi_object.comm->errhandler_type,
                                       ec, message);
         break;
-    case OMPI_REQUEST_IO:
-        return ompi_errhandler_invoke(mpi_object.file->error_handler,
-                                      mpi_object.file,
-                                      mpi_object.file->errhandler_type,
+    case OMPI_REQUEST_IO: {
+        /* An IO request whose file handle could not be determined when it was
+         * created -- an ompio_file_t that no MPI_File_open owns, as the
+         * sharedfp components allocate for their own bookkeeping -- still has
+         * to reach an error handler rather than a NULL dereference.  Falling
+         * back to MPI_FILE_NULL's handler mirrors what
+         * ompi_grequest_construct does with MPI_COMM_WORLD for a generalized
+         * request.
+         */
+        struct ompi_file_t *file = (NULL != mpi_object.file) ? mpi_object.file
+                                                            : &ompi_mpi_file_null.file;
+        return ompi_errhandler_invoke(file->error_handler,
+                                      file,
+                                      file->errhandler_type,
                                       ec, message);
         break;
+    }
     case OMPI_REQUEST_WIN:
         return ompi_errhandler_invoke(mpi_object.win->error_handler,
                                       mpi_object.win,

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -420,6 +420,10 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
     }
 
     mca_common_ompio_request_alloc (&ompio_req, MCA_OMPIO_REQUEST_READ);
+    /* See mca_common_ompio_file_iwrite: the error handler for a failed request
+     * is reached through req_mpi_object.
+     */
+    ompio_req->req_ompi.req_mpi_object.file = fh->f_fh;
 
     if (0 == count || 0 == fh->f_fview.f_iov_count) {
         ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;

--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -509,7 +509,16 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
                                              &tbr, &spc,
                                              &fh->f_io_array, &fh->f_num_of_io_entries);
 
-            fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
+            if (OMPI_SUCCESS != fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req)) {
+                /* See the same place in common_ompio_file_write.c: without this
+                 * the failure is indistinguishable from a completed request and
+                 * MPI_Wait reports MPI_SUCCESS for a read that never happened.
+                 */
+                ret = MPI_ERR_IO;
+                ompio_req->req_ompi.req_status.MPI_ERROR = MPI_ERR_IO;
+                ompio_req->req_ompi.req_status._ucount = 0;
+                ompi_request_complete (&ompio_req->req_ompi, false);
+            }
         }
     }
     else {

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -364,6 +364,11 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
     }
 
     mca_common_ompio_request_alloc (&ompio_req, MCA_OMPIO_REQUEST_WRITE);
+    /* The error handler that MPI_Wait and friends invoke for a failed request
+     * is reached through req_mpi_object, so an IO request needs the file it
+     * came from.
+     */
+    ompio_req->req_ompi.req_mpi_object.file = fh->f_fh;
 
     if (0 == count || 0 == fh->f_fview.f_iov_count) {
         ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_SUCCESS;

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -453,7 +453,20 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
 					     &i, &total_bytes_written, &spc,
 					     &fh->f_io_array, &fh->f_num_of_io_entries);
 
-            fh->f_fbtl->fbtl_ipwritev (fh, (ompi_request_t *) ompio_req);
+            if (OMPI_SUCCESS != fh->f_fbtl->fbtl_ipwritev (fh, (ompi_request_t *) ompio_req)) {
+                /* The fbtl could not post the operation. Without this the
+                 * request carries no progress function, which the progress loop
+                 * cannot tell from a parent request with no subrequests left, so
+                 * it completes it with an untouched status: MPI_Wait then reports
+                 * MPI_SUCCESS for a write that never happened. The initiating
+                 * call reports it too, the way the fallback path below does for
+                 * an fbtl without nonblocking support.
+                 */
+                ret = MPI_ERR_IO;
+                ompio_req->req_ompi.req_status.MPI_ERROR = MPI_ERR_IO;
+                ompio_req->req_ompi.req_status._ucount = 0;
+                ompi_request_complete (&ompio_req->req_ompi, false);
+            }
         }
     } else {
         // This fbtl does not support non-blocking write operations

--- a/ompi/mca/fbtl/posix/fbtl_posix.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix.c
@@ -30,8 +30,16 @@
 #include "ompi_config.h"
 #include "mpi.h"
 
+#include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/uio.h>
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#if defined(__APPLE__) && defined(HAVE_SYS_SYSCTL_H)
+#include <sys/sysctl.h>
+#endif
 #if HAVE_AIO_H
 #include <aio.h>
 #endif
@@ -104,13 +112,129 @@ int mca_fbtl_posix_component_file_unquery (ompio_file_t *file) {
 int mca_fbtl_posix_module_init (ompio_file_t *file) {
 
 #if defined (FBTL_POSIX_HAVE_AIO)
-    long val = sysconf(_SC_AIO_MAX);
-    if ( -1 != val ) {
-        ompi_fbtl_posix_max_prd_active_reqs = (int)val;
+    /* An explicit fbtl_posix_max_aio_reqs wins; otherwise ask the system.
+     * The number wanted is what *one process* may have outstanding, and
+     * sysconf(_SC_AIO_MAX) is not always that: on Darwin it reports
+     * kern.aiomax, the limit across all processes on the machine (90 by
+     * default), where a single process is held to kern.aioprocmax (16). Sizing
+     * a batch of concurrent aio_write() calls from the former overruns the
+     * latter by 5x on a stock machine, so read the per-process sysctl there.
+     */
+    if ( 0 >= mca_fbtl_posix_max_aio_reqs ) {
+        long val = -1;
+#if defined(__APPLE__) && defined(HAVE_SYS_SYSCTL_H)
+        int procmax = 0;
+        size_t procmax_len = sizeof(procmax);
+        if ( 0 == sysctlbyname("kern.aioprocmax", &procmax, &procmax_len, NULL, 0) &&
+             0 < procmax ) {
+            val = (long)procmax;
+        }
+#endif
+        if ( 0 >= val ) {
+            val = sysconf(_SC_AIO_MAX);
+        }
+        if ( 0 < val ) {
+            ompi_fbtl_posix_max_prd_active_reqs = (int)val;
+        }
+    }
+    else {
+        ompi_fbtl_posix_max_prd_active_reqs = mca_fbtl_posix_max_aio_reqs;
     }
 #endif
     return OMPI_SUCCESS;
 }
+
+#if defined (FBTL_POSIX_HAVE_AIO)
+/* Hand requests [first, last) to the kernel. *posted comes back as one past the
+ * last request accepted, so that the caller can make it prd_last_active_req; it
+ * is set whether this returns success or not, since the caller has to know what
+ * is in flight either way.
+ *
+ * EAGAIN is not a failure. It means this process already has as many aio
+ * operations outstanding as it is allowed, which is transient -- a slot comes
+ * back when a request is aio_return()ed -- so the requests that did not fit are
+ * simply left for a later call, and *posted says where to resume. Retrying here
+ * cannot work: nothing in this process reaps anything until the request this
+ * batch belongs to is registered with mca_common_ompio_progress, which happens
+ * only once the caller returns.
+ */
+int mca_fbtl_posix_post_reqs ( mca_fbtl_posix_request_data_t *data,
+                               int first, int last, int *posted )
+{
+    int i, ret = OMPI_SUCCESS;
+
+    for ( i = first; i < last; i++ ) {
+        int rc;
+        if ( FBTL_POSIX_AIO_WRITE == data->prd_req_type ) {
+            rc = aio_write ( &data->prd_aio.aio_reqs[i] );
+        }
+        else {
+            rc = aio_read ( &data->prd_aio.aio_reqs[i] );
+        }
+        if ( -1 == rc ) {
+            if ( EAGAIN != errno ) {
+                opal_output(1, "mca_fbtl_posix_post_reqs: error in aio_%s(): errno %d %s",
+                            FBTL_POSIX_AIO_WRITE == data->prd_req_type ? "write" : "read",
+                            errno, strerror(errno));
+                ret = OMPI_ERROR;
+            }
+            break;
+        }
+    }
+
+    *posted = i;
+    return ret;
+}
+
+/* Wait for the requests in [first, last) that are still in flight and reap
+ * them. Every aio operation that has been posted has to be aio_return()ed even
+ * once it has completed, because that is what releases its slot in the queue --
+ * an abandoned request costs the process a slot for the rest of its life. Used
+ * on the error paths, which would otherwise free the aiocbs from under the
+ * kernel as well, or leave the rest of the active window in flight.
+ *
+ * prd_aio.aio_req_status is what says whether an operation is still in flight:
+ * mca_fbtl_posix_progress overwrites the entry with the aio_error() result once
+ * it has reaped that operation, so a window that an earlier progress call
+ * partly reaped must not be handed to aio_error() or aio_return() a second
+ * time.
+ *
+ * The wait is aio_suspend() rather than mca_common_ompio_progress(). This
+ * function is called from mca_fbtl_posix_progress, which ompio progress
+ * reaches through req_progress_fn; ompio progress has no re-entrancy guard,
+ * and OPAL_THREAD_TRYLOCK is a compile-time 0 unless opal_using_threads(), so
+ * calling it here would walk the pending request list again and re-enter
+ * mca_fbtl_posix_progress on the very request being drained. aio_suspend waits
+ * on the one operation and calls back into nothing.
+ */
+void mca_fbtl_posix_drain_reqs ( mca_fbtl_posix_request_data_t *data,
+                                 int first, int last )
+{
+    int i;
+
+    for ( i = first; i < last; i++ ) {
+        const struct aiocb *cb = &data->prd_aio.aio_reqs[i];
+        ssize_t len;
+
+        if ( EINPROGRESS != data->prd_aio.aio_req_status[i] ) {
+            /* Already reaped, by this or by an earlier progress call. */
+            continue;
+        }
+        while ( EINPROGRESS == aio_error ( cb ) ) {
+            /* aio_suspend() may return early, e.g. on a signal; aio_error() is
+             * the condition that decides whether to wait again.
+             */
+            (void) aio_suspend ( &cb, 1, NULL );
+        }
+        data->prd_aio.aio_req_status[i] = aio_error ( cb );
+        len = aio_return ( &data->prd_aio.aio_reqs[i] );
+        if ( 0 < len ) {
+            /* Whatever did land counts towards what the request reports. */
+            data->prd_total_len += len;
+        }
+    }
+}
+#endif
 
 
 int mca_fbtl_posix_module_finalize (ompio_file_t *file) {
@@ -190,8 +314,27 @@ bool mca_fbtl_posix_progress ( mca_ompio_request_t *req)
                 continue;
             }
             else {
-                /* an error occurred. Mark the request done, but
-                   set an error code in the status */
+                /* An error occurred. Reap this operation and the rest of the
+                 * active window before giving up on the request: an operation
+                 * that is never aio_return()ed costs the process a queue slot
+                 * for the rest of its life, and the aiocbs are released when
+                 * the request is freed. Reaping the failed operation is a bare
+                 * aio_return -- aio_error has already said it is no longer in
+                 * flight, and its recorded status is the error code, which is
+                 * how mca_fbtl_posix_drain_reqs knows to leave it alone. That
+                 * call also lets prd_total_len account for whatever landed in
+                 * the rest of the window. Then release the lock the batch was
+                 * posted under, mark the request done, and set an error code
+                 * in the status.
+                 *
+                 * prd_open_reqs is deliberately left alone: this request is
+                 * still counted in it, so the "all pending operations are
+                 * finished" tail below, which would unlock a second time and
+                 * overwrite MPI_ERROR with OMPI_SUCCESS, is correctly skipped.
+                 */
+                (void) aio_return ( &data->prd_aio.aio_reqs[i] );
+                mca_fbtl_posix_drain_reqs ( data, i + 1, data->prd_last_active_req );
+                mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter );
                 req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
                 req->req_ompi.req_status._ucount = data->prd_total_len;
                 ret = true;
@@ -205,22 +348,39 @@ bool mca_fbtl_posix_progress ( mca_ompio_request_t *req)
 #if 0
     printf("lcount=%d open_reqs=%d\n", lcount, data->prd_open_reqs );
 #endif
-    if ( (lcount == data->prd_req_chunks) && (0 != data->prd_open_reqs )) {
+    /* Every request in the active window is accounted for. If any remain
+     * unfinished, the next batch goes out -- which includes the case of an empty
+     * window, left behind when the process's aio queue was full and would take
+     * none of the previous batch. Comparing lcount against the width of the
+     * window rather than against prd_req_chunks is what lets that work: a window
+     * is only as wide as the queue allowed, which need not be a whole chunk.
+     */
+    if ( (lcount == (data->prd_last_active_req - data->prd_first_active_req)) &&
+         (0 != data->prd_open_reqs )) {
+        int want, posted;
+
         /* release the lock of the previous operations */
         mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter );
-        
+
         /* post the next batch of operations */
         data->prd_first_active_req = data->prd_last_active_req;
-        if ( (data->prd_req_count-data->prd_last_active_req) > data->prd_req_chunks ) {
-            data->prd_last_active_req += data->prd_req_chunks;
+        if ( (data->prd_req_count-data->prd_first_active_req) > data->prd_req_chunks ) {
+            want = data->prd_first_active_req + data->prd_req_chunks;
         }
         else {
-            data->prd_last_active_req = data->prd_req_count;
+            want = data->prd_req_count;
+        }
+        if ( want <= data->prd_first_active_req ) {
+            /* Requests are outstanding but none are left to post, which should
+             * not happen. Leave the request alone rather than index outside the
+             * array below.
+             */
+            return ret;
         }
 
         start_offset = data->prd_aio.aio_reqs[data->prd_first_active_req].aio_offset;
-        end_offset   = data->prd_aio.aio_reqs[data->prd_last_active_req-1].aio_offset +
-                       data->prd_aio.aio_reqs[data->prd_last_active_req-1].aio_nbytes;
+        end_offset   = data->prd_aio.aio_reqs[want-1].aio_offset +
+                       data->prd_aio.aio_reqs[want-1].aio_nbytes;
         total_length = (end_offset - start_offset);
 
         if ( FBTL_POSIX_AIO_READ == data->prd_req_type ) {
@@ -238,22 +398,26 @@ bool mca_fbtl_posix_progress ( mca_ompio_request_t *req)
             return false;
         }
         
-        for ( i=data->prd_first_active_req; i< data->prd_last_active_req; i++ ) {
-            if ( FBTL_POSIX_AIO_READ == data->prd_req_type ) {
-                if (-1 == aio_read(&data->prd_aio.aio_reqs[i])) {
-                    opal_output(1, "mca_fbtl_posix_progress: error in aio_read()");
-                    mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter );
-                    return false;
-                }
-            }
-            else if ( FBTL_POSIX_AIO_WRITE == data->prd_req_type ) {
-                if (-1 == aio_write(&data->prd_aio.aio_reqs[i])) {
-                    opal_output(1, "mca_fbtl_posix_progress: error in aio_write()");
-                    mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter );
-                    return false;
-                }
-            }
+        if ( OMPI_SUCCESS != mca_fbtl_posix_post_reqs ( data, data->prd_first_active_req,
+                                                        want, &posted ) ) {
+            /* A real error rather than a full queue. Reap the part of the batch
+             * that did go out, then complete the request with an error instead
+             * of leaving the caller waiting on operations that will never be
+             * posted.
+             */
+            mca_fbtl_posix_drain_reqs ( data, data->prd_first_active_req, posted );
+            mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter );
+            data->prd_last_active_req = data->prd_first_active_req;
+            data->prd_open_reqs = 0;
+            req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
+            req->req_ompi.req_status._ucount = data->prd_total_len;
+            return true;
         }
+        /* posted may fall short of want, the queue being full; the remainder
+         * waits for the next call, which finds a short or empty window and comes
+         * back here.
+         */
+        data->prd_last_active_req = posted;
 #if 0
         printf("posting new batch: first=%d last=%d\n", data->prd_first_active_req, data->prd_last_active_req );
 #endif

--- a/ompi/mca/fbtl/posix/fbtl_posix.h
+++ b/ompi/mca/fbtl/posix/fbtl_posix.h
@@ -35,6 +35,7 @@ extern bool mca_fbtl_posix_write_datasieving;
 extern size_t mca_fbtl_posix_max_block_size;
 extern size_t mca_fbtl_posix_max_gap_size;
 extern size_t mca_fbtl_posix_max_tmpbuf_size;
+extern int mca_fbtl_posix_max_aio_reqs;
 
 BEGIN_C_DECLS
 
@@ -97,6 +98,13 @@ struct mca_fbtl_posix_request_data_t {
 
 };
 typedef struct mca_fbtl_posix_request_data_t mca_fbtl_posix_request_data_t;
+
+#if defined (FBTL_POSIX_HAVE_AIO)
+int mca_fbtl_posix_post_reqs ( mca_fbtl_posix_request_data_t *data,
+                               int first, int last, int *posted );
+void mca_fbtl_posix_drain_reqs ( mca_fbtl_posix_request_data_t *data,
+                                 int first, int last );
+#endif
 
 
 /* define constants for AIO requests */

--- a/ompi/mca/fbtl/posix/fbtl_posix_component.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_component.c
@@ -42,6 +42,7 @@ bool mca_fbtl_posix_write_datasieving = true;
 size_t mca_fbtl_posix_max_block_size  = 1048576;  // 1MB
 size_t mca_fbtl_posix_max_gap_size    = 4096;     // Size of a block in many linux fs
 size_t mca_fbtl_posix_max_tmpbuf_size = 67108864; // 64 MB
+int mca_fbtl_posix_max_aio_reqs       = 0;        // 0: ask the system
 /*
  * Private functions
  */
@@ -130,6 +131,15 @@ static int register_component(void)
                                            MCA_BASE_VAR_SCOPE_READONLY,
                                            &mca_fbtl_posix_write_datasieving );
 
-    
+    mca_fbtl_posix_max_aio_reqs = 0;
+    (void) mca_base_component_var_register(&mca_fbtl_posix_component.fbtlm_version,
+                                           "max_aio_reqs", "Maximum number of asynchronous I/O operations to keep outstanding "
+                                           "per process. Default: 0, meaning ask the operating system what it allows one "
+                                           "process to have outstanding.",
+                                           MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                           OPAL_INFO_LVL_9,
+                                           MCA_BASE_VAR_SCOPE_READONLY,
+                                           &mca_fbtl_posix_max_aio_reqs );
+
     return OMPI_SUCCESS;
 }

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
@@ -34,8 +34,6 @@
 #include "ompi/constants.h"
 #include "ompi/mca/fbtl/fbtl.h"
 
-#define MAX_ATTEMPTS 10
-
 ssize_t mca_fbtl_posix_ipreadv (ompio_file_t *fh,
                                ompi_request_t *request)
 {
@@ -112,24 +110,24 @@ ssize_t mca_fbtl_posix_ipreadv (ompio_file_t *fh,
         return OMPI_ERROR;
     }
 
-    for (i=0; i < data->prd_last_active_req; i++) {
-        int counter=0;
-        while ( MAX_ATTEMPTS > counter ) { 
-            if  ( -1 != aio_read(&data->prd_aio.aio_reqs[i]) ) {
-                break;
-            }
-            counter++;
-            mca_common_ompio_progress();
-        }
-        if ( MAX_ATTEMPTS == counter ) {
-           opal_output(1, "mca_fbtl_posix_ipreadv: error in aio_read(): errno %d %s", errno, strerror(errno));
-           mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
-           free(data->prd_aio.aio_reqs);
-           free(data->prd_aio.aio_req_status);
-           free(data);
-           return OMPI_ERROR;
-        }
+    ret = mca_fbtl_posix_post_reqs ( data, data->prd_first_active_req,
+                                     data->prd_last_active_req, &i );
+    if ( OMPI_SUCCESS != ret ) {
+       opal_output(1, "mca_fbtl_posix_ipreadv: error in aio_read(): errno %d %s", errno, strerror(errno));
+       /* Reap what did get posted; see the same place in
+        * fbtl_posix_ipwritev.c for why this cannot be skipped.
+        */
+       mca_fbtl_posix_drain_reqs ( data, data->prd_first_active_req, i );
+       mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
+       free(data->prd_aio.aio_reqs);
+       free(data->prd_aio.aio_req_status);
+       free(data);
+       return OMPI_ERROR;
     }
+    /* Whatever the queue would not take stays for mca_fbtl_posix_progress; see
+     * fbtl_posix_ipwritev.c.
+     */
+    data->prd_last_active_req = i;
 
     req->req_data = data;
     req->req_progress_fn = mca_fbtl_posix_progress;

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
@@ -33,8 +33,6 @@
 #include "ompi/constants.h"
 #include "ompi/mca/fbtl/fbtl.h"
 
-#define MAX_ATTEMPTS 10
-
 ssize_t  mca_fbtl_posix_ipwritev (ompio_file_t *fh,
                                  ompi_request_t *request)
 {
@@ -110,24 +108,29 @@ ssize_t  mca_fbtl_posix_ipwritev (ompio_file_t *fh,
         return OMPI_ERROR;
     }
 
-    for (i=0; i < data->prd_last_active_req; i++) {
-        int counter=0;
-        while ( MAX_ATTEMPTS > counter ) {
-            if (-1 != aio_write(&data->prd_aio.aio_reqs[i])) {
-                break;
-            }
-            counter++;
-            mca_common_ompio_progress();
-        }
-        if ( MAX_ATTEMPTS == counter ) {
-            opal_output(1, "mca_fbtl_posix_ipwritev: error in aio_write():  %s", strerror(errno));
-            mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
-            free(data->prd_aio.aio_req_status);
-            free(data->prd_aio.aio_reqs);
-            free(data);
-            return OMPI_ERROR;
-        }
+    ret = mca_fbtl_posix_post_reqs ( data, data->prd_first_active_req,
+                                     data->prd_last_active_req, &i );
+    if ( OMPI_SUCCESS != ret ) {
+        opal_output(1, "mca_fbtl_posix_ipwritev: error in aio_write():  %s", strerror(errno));
+        /* Reap what did get posted. Freeing the aiocbs with operations still
+         * outstanding against them would leave the kernel writing into memory
+         * this request no longer owns, and would cost the process a queue slot
+         * per abandoned request for the rest of its life.
+         */
+        mca_fbtl_posix_drain_reqs ( data, data->prd_first_active_req, i );
+        mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
+        free(data->prd_aio.aio_req_status);
+        free(data->prd_aio.aio_reqs);
+        free(data);
+        return OMPI_ERROR;
     }
+    /* The process's aio queue may have been full before the whole batch was
+     * posted. Whatever did not fit stays for mca_fbtl_posix_progress to post
+     * once a slot frees up, so the active window is what was accepted rather
+     * than what was wanted. Nothing is lost and nothing is reported: this is
+     * ordinary back-pressure, not a failure.
+     */
+    data->prd_last_active_req = i;
 
     req->req_data = data;
     req->req_progress_fn = mca_fbtl_posix_progress;


### PR DESCRIPTION
I created this PR with AI. Feel free to ignore. I am opening this PR mostly because I have a presumably-working patch at hand. AI text follows.



Three commits. The first is the fix, the second stops the failure being
invisible, the third is the changelog entry.

Fixes #14278, which has the measurements, the three reproducers and the backtrace.
Short version: on macOS the `posix` fbtl posts 90 concurrent `aio_write`s where
the process is allowed 16, and when the queue refuses one it abandons the
operation, leaks the slots it did get, and reports `MPI_SUCCESS`. So
`MPI_File_iwrite_all` through a fragmented view writes 16 blocks of 512 and says
it wrote all of them, and every later nonblocking file operation in that process
fails too.

### What the commits do

**`fbtl/posix: stop losing nonblocking I/O when the aio queue is full`**

- Size the batch from `kern.aioprocmax` on Darwin rather than
  `sysconf(_SC_AIO_MAX)`, which there reports the machine-wide `kern.aiomax`.
  Falls back to `sysconf` elsewhere and if the sysctl is unavailable.
- Add an `fbtl_posix_max_aio_reqs` MCA parameter, which wins when set. `sysconf`
  was the only thing that ever assigned this, so there was no way to correct it
  from outside.
- Treat `EAGAIN` as back-pressure rather than as an error:
  `mca_fbtl_posix_post_reqs` posts what the queue accepts and reports where it
  stopped, and the remainder waits for a later progress call. The existing
  ten-attempt retry loop is removed because it cannot succeed — a slot is
  released by `aio_return`, and the only caller of `aio_return` is reached
  through `req->req_progress_fn`, which is assigned after the loop runs.
- `mca_fbtl_posix_progress` now arms the next batch on
  `lcount == prd_last_active_req - prd_first_active_req` rather than on a whole
  `prd_req_chunks`. The old condition assumed every window is a full chunk,
  which is what a short window is not; an empty window reduces to the same
  expression and is retried.
- `mca_fbtl_posix_drain_reqs` reaps what was posted before the aiocbs are freed
  on a genuine error. Freeing them with operations outstanding is undefined on
  POSIX's terms, and an unreaped operation costs the process a queue slot for
  the rest of its life.

**`ompio: report a nonblocking fbtl operation that could not be posted`**

`mca_common_ompio_file_iwrite` and `..._iread` called the fbtl as a statement. A
request with no progress function is indistinguishable, to
`mca_common_ompio_progress`, from a parent request whose subrequests have all
completed, so it was completed with a status nothing had written — which is where
the bogus `MPI_SUCCESS` came from. Now sets `MPI_ERR_IO` and completes the
request at the call site.

**`docs: note the posix fbtl aio fixes in the v6.1.x changelog`**
