### PR TITLE
v5.0.x: Backport/pr 13837 fix SPC counters for partitioned communication

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -73,7 +73,7 @@ EXAMPLES = \
 # others if we have the appropriate Open MPI / OpenSHMEM language
 # bindings.
 
-all: hello_c ring_c connectivity_c spc_example hello_sessions_c
+all: hello_c ring_c connectivity_c hello_sessions_c
 	@ if which ompi_info >/dev/null 2>&1 ; then \
 	    $(MAKE) mpi; \
 	fi
@@ -95,6 +95,9 @@ mpi:
 	fi
 	@ if ompi_info --parsable | grep -q bindings:java:yes >/dev/null; then \
 	    $(MAKE) Hello.class Ring.class; \
+	fi
+	@ if ompi_info --parsable | grep -q enable-spc >/dev/null; then \
+	    $(MAKE) spc_example; \
 	fi
 
 # OpenSHMEM examples

--- a/ompi/mpi/c/pready_list.c
+++ b/ompi/mpi/c/pready_list.c
@@ -46,7 +46,7 @@ static const char FUNC_NAME[] = "MPI_Pready_list";
 int MPI_Pready_list(int length, int* partitions, MPI_Request request)
 {
     int rc = OMPI_SUCCESS;
-    SPC_RECORD(OMPI_SPC_PREADY, 1);
+    SPC_RECORD(OMPI_SPC_PREADY_LIST, 1);
 
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;

--- a/ompi/mpi/c/pready_range.c
+++ b/ompi/mpi/c/pready_range.c
@@ -47,7 +47,7 @@ int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request)
 {
     int rc;
 
-    SPC_RECORD(OMPI_SPC_PREADY, 1);
+    SPC_RECORD(OMPI_SPC_PREADY_RANGE, 1);
 
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -48,6 +48,8 @@ int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype data
 {
     int rc;
 
+    SPC_RECORD(OMPI_SPC_PRECV_INIT, 1);
+
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/mpi/c/psend_init.c
+++ b/ompi/mpi/c/psend_init.c
@@ -48,6 +48,8 @@ int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatyp
 {
     int rc;
 
+    SPC_RECORD(OMPI_SPC_PSEND_INIT, 1);
+
     if (MPI_PARAM_CHECK) {
         rc = OMPI_SUCCESS;
 

--- a/ompi/runtime/ompi_spc.c
+++ b/ompi/runtime/ompi_spc.c
@@ -170,7 +170,11 @@ static const ompi_spc_event_t ompi_spc_events_desc[OMPI_SPC_NUM_COUNTERS] = {
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV, "The number of times MPI_Isendrecv was called.", false, false),
     SET_COUNTER_ARRAY(OMPI_SPC_ISENDRECV_REPLACE, "The number of times MPI_Isendrecv_replace was called.", false, false),
     SET_COUNTER_ARRAY(OMPI_SPC_PARRIVED, "The number of times MPI_Parrived was called.", false, false),
-    SET_COUNTER_ARRAY(OMPI_SPC_PREADY, "The number of times MPI_Pready (or similar functions) was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY, "The number of times MPI_Pready was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY_LIST, "The number of times MPI_Pready_list was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PREADY_RANGE, "The number of times MPI_Pready_range was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PRECV_INIT, "The number of times MPI_Precv_init was called.", false, false),
+    SET_COUNTER_ARRAY(OMPI_SPC_PSEND_INIT, "The number of times MPI_Psend_init was called.", false, false)
 };
 
 /* An array of event structures to store the event data (value, attachments, flags) */

--- a/ompi/runtime/ompi_spc.h
+++ b/ompi/runtime/ompi_spc.h
@@ -156,6 +156,10 @@ typedef enum ompi_spc_counters {
     OMPI_SPC_ISENDRECV_REPLACE,
     OMPI_SPC_PARRIVED,
     OMPI_SPC_PREADY,
+    OMPI_SPC_PREADY_LIST,
+    OMPI_SPC_PREADY_RANGE,
+    OMPI_SPC_PRECV_INIT,
+    OMPI_SPC_PSEND_INIT,
     OMPI_SPC_NUM_COUNTERS /* This serves as the number of counters.  It must be last. */
 } ompi_spc_counters_t;
 


### PR DESCRIPTION
Backport of PR #13837 to v5.0.x — fix SPC counters for partitioned communication

Backports a single instrumentation fix from PR #13837 (merged to main) to v5.0.x. Companion to issue #14157.

MPI_Pready_list and MPI_Pready_range were both recording to OMPI_SPC_PREADY (the MPI_Pready counter) instead of their own dedicated counters. Adds OMPI_SPC_PREADY_LIST and OMPI_SPC_PREADY_RANGE.

MPI_Precv_init and MPI_Psend_init had no SPC_RECORD call at all. Adds OMPI_SPC_PRECV_INIT and OMPI_SPC_PSEND_INIT.

Also guards spc_example in examples/Makefile behind a runtime --enable-spc check; previously it was an unconditional dependency of the all target, causing build failures when SPC support was absent.

v5.0.x adaptation note: Changes applied directly to .c files rather than the .c.in templates used on main.

bot:notacherrypick