### PR TITLE
btl/ofi: remove redundant NULL checks on fi_info attributes

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -470,8 +470,8 @@ no_hmem:
         struct fi_info *tmp = info_list;
         while (tmp && NULL != unique_domains) {
             if (OPAL_SUCCESS == validate_info(tmp, required_caps, include_list, exclude_list)) {
-                const char *p = (NULL != tmp->fabric_attr) ? tmp->fabric_attr->prov_name : NULL;
-                const char *d = (NULL != tmp->domain_attr) ? tmp->domain_attr->name : NULL;
+                const char *p = tmp->fabric_attr->prov_name;
+                const char *d = tmp->domain_attr->name;
                 if (NULL == first_prov) first_prov = p;
                 if (NULL != first_prov && NULL != p && 0 == strcmp(first_prov, p) && NULL != d) {
                     /* Only count unique domain names */
@@ -527,9 +527,8 @@ no_hmem:
             if (OPAL_SUCCESS != validate_info(info, required_caps, include_list, exclude_list)) {
                 continue;
             }
-            const char *prov = (NULL != info->fabric_attr)
-                               ? info->fabric_attr->prov_name : NULL;
-            const char *d = (NULL != info->domain_attr) ? info->domain_attr->name : NULL;
+            const char *prov = info->fabric_attr->prov_name;
+            const char *d = info->domain_attr->name;
             if (NULL != first_prov && NULL != prov && NULL != d
                 && 0 == strcmp(first_prov, prov) && 0 == strcmp(want, d)) {
                 (void) mca_btl_ofi_init_device(info);


### PR DESCRIPTION
Fixes #14287

  Coverity flagged two new REVERSE_INULL defects introduced by #14115, both in `mca_btl_ofi_component_init()`:

  - CID 1699699 — `btl_ofi_component.c:473` (`tmp->fabric_attr`)
  - CID 1699698 — `btl_ofi_component.c:530` (`info->fabric_attr`)

  Both sites null-checked `fabric_attr` / `domain_attr` *after* those members had already been dereferenced on every path reaching the check. Each is guarded by a successful `validate_info()` call, and `validate_info()` dereferences `info->fabric_attr->prov_name` unconditionally at line 96 and `info->domain_attr->mr_mode` at line 122 were NULL the process would already have crashed inside `validate_info()`, the downstream checks can never fire.

  `fi_getinfo()` always populates `fabric_attr` and `domain_attr` on the `fi_info` structures it returns, and the rest of this file has always relied on that (e.g. the bare `strdup(info->domain_attr->name)` in `mca_btl_ofi_init_device()`). The checks were inconsistent with the surrounding convention rather than protective, so they are removed.

  The `prov_name` and `name` *string* pointers are a separate matter and can legitimately be NULL, so the `NULL != p` / `NULL != d` guards on those values are retained. No functional change.