### PR TITLE
win: defer allocation of w_name until it is actually needed

### DIFF
--- a/ompi/mpi/c/win_get_name.c.in
+++ b/ompi/mpi/c/win_get_name.c.in
@@ -54,10 +54,13 @@ PROTOTYPE ERROR_CLASS win_get_name(WIN win, STRING_OUT win_name, INT_OUT resultl
        so that the output is bounded by @MPI_MAX_OBJECT_NAME@ -- the entry
        point's own MPI_MAX_OBJECT_NAME, which matches the size of the
        caller's buffer: OPAL_MAX_OBJECT_NAME for the OMPI binding, the MPI
-       Forum ABI maximum for the standard-ABI binding.  win->w_name is sized
-       to the ABI maximum and is always \0-terminated. */
+       Forum ABI maximum for the standard-ABI binding.  w_name is only
+       allocated the first time a name is set on the window: if it is still
+       NULL, the window's name is the empty string.  When allocated, it is
+       sized to the ABI maximum and is always \0-terminated. */
     OPAL_THREAD_LOCK(&(win->w_lock));
-    opal_string_copy(win_name, win->w_name, @MPI_MAX_OBJECT_NAME@);
+    const char *name = (NULL == win->w_name) ? "" : win->w_name;
+    opal_string_copy(win_name, name, @MPI_MAX_OBJECT_NAME@);
     /* The copy above may truncate (w_name holds up to the ABI maximum);
        resultlen must describe the name actually returned. */
     *resultlen = (int) strlen(win_name);

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -165,13 +165,6 @@ static int alloc_window(struct ompi_communicator_t *comm, opal_info_t *info, int
         return OMPI_ERR_OUT_OF_RESOURCE;
     }
 
-    win->w_name = (char*) malloc (OMPI_MPI_MAX_OBJECT_NAME_ABI);
-    if (NULL == win->w_name) {
-        OBJ_RELEASE(win);
-        return OMPI_ERR_OUT_OF_RESOURCE;
-    }
-    win->w_name[0] = '\0';
-
     /* Copy the info for the info layer */
     win->super.s_info = OBJ_NEW(opal_info_t);
     if (info) {
@@ -457,6 +450,17 @@ int
 ompi_win_set_name(ompi_win_t *win, const char *win_name)
 {
     OPAL_THREAD_LOCK(&(win->w_lock));
+
+    /* Defer allocation of the storage for the window name until it is
+       actually needed (i.e. the first time a name is set). */
+    if (NULL == win->w_name) {
+        win->w_name = (char *) malloc (OMPI_MPI_MAX_OBJECT_NAME_ABI);
+        if (NULL == win->w_name) {
+            OPAL_THREAD_UNLOCK(&(win->w_lock));
+            return OMPI_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
     /* Bound the store by the full internal buffer size (the ABI maximum); the
      * per-entry-point limit (OPAL_MAX_OBJECT_NAME for the OMPI bindings, the
      * ABI maximum for the standard-ABI bindings) is applied by the caller. */
@@ -471,10 +475,14 @@ int
 ompi_win_get_name(ompi_win_t *win, char *win_name, int *length)
 {
     OPAL_THREAD_LOCK(&(win->w_lock));
-    opal_string_copy(win_name, win->w_name, MPI_MAX_OBJECT_NAME);
-    /* w_name can hold up to the (larger) MPI Forum ABI maximum, so the
-       copy above may truncate; report the length of what was actually
-       returned, per MPI's requirement on resultlen. */
+
+    /* If no name has ever been set on this window, its name is the empty
+       string (per the MPI standard).  w_name can hold up to the (larger)
+       MPI Forum ABI maximum, so the copy below may truncate; report the
+       length of what was actually returned, per MPI's requirement on
+       resultlen. */
+    const char *name = (NULL == win->w_name) ? "" : win->w_name;
+    opal_string_copy(win_name, name, MPI_MAX_OBJECT_NAME);
     *length = (int)strlen(win_name);
     OPAL_THREAD_UNLOCK(&(win->w_lock));
 


### PR DESCRIPTION
The dynamically allocated ompi_win_t.w_name buffer was allocated up front on the window creation path, so every window paid for an OMPI_MPI_MAX_OBJECT_NAME_ABI-byte allocation even though most windows never have a name set on them.

Defer the allocation of the w_name buffer until it is actually needed, i.e. the first time a name is set via ompi_win_set_name. Windows whose name is never set now carry only a NULL pointer.

Changes to ompi/win/win.c:

- alloc_window: no longer eagerly malloc's w_name; the constructor already initializes it to NULL.

- ompi_win_set_name: allocate the buffer on demand the first time a name is set (reusing it on subsequent sets), returning OMPI_ERR_OUT_OF_RESOURCE if the allocation fails.

- ompi_win_get_name: treat a NULL w_name as the empty string, per the MPI standard, so callers that query a name before one has been set get a zero-length string rather than dereferencing NULL. The copy is done with a single opal_string_copy() using an empty-string fallback.

The destructor already frees w_name only when non-NULL, so it needs no change, and the MPI_WIN_NULL predefined window (which strdup's its name) is unaffected.
