### PR TITLE
bindings: fix parameter docstring typo

### DIFF
--- a/ompi/mpi/bindings/ompi_bindings/util.py
+++ b/ompi/mpi/bindings/ompi_bindings/util.py
@@ -87,7 +87,7 @@ def fortran_f08_generic_interface_name(fn_name):
     return f'MPI_{fn_name.capitalize()}'
 
 def break_param_lines_fortran(start, params, end):
-    """Break paramters for a fortran call onto multiple lines.
+    """Break parameters for a fortran call onto multiple lines.
 
     This is often necessary to avoid going over the max line length of 132
     characters.


### PR DESCRIPTION
## Summary
- fix the misspelled word in break_param_lines_fortran documentation
- keep the helper behavior unchanged

## Testing
- python -m py_compile ompi/mpi/bindings/ompi_bindings/util.py
- git diff --check
