### PR TITLE
CID:169969(8/9) btl/ofi: drop redundant NULL checks flagged by Coverity

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -470,8 +470,10 @@ no_hmem:
         struct fi_info *tmp = info_list;
         while (tmp && NULL != unique_domains) {
             if (OPAL_SUCCESS == validate_info(tmp, required_caps, include_list, exclude_list)) {
-                const char *p = (NULL != tmp->fabric_attr) ? tmp->fabric_attr->prov_name : NULL;
-                const char *d = (NULL != tmp->domain_attr) ? tmp->domain_attr->name : NULL;
+                /* validate_info() succeeded, so it already dereferenced both
+                 * fabric_attr and domain_attr; they are guaranteed non-NULL. */
+                const char *p = tmp->fabric_attr->prov_name;
+                const char *d = tmp->domain_attr->name;
                 if (NULL == first_prov) first_prov = p;
                 if (NULL != first_prov && NULL != p && 0 == strcmp(first_prov, p) && NULL != d) {
                     /* Only count unique domain names */
@@ -527,9 +529,10 @@ no_hmem:
             if (OPAL_SUCCESS != validate_info(info, required_caps, include_list, exclude_list)) {
                 continue;
             }
-            const char *prov = (NULL != info->fabric_attr)
-                               ? info->fabric_attr->prov_name : NULL;
-            const char *d = (NULL != info->domain_attr) ? info->domain_attr->name : NULL;
+            /* validate_info() succeeded, so it already dereferenced both
+             * fabric_attr and domain_attr; they are guaranteed non-NULL. */
+            const char *prov = info->fabric_attr->prov_name;
+            const char *d = info->domain_attr->name;
             if (NULL != first_prov && NULL != prov && NULL != d
                 && 0 == strcmp(first_prov, prov) && 0 == strcmp(want, d)) {
                 (void) mca_btl_ofi_init_device(info);


### PR DESCRIPTION
In mca_btl_ofi_component_init() the unique-domain counting loop and the module-creation loop both guarded tmp->fabric_attr / info->fabric_attr and the corresponding domain_attr with ternary NULL checks before reading prov_name and name. These checks ran only after validate_info() had already returned OPAL_SUCCESS.

validate_info() unconditionally dereferences info->fabric_attr->prov_name and info->domain_attr->name on every code path, so once it returns OPAL_SUCCESS both struct pointers are guaranteed non-NULL. The later "is it NULL?" tests therefore imply a possibility that cannot occur, which is exactly what Coverity's REVERSE_INULL checker reported (CID 1699699 and CID 1699698): the pointer was already dereferenced on all paths leading to the check.

Replace the redundant struct-pointer guards with direct dereferences and add a short comment recording the invariant that validate_info() establishes. The NULL checks on the resulting prov_name / name string values are kept, since those string fields can legitimately be NULL even when the attribute structs are not. Behavior is unchanged; this only removes the contradictory checks and clears the two defects.
