### PR TITLE
MPI_T: improve make cleanliness

### DIFF
--- a/ompi/mpi/tool/Makefile.am
+++ b/ompi/mpi/tool/Makefile.am
@@ -203,6 +203,9 @@ libmpi_mpit_profile_la_CPPFLAGS = -DOMPI_BUILD_MPI_PROFILING=1
 EXTRA_DIST = $(prototype_sources)
 
 MAINTAINERCLEANFILES = *_generated.c 
+if OPAL_DEVEL_BUILD
+CLEANFILES += *_generated.c 
+endif
 
 if OMPI_STANDARD_ABI
 include Makefile_abi.include


### PR DESCRIPTION
We forgot to apply the same clean policy in ompi/mpi/tool folder that we apply in ompi/mpi/c.

Namely, in a devel workarea

```
make clean
```

will remove all *generated.c files.

In a tarball workarea still have to run

```
make maintainer-clean
```