### PR TITLE
[v6.0.x] coll/han: restore zero-size guard in han_scratch_alloc

### DIFF
--- a/ompi/mca/coll/han/coll_han.h
+++ b/ompi/mca/coll/han/coll_han.h
@@ -91,6 +91,12 @@ enum {
  */
 static inline char *han_scratch_alloc(char **buf, size_t *buf_size, size_t needed)
 {
+    if (0 == needed) {
+        /* Return a valid non-NULL pointer for zero-size allocations,
+         * matching malloc(0) behavior that callers rely on. */
+        static char zero_len_sentinel;
+        return &zero_len_sentinel;
+    }
     if (*buf_size < needed) {
         char *p = realloc(*buf, needed);
         if (NULL == p) return NULL;

--- a/ompi/mca/coll/han/coll_han_alltoall.c
+++ b/ompi/mca/coll/han/coll_han_alltoall.c
@@ -63,7 +63,9 @@ static inline int ring_partner(int rank, int round, int comm_size) {
 
 /**
  * Set up or reuse cached SMSC arrays for alltoall.
- * Returns true if cache was valid (allgather + map can be skipped).
+ * Returns 1 if cache was valid (allgather + map can be skipped),
+ * 0 on cache miss (arrays allocated, caller must populate),
+ * or -1 on allocation failure.
  */
 static int alltoall_cache_setup(
     mca_coll_han_module_t *han_module,

--- a/ompi/mca/coll/han/coll_han_alltoallv.c
+++ b/ompi/mca/coll/han/coll_han_alltoallv.c
@@ -586,7 +586,7 @@ static int alltoallv_sendrecv_w(
 /**
  * Set up persistent allocations for alltoallv.
  * Grows arrays to high-water mark to avoid per-call malloc/free.
- * Returns 0 on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
+ * Returns OMPI_SUCCESS on success, OMPI_ERR_OUT_OF_RESOURCE on failure.
  */
 static int alltoallv_cache_setup(
     struct han_alltoallv_cache *c,


### PR DESCRIPTION
The guard added to han_scratch_alloc in b4624fa434 (PR #13824) did not make it to v6.0.x. The backport (PR #13890) modified coll_han.h but did not carry these six lines, while it did carry the change that sets han_use_persist_buffers = true by default. On main those two arrived in the same commit, which is what made the default safe.

Without the guard, han_scratch_alloc(needed == 0) skips the grow branch and returns *buf, which is NULL until the first non-zero allocation. Callers read NULL as OOM and return OMPI_ERR_OUT_OF_RESOURCE, which errcode-internal.c maps to MPI_ERR_INTERN. The gatherv and scatterv node-leader paths sum a data-dependent total_rsize that is legitimately 0 for a zero-byte collective, so benchmarks that start at size 0 fail immediately with no bytes transferred.

With the old han_use_persist_buffers = false default, the non-persist path called malloc(0), which returns non-NULL, so the missing guard was unreachable. Enabling persist buffers by default made it reachable.

Reproduced on a 2+ node cluster, 16 ranks, with two builds of v6.0.x differing only by these six lines. Zero-count MPI_Gatherv and MPI_Scatterv return MPI_ERR_INTERN without the guard and succeed with it; count 8 passes either way. The failure is reported by the second node's leader, the only rank that reaches the zero-size scratch call. Setting --mca coll_han_use_persist_buffers 0 also avoids it, confirming the persist path as the mechanism.

The hunk applies to unchanged context: coll_han.h at b4624fa434's parent is byte-identical to coll_han.h on v6.0.x.

Also picks up two comment-only doc-string corrections from the same upstream commit.


(cherry picked from commit b4624fa434e15b2b3f4b6e5a0a72dd2a48d84b0e)