### PR TITLE
docs: describe OFI BTL multi-NIC support

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -50,3 +50,11 @@ Open MPI version v6.1.0
   run-time MCA parameters), and a manifest, all indexed from
   ``llms.txt``. See the "LLM-friendly documentation artifacts" page in
   the developer documentation.
+
+- OFI / Libfabric updates:
+
+  - The ``ofi`` BTL now supports multi-rail / multi-NIC operation for
+    ``ob1`` traffic when multiple Libfabric NICs are available.  Open MPI
+    automatically gives each process on a node its own share of the
+    available NICs, which can significantly improve both single-rank and
+    total node bandwidth on multi-NIC systems such as AWS EFA.

--- a/docs/release-notes/networks.rst
+++ b/docs/release-notes/networks.rst
@@ -121,3 +121,10 @@ Miscellaneous network notes
   message about sending too large of a message when using the OFI MTL,
   please reach out to your networking vendor to ask them to support a
   larger ``max_msg_size`` for tagged messages.
+
+* Starting with Open MPI v6.0.0, the ``ofi`` BTL can use multiple
+  Libfabric NICs per process when more than one NIC is available for
+  the selected provider.  Open MPI automatically gives each process on
+  a node its own share of the available NICs, which can improve both
+  single-rank and total node bandwidth on multi-NIC systems.  See
+  :doc:`../tuning-apps/networking/ofi` for details.

--- a/docs/tuning-apps/networking/ofi.rst
+++ b/docs/tuning-apps/networking/ofi.rst
@@ -77,6 +77,45 @@ Each component also has its own component-specific parameters; use
 For more information, refer to the `Libfabric web site
 <https://libfabric.org/>`_.
 
+OFI BTL: multi-rail / multi-NIC support
+---------------------------------------
+
+Starting with Open MPI v6.0.0, the ``ofi`` BTL can use multiple
+Libfabric NICs per process when more than one NIC is available for the
+selected provider.  This primarily benefits ``ob1``-based traffic
+patterns, allowing a single MPI rank to spread its traffic across
+multiple NICs instead of being limited to the bandwidth of a single
+device.
+
+Open MPI first counts the distinct physical NICs the selected provider
+reports on the local node, ignoring duplicates (some providers report
+the same physical NIC more than once), and lists them in a fixed order
+so that every process on the node agrees on that order.  It then gives
+each process an even share of those NICs, computed automatically as
+roughly the number of NICs divided by the number of processes on the
+node (always at least one NIC per process).
+
+Each process is assigned a different portion of the NIC list, so when
+there are at least as many NICs as processes on the node, the processes
+use non-overlapping sets of NICs rather than all competing for the same
+device.  On nodes with many NICs, this can improve both the bandwidth
+seen by a single rank and the total bandwidth of the node.
+
+This behavior is automatic; there is no MCA parameter to manually assign
+per-rank NIC slices.  The ``ofi`` BTL still selects Libfabric providers
+through its normal provider include / exclude MCA parameters.
+
+For example, to force ``ob1`` to use the ``ofi`` BTL together with the
+usual loopback support:
+
+.. code-block:: sh
+
+   shell$ mpirun --mca pml ob1 --mca btl ofi,self ./mpi_hello
+
+On multi-NIC Libfabric systems such as AWS EFA instances, this lets a
+single rank's traffic use multiple NICs, and also spreads the processes
+on a node across different NICs.
+
 Omni-Path: multi-rail with multiple HFI cards
 ---------------------------------------------
 


### PR DESCRIPTION
Document the user-visible OFI / Libfabric changes introduced by PR the ofi BTL's multi-rail / multi-NIC behavior under ob1, including how Open MPI deduplicates Libfabric domain names, computes modules per process, and assigns disjoint per-process NIC slices on multi-NIC systems such as AWS EFA.

Also add a brief note in the network release notes and a v6.1.x changelog entry so users can discover the new behavior from both the general network documentation and the release notes.

related to #14115