### PR TITLE
v5.0.x: Backport/pr 14155 to v5.0.x : partitioned communication correctness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -512,6 +512,7 @@ test/class/opal_tree
 test/class/opal_value_array
 
 test/part/parrived_null_inactive
+test/part/partitioned_proc_null
 
 test/datatype/ddt_test
 test/datatype/ddt_pack

--- a/.gitignore
+++ b/.gitignore
@@ -511,6 +511,8 @@ test/class/opal_proc_table
 test/class/opal_tree
 test/class/opal_value_array
 
+test/part/parrived_null_inactive
+
 test/datatype/ddt_test
 test/datatype/ddt_pack
 test/datatype/external32

--- a/configure.ac
+++ b/configure.ac
@@ -1533,7 +1533,7 @@ AC_CONFIG_FILES([
     test/util/Makefile
 ])
 
-m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile])])
+m4_ifdef([project_ompi], [AC_CONFIG_FILES([test/monitoring/Makefile test/spc/Makefile test/part/Makefile])])
 
 AC_CONFIG_FILES([contrib/dist/mofed/debian/rules],
                 [chmod +x contrib/dist/mofed/debian/rules])

--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -62,7 +62,8 @@ DESCRIPTION
 -----------
 
 ``request`` may be a null request (``MPI_REQUEST_NULL``) or an inactive
-request, in which case ``flag`` is set to true.
+request, in which case ``flag`` is set to true.  A request created with
+``MPI_PROC_NULL`` is likewise always reported as arrived.
 
 Calling :ref:`MPI_Parrived` on a request that does not correspond to a
 partitioned receive operation is erroneous.

--- a/docs/man-openmpi/man3/MPI_Parrived.3.rst
+++ b/docs/man-openmpi/man3/MPI_Parrived.3.rst
@@ -58,6 +58,15 @@ OUTPUT PARAMETERS
 * ``flag``: True if partition is completed.
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``request`` may be a null request (``MPI_REQUEST_NULL``) or an inactive
+request, in which case ``flag`` is set to true.
+
+Calling :ref:`MPI_Parrived` on a request that does not correspond to a
+partitioned receive operation is erroneous.
+
 ERRORS
 ------
 

--- a/docs/man-openmpi/man3/MPI_Precv_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Precv_init.3.rst
@@ -68,6 +68,16 @@ OUTPUT PARAMETERS
 * ``request``: Communication request (handle).
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``source`` may be ``MPI_PROC_NULL``, in which case the communication has
+no effect: the resulting request completes as soon as it is started, the
+receive buffer is not modified, and the status returned by a completing
+procedure has ``source = MPI_PROC_NULL``, ``tag = MPI_ANY_TAG``, and a
+count of zero.  :ref:`MPI_Parrived` reports every partition of such a
+request as arrived.
+
 ERRORS
 ------
 

--- a/docs/man-openmpi/man3/MPI_Psend_init.3.rst
+++ b/docs/man-openmpi/man3/MPI_Psend_init.3.rst
@@ -68,6 +68,14 @@ OUTPUT PARAMETERS
 * ``request``: Communication request (handle).
 * ``ierror``: Fortran only: Error status (integer).
 
+DESCRIPTION
+-----------
+
+``dest`` may be ``MPI_PROC_NULL``, in which case the communication has no
+effect: the resulting request completes as soon as it is started, and
+:ref:`MPI_Pready` (and its variants) on that request succeeds without
+transferring anything.
+
 ERRORS
 ------
 

--- a/ompi/mca/part/persist/part_persist.h
+++ b/ompi/mca/part/persist/part_persist.h
@@ -96,10 +96,14 @@ mca_part_persist_free_req(struct mca_part_persist_request_t* req)
     opal_list_remove_item(ompi_part_persist.progress_list, (opal_list_item_t*)req->progress_elem);
     OBJ_RELEASE(req->progress_elem);
 
-    for(i = 0; i < req->real_parts; i++) {
-        ompi_request_free(&(req->persist_reqs[i]));
+    /* The per-partition requests are only created once the setup handshake
+     * has completed, so an uninitialized request has none. */
+    if(NULL != req->persist_reqs) {
+        for(i = 0; i < req->real_parts; i++) {
+            ompi_request_free(&(req->persist_reqs[i]));
+        }
+        free(req->persist_reqs);
     }
-    free(req->persist_reqs);
     free(req->flags);
 
     if( MCA_PART_PERSIST_REQUEST_PRECV == req->req_type ) {
@@ -221,6 +225,18 @@ mca_part_persist_progress(void)
     OPAL_LIST_FOREACH(current, ompi_part_persist.progress_list, mca_part_persist_list_t) {
         mca_part_persist_request_t *req = (mca_part_persist_request_t *) current->item;
 
+        /* A request that MPI_Request_free has been called on is reclaimed
+         * once it is inactive.  This is checked before anything else, and
+         * for uninitialized requests as well as initialized ones: a request
+         * that was never started never completes its lazy setup handshake,
+         * so it would otherwise be left on the progress list forever.  Its
+         * handshake was already cancelled by mca_part_persist_free, so it
+         * must not be run through the setup path below. */
+        if(true == req->req_free_called && true == req->req_part_complete && REQUEST_COMPLETED == req->req_ompi.req_complete &&  OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
+            to_delete = req;
+            continue;
+        }
+
         /* Check to see if request is initilaized */
         if(false == req->initialized) {
             int done = 0; 
@@ -316,11 +332,7 @@ mca_part_persist_progress(void)
                 {
                     req->first_send = false;
                     mca_part_persist_complete(req);
-                } 
-            }
-
-            if(true == req->req_free_called && true == req->req_part_complete && REQUEST_COMPLETED == req->req_ompi.req_complete &&  OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
-                to_delete = req;
+                }
             }
         }
 
@@ -370,11 +382,15 @@ mca_part_persist_precv_init(void *buf,
 
     mca_part_persist_request_t *req = (mca_part_persist_request_t *) recvreq;
 
-    /* Set lazy initializion flags */
+    /* Set lazy initializion flags.  real_parts and persist_reqs are not
+     * known until the setup handshake completes; keep them empty so that
+     * freeing a request that was never started is safe. */
     req->initialized = false;
-    req->first_send  = true; 
+    req->first_send  = true;
     req->flag_post_setup_recv = false;
     req->flags = NULL;
+    req->persist_reqs = NULL;
+    req->real_parts = 0;
     /* Non-blocking receive on setup info */
     err	= MCA_PML_CALL(irecv(&req->setup_info[1], sizeof(struct ompi_mca_persist_setup_t), MPI_BYTE, src, tag, comm, &req->setup_req[1])); 
     if(OMPI_SUCCESS != err) return OMPI_ERROR;
@@ -434,10 +450,14 @@ mca_part_persist_psend_init(const void* buf,
                                     datatype, buf, parts, count, flags);
     mca_part_persist_request_t *req = (mca_part_persist_request_t *) sendreq;
 
-    /* Set lazy initialization variables */
+    /* Set lazy initialization variables.  The per-partition sends are not
+     * created until the setup handshake completes; keep the array empty so
+     * that freeing a request that was never started is safe. */
     req->initialized = false;
-    req->first_send  = true; 
-    
+    req->first_send  = true;
+    req->persist_reqs = NULL;
+
+
 
     /* Determine total bytes to send. */
     err = opal_datatype_type_size(&(req->req_datatype->super), &dt_size_);
@@ -609,6 +629,28 @@ mca_part_persist_free(ompi_request_t** request)
 
     if(true == req->req_free_called) return OMPI_ERROR;
     req->req_free_called = true;
+
+    /* If this request never completed its lazy setup handshake, its setup
+     * requests are still outstanding against req->setup_info[], which will
+     * be recycled when the request is reclaimed.  The setup receive is
+     * posted on the user's communicator with the user's peer and tag, so if
+     * it is left posted it will also match -- and consume -- the setup
+     * message of the next partitioned operation that uses that same
+     * communicator, peer, and tag; that operation would then never be set up
+     * and would never complete.  Cancel the handshake here rather than when
+     * the request is reclaimed in the progress engine: the next partitioned
+     * operation can be initialized before the progress engine runs again. */
+    if(false == req->initialized &&
+       OMPI_REQUEST_INACTIVE == req->req_ompi.req_state) {
+        if(false == req->flag_post_setup_recv) {
+            ompi_request_cancel(req->setup_req[1]);
+            ompi_request_wait(&(req->setup_req[1]), MPI_STATUS_IGNORE);
+        }
+        if(MCA_PART_PERSIST_REQUEST_PSEND == req->req_type) {
+            ompi_request_cancel(req->setup_req[0]);
+            ompi_request_wait(&(req->setup_req[0]), MPI_STATUS_IGNORE);
+        }
+    }
 
     *request = MPI_REQUEST_NULL;
     return OMPI_SUCCESS;

--- a/ompi/mpi/c/parrived.c
+++ b/ompi/mpi/c/parrived.c
@@ -64,7 +64,8 @@ int MPI_Parrived(MPI_Request request, int partition,  int *flag)
             rc = MPI_ERR_ARG;
         } else if (NULL == request ||
                    (MPI_REQUEST_NULL != request &&
-                    OMPI_REQUEST_PART != request->req_type)) {
+                    OMPI_REQUEST_PART != request->req_type &&
+                    OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
@@ -77,6 +78,18 @@ int MPI_Parrived(MPI_Request request, int partition,  int *flag)
             *flag = 1;
             return MPI_SUCCESS;
         }
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): a receive from MPI_PROC_NULL "succeeds and
+    // returns as soon as possible", so every partition of a partitioned
+    // receive from MPI_PROC_NULL (a persistent no-op request; see
+    // MPI_Precv_init) has trivially arrived.  This is checked
+    // unconditionally: such a request is not a partitioned request, so it
+    // must never be handed to the part framework, and -- once started -- it
+    // is active, so the inactive short circuit above does not cover it.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        *flag = 1;
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_parrived(partition, partition, flag, request);

--- a/ompi/mpi/c/parrived.c
+++ b/ompi/mpi/c/parrived.c
@@ -53,23 +53,30 @@ int MPI_Parrived(MPI_Request request, int partition,  int *flag)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        // MPI-5.0 sec 4.2.2 (p.119): MPI_Parrived on a null or inactive
-        // request returns flag = true.  Handle these before the
-        // request-type check so MPI_REQUEST_NULL (req_type ==
-        // OMPI_REQUEST_NULL) and a never-started inactive partitioned
-        // receive request are not rejected with MPI_ERR_REQUEST.
-        if (NULL == request || MPI_REQUEST_NULL == request) {
-            *flag = 1;
-            return MPI_SUCCESS;
-        }
-        if (OMPI_REQUEST_INACTIVE == request->req_state) {
-            *flag = 1;
-            return MPI_SUCCESS;
-        }
-        if (OMPI_REQUEST_PART != request->req_type) {
+        // MPI-5.0 sec 4.2.2 (p.119) explicitly permits a null request
+        // here, so MPI_REQUEST_NULL must survive the request type check:
+        // its req_type is OMPI_REQUEST_NULL, not OMPI_REQUEST_PART.  Any
+        // other type of request is erroneous ("Calling MPI_PARRIVED on a
+        // request that does not correspond to a partitioned receive
+        // operation is erroneous"), including an inactive one, so this
+        // check must precede the inactive check below.
+        if (NULL == flag) {
+            rc = MPI_ERR_ARG;
+        } else if (NULL == request ||
+                   (MPI_REQUEST_NULL != request &&
+                    OMPI_REQUEST_PART != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+
+        // MPI-5.0 sec 4.2.2 (p.119): "MPI_PARRIVED may be called with a
+        // null or inactive request argument.  In either case, the
+        // operation returns with flag = true."
+        if (MPI_REQUEST_NULL == request ||
+            OMPI_REQUEST_INACTIVE == request->req_state) {
+            *flag = 1;
+            return MPI_SUCCESS;
+        }
     }
 
     rc = mca_part.part_parrived(partition, partition, flag, request);

--- a/ompi/mpi/c/pready.c
+++ b/ompi/mpi/c/pready.c
@@ -53,10 +53,21 @@ int MPI_Pready(int partition, MPI_Request request)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_pready(partition, partition, request);

--- a/ompi/mpi/c/pready_list.c
+++ b/ompi/mpi/c/pready_list.c
@@ -52,10 +52,21 @@ int MPI_Pready_list(int length, int* partitions, MPI_Request request)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     for(int i = 0; i < length && OMPI_SUCCESS == rc; i++) {

--- a/ompi/mpi/c/pready_range.c
+++ b/ompi/mpi/c/pready_range.c
@@ -53,10 +53,21 @@ int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request)
         rc = OMPI_SUCCESS;
 
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);
-        if (NULL == request || OMPI_REQUEST_PART != request->req_type) {
+        if (NULL == request ||
+            (OMPI_REQUEST_PART != request->req_type &&
+             OMPI_REQUEST_NOOP != request->req_type)) {
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): "a communication with MPI_PROC_NULL has no
+    // effect", so there is nothing to mark ready on a partitioned send to
+    // MPI_PROC_NULL (a persistent no-op request; see MPI_Psend_init).  This
+    // is checked unconditionally: such a request is not a partitioned
+    // request, so it must never be handed to the part framework.
+    if (OMPI_REQUEST_NOOP == request->req_type) {
+        return MPI_SUCCESS;
     }
 
     rc = mca_part.part_pready(partition_low, partition_high, request);

--- a/ompi/mpi/c/precv_init.c
+++ b/ompi/mpi/c/precv_init.c
@@ -32,6 +32,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mca/part/part.h"
 #include "ompi/datatype/ompi_datatype.h"
+#include "ompi/request/request.h"
 #include "ompi/runtime/ompi_spc.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -56,6 +57,16 @@ int MPI_Precv_init(void* buf, int partitions, MPI_Count count, MPI_Datatype data
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): MPI_PROC_NULL may be used wherever a source
+    // or destination rank is required, and "a communication with
+    // MPI_PROC_NULL has no effect."  Hand back the same persistent no-op
+    // request that MPI_Recv_init does, rather than passing MPI_PROC_NULL
+    // down to the PML as if it were a real peer rank.
+    if (MPI_PROC_NULL == source) {
+        rc = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
 
     rc = mca_part.part_precv_init(buf, partitions, count, datatype, source, tag, comm, info, request);

--- a/ompi/mpi/c/psend_init.c
+++ b/ompi/mpi/c/psend_init.c
@@ -32,6 +32,7 @@
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/mca/part/part.h"
 #include "ompi/datatype/ompi_datatype.h"
+#include "ompi/request/request.h"
 #include "ompi/runtime/ompi_spc.h"
 
 #if OMPI_BUILD_MPI_PROFILING
@@ -56,6 +57,16 @@ int MPI_Psend_init(const void* buf, int partitions, MPI_Count count, MPI_Datatyp
             rc = MPI_ERR_REQUEST;
         }
         OMPI_ERRHANDLER_CHECK(rc, MPI_COMM_WORLD, rc, FUNC_NAME);
+    }
+
+    // MPI-5.0 sec 3.10 (p.110): MPI_PROC_NULL may be used wherever a source
+    // or destination rank is required, and "a communication with
+    // MPI_PROC_NULL has no effect."  Hand back the same persistent no-op
+    // request that MPI_Send_init does, rather than passing MPI_PROC_NULL
+    // down to the PML as if it were a real peer rank.
+    if (MPI_PROC_NULL == dest) {
+        rc = ompi_request_persistent_noop_create(request);
+        OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
     }
 
     rc = mca_part.part_psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,6 +24,6 @@
 # support needs to be first for dependencies
 SUBDIRS = support asm class threads datatype util mpool
 if PROJECT_OMPI
-SUBDIRS += monitoring spc
+SUBDIRS += monitoring spc part
 endif
 DIST_SUBDIRS = event $(SUBDIRS)

--- a/test/part/Makefile.am
+++ b/test/part/Makefile.am
@@ -1,0 +1,42 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# These are single-process partitioned communication tests.  Each calls
+# MPI_Init and performs all of its communication on MPI_COMM_SELF or with
+# MPI_PROC_NULL, so they need no launcher and can run as part of 'make
+# check'.  They exercise the MPI_Parrived null / inactive request behavior
+# required by MPI-5.0 sec. 4.2.2 (Open MPI issue #14003), and partitioned
+# communication with MPI_PROC_NULL (MPI-5.0 sec. 3.10).
+
+if PROJECT_OMPI
+
+check_PROGRAMS = \
+        parrived_null_inactive \
+        partitioned_proc_null
+TESTS = $(check_PROGRAMS)
+
+common_ldflags = $(OMPI_PKG_CONFIG_LDFLAGS)
+common_ldadd = \
+        $(top_builddir)/ompi/lib@OMPI_LIBMPI_NAME@.la \
+        $(top_builddir)/opal/lib@OPAL_LIB_NAME@.la
+
+parrived_null_inactive_SOURCES = parrived_null_inactive.c
+parrived_null_inactive_LDFLAGS = $(common_ldflags)
+parrived_null_inactive_LDADD = $(common_ldadd)
+
+partitioned_proc_null_SOURCES = partitioned_proc_null.c
+partitioned_proc_null_LDFLAGS = $(common_ldflags)
+partitioned_proc_null_LDADD = $(common_ldadd)
+
+endif # PROJECT_OMPI
+
+distclean-local:
+	rm -rf *.dSYM .deps .libs *.la *.lo *.log *.o *.trs \
+		parrived_null_inactive partitioned_proc_null Makefile

--- a/test/part/parrived_null_inactive.c
+++ b/test/part/parrived_null_inactive.c
@@ -1,0 +1,235 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) regression test for Open MPI
+ * issue #14003: MPI_Parrived must return flag = true when called with a
+ * null or an inactive request.
+ *
+ * MPI-5.0 section 4.2.2 (p.119) states:
+ *
+ *   "MPI_PARRIVED may be called with a null or inactive request
+ *    argument.  In either case, the operation returns with flag = true.
+ *    Calling MPI_PARRIVED on a request that does not correspond to a
+ *    partitioned receive operation is erroneous."
+ *
+ * Four cases are covered: a null request, an inactive request that has
+ * never been started, an active request being probed per partition, and
+ * an inactive request that has completed and been reset.
+ *
+ * The partitioned send/receive pair is set up on MPI_COMM_SELF, so this
+ * is a valid single-process test and needs no launcher.
+ *
+ * Note: Open MPI only guarantees the null-request case when MPI
+ * parameter checking is enabled (the check lives in the C binding, which
+ * is compiled/branched out when checking is off, so as not to burden the
+ * probing fast path).  The null case is therefore skipped when the
+ * mpi_param_check MCA variable reads as false.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "mpi.h"
+
+/* Bound the polling loops so that a regression fails the test rather
+   than hanging "make check" forever. */
+#define MAX_POLL 10000000
+
+#define PARTITIONS 4
+#define COUNT 3
+
+static int failures = 0;
+
+static void check(int condition, const char *msg)
+{
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        ++failures;
+    }
+}
+
+/* Verify that MPI_Parrived succeeded and returned the expected flag. */
+static void check_parrived(int rc, int flag, int expected, const char *msg)
+{
+    if (MPI_SUCCESS != rc) {
+        char estr[MPI_MAX_ERROR_STRING];
+        int elen;
+        MPI_Error_string(rc, estr, &elen);
+        fprintf(stderr, "FAIL: %s: MPI_Parrived returned '%s' (expected "
+                "MPI_SUCCESS)\n", msg, estr);
+        ++failures;
+    } else if (!!flag != !!expected) {
+        fprintf(stderr, "FAIL: %s: MPI_Parrived returned flag=%s (expected "
+                "%s)\n", msg, flag ? "true" : "false",
+                expected ? "true" : "false");
+        ++failures;
+    }
+}
+
+/* Read the mpi_param_check MCA variable through MPI_T.  Assume checking
+   is enabled if it cannot be read (that is the default). */
+static int param_check_enabled(void)
+{
+    int provided, num_cvar, i, enabled = 1;
+
+    if (MPI_SUCCESS != MPI_T_init_thread(MPI_THREAD_SINGLE, &provided)) {
+        return enabled;
+    }
+    if (MPI_SUCCESS != MPI_T_cvar_get_num(&num_cvar)) {
+        MPI_T_finalize();
+        return enabled;
+    }
+
+    for (i = 0; i < num_cvar; ++i) {
+        char name[128];
+        int name_len = (int) sizeof(name);
+        int desc_len = 0;
+        int verbosity, bind, scope, count;
+        MPI_Datatype datatype;
+        MPI_T_enum enumtype;
+        MPI_T_cvar_handle handle;
+        int value;
+
+        if (MPI_SUCCESS != MPI_T_cvar_get_info(i, name, &name_len, &verbosity,
+                                               &datatype, &enumtype, NULL,
+                                               &desc_len, &bind, &scope)) {
+            continue;
+        }
+        if (0 != strcmp(name, "mpi_param_check") || MPI_INT != datatype) {
+            continue;
+        }
+        if (MPI_SUCCESS == MPI_T_cvar_handle_alloc(i, NULL, &handle, &count)) {
+            if (1 == count && MPI_SUCCESS == MPI_T_cvar_read(handle, &value)) {
+                enabled = value;
+            }
+            MPI_T_cvar_handle_free(&handle);
+        }
+        break;
+    }
+
+    MPI_T_finalize();
+
+    return enabled;
+}
+
+int main(int argc, char *argv[])
+{
+    double sendbuf[PARTITIONS * COUNT];
+    double recvbuf[PARTITIONS * COUNT];
+    MPI_Request sreq = MPI_REQUEST_NULL;
+    MPI_Request rreq = MPI_REQUEST_NULL;
+    int i, j, flag, rc;
+
+    MPI_Init(&argc, &argv);
+
+    /* Report errors instead of aborting, so that a non-conformant
+       MPI_ERR_REQUEST is counted as a test failure. */
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+    MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_RETURN);
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        sendbuf[i] = (double) i;
+        recvbuf[i] = -1.0;
+    }
+
+    /* Case 1: a null request is trivially arrived.  MPI_Parrived may be
+       called more than once for a partition, so call it twice. */
+    if (param_check_enabled()) {
+        for (i = 0; i < 2; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(MPI_REQUEST_NULL, 0, &flag);
+            check_parrived(rc, flag, 1, "null request");
+        }
+    } else {
+        printf("SKIP: null request (MPI parameter checking is disabled)\n");
+    }
+
+    /* Case 2: an inactive (initialized but never started) partitioned
+       receive request is trivially arrived. */
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &rreq);
+    check(MPI_SUCCESS == rc, "MPI_Precv_init failed");
+    if (MPI_SUCCESS == rc) {
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_parrived(rc, flag, 1, "never-started inactive request");
+        }
+        MPI_Request_free(&rreq);
+    }
+
+    /* Cases 3 and 4: an active partitioned receive must report per-
+       partition arrival, and the same request must again report arrived
+       once it has completed and returned to the inactive state.
+
+       Send to and receive from MPI_COMM_SELF: matching is by the order in
+       which the initialization calls are made (MPI-5.0 section 4.2.3). */
+    rc = MPI_Psend_init(sendbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &sreq);
+    check(MPI_SUCCESS == rc, "MPI_Psend_init failed");
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, 0, 1,
+                        MPI_COMM_SELF, MPI_INFO_NULL, &rreq);
+    check(MPI_SUCCESS == rc, "MPI_Precv_init failed");
+
+    if (0 == failures) {
+        MPI_Start(&sreq);
+        MPI_Start(&rreq);
+
+        /* Case 3a: no partition has been marked ready yet, so no
+           partition can have arrived. */
+        flag = 1;
+        rc = MPI_Parrived(rreq, 0, &flag);
+        check_parrived(rc, flag, 0, "active request, no MPI_Pready yet");
+
+        /* Case 3b: mark the send partitions ready one at a time; each
+           must eventually arrive on the receive side (MPI-5.0 section
+           4.2.2: "Repeated calls to MPI_PARRIVED ... will eventually
+           return flag = true"). */
+        for (i = 0; i < PARTITIONS; ++i) {
+            rc = MPI_Pready(i, sreq);
+            check(MPI_SUCCESS == rc, "MPI_Pready failed");
+
+            flag = 0;
+            for (j = 0; j < MAX_POLL && !flag; ++j) {
+                rc = MPI_Parrived(rreq, i, &flag);
+                if (MPI_SUCCESS != rc) {
+                    break;
+                }
+            }
+            check_parrived(rc, flag, 1, "active request, partition ready");
+        }
+
+        MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+        MPI_Wait(&rreq, MPI_STATUS_IGNORE);
+
+        for (i = 0; i < PARTITIONS * COUNT; ++i) {
+            check(recvbuf[i] == (double) i, "received wrong data");
+        }
+
+        /* Case 4: the operation completed, so the request is inactive
+           again -- but, unlike case 2, it has been started before.  It
+           must still report arrived. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_parrived(rc, flag, 1, "completed, reset inactive request");
+        }
+    }
+
+    MPI_Request_free(&sreq);
+    MPI_Request_free(&rreq);
+
+    if (0 == failures) {
+        printf("PASS: parrived_null_inactive\n");
+    }
+
+    MPI_Finalize();
+
+    return failures ? 1 : 0;
+}

--- a/test/part/partitioned_proc_null.c
+++ b/test/part/partitioned_proc_null.c
@@ -1,0 +1,168 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Single-process (no launcher required) regression test for partitioned
+ * communication with MPI_PROC_NULL.
+ *
+ * MPI-5.0 section 3.10 (p.110) states:
+ *
+ *   "The special value MPI_PROC_NULL can be used instead of a rank
+ *    wherever a source or a destination argument is required in a call.
+ *    A communication with MPI_PROC_NULL has no effect.  A send to
+ *    MPI_PROC_NULL succeeds and returns as soon as possible.  A receive
+ *    from MPI_PROC_NULL succeeds and returns as soon as possible with no
+ *    modifications to the receive buffer.  When a receive with source =
+ *    MPI_PROC_NULL is executed then the status object returns source =
+ *    MPI_PROC_NULL, tag = MPI_ANY_TAG and count = 0."
+ *
+ * MPI_Psend_init and MPI_Precv_init take dest and source arguments, so
+ * MPI_PROC_NULL is valid for both.  Open MPI used to pass MPI_PROC_NULL
+ * straight through to the PML as if it were a real peer rank, which read
+ * past the start of the communicator's process array.
+ */
+
+#include <stdio.h>
+
+#include "mpi.h"
+
+#define PARTITIONS 4
+#define COUNT 3
+
+static int failures = 0;
+
+static void check(int condition, const char *msg)
+{
+    if (!condition) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        ++failures;
+    }
+}
+
+static void check_rc(int rc, const char *msg)
+{
+    if (MPI_SUCCESS != rc) {
+        char estr[MPI_MAX_ERROR_STRING];
+        int elen;
+        MPI_Error_string(rc, estr, &elen);
+        fprintf(stderr, "FAIL: %s returned '%s' (expected MPI_SUCCESS)\n",
+                msg, estr);
+        ++failures;
+    }
+}
+
+/* An MPI_PROC_NULL receive must leave the buffer untouched. */
+static void check_untouched(const double *buf, const char *msg)
+{
+    int i;
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        if (buf[i] != -1.0) {
+            fprintf(stderr, "FAIL: %s: receive buffer was modified\n", msg);
+            ++failures;
+            return;
+        }
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    double sendbuf[PARTITIONS * COUNT];
+    double recvbuf[PARTITIONS * COUNT];
+    MPI_Request sreq = MPI_REQUEST_NULL;
+    MPI_Request rreq = MPI_REQUEST_NULL;
+    MPI_Status status;
+    int i, flag, rc, count;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    for (i = 0; i < PARTITIONS * COUNT; ++i) {
+        sendbuf[i] = (double) i;
+        recvbuf[i] = -1.0;
+    }
+
+    /* Both of these must succeed rather than reaching the PML with
+       MPI_PROC_NULL as a peer rank. */
+    rc = MPI_Psend_init(sendbuf, PARTITIONS, COUNT, MPI_DOUBLE, MPI_PROC_NULL,
+                        1, MPI_COMM_WORLD, MPI_INFO_NULL, &sreq);
+    check_rc(rc, "MPI_Psend_init(MPI_PROC_NULL)");
+    rc = MPI_Precv_init(recvbuf, PARTITIONS, COUNT, MPI_DOUBLE, MPI_PROC_NULL,
+                        1, MPI_COMM_WORLD, MPI_INFO_NULL, &rreq);
+    check_rc(rc, "MPI_Precv_init(MPI_PROC_NULL)");
+
+    if (0 == failures) {
+        /* An inactive request is trivially arrived (MPI-5.0 sec 4.2.2). */
+        flag = 0;
+        rc = MPI_Parrived(rreq, 0, &flag);
+        check_rc(rc, "MPI_Parrived (inactive, MPI_PROC_NULL)");
+        check(flag, "inactive MPI_PROC_NULL request: expected flag = true");
+
+        rc = MPI_Start(&sreq);
+        check_rc(rc, "MPI_Start (MPI_PROC_NULL send)");
+        rc = MPI_Start(&rreq);
+        check_rc(rc, "MPI_Start (MPI_PROC_NULL receive)");
+
+        /* Marking partitions ready has no effect, but must succeed. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            rc = MPI_Pready(i, sreq);
+            check_rc(rc, "MPI_Pready (MPI_PROC_NULL)");
+        }
+        rc = MPI_Pready_range(0, PARTITIONS - 1, sreq);
+        check_rc(rc, "MPI_Pready_range (MPI_PROC_NULL)");
+        {
+            int list[PARTITIONS];
+            for (i = 0; i < PARTITIONS; ++i) {
+                list[i] = i;
+            }
+            rc = MPI_Pready_list(PARTITIONS, list, sreq);
+            check_rc(rc, "MPI_Pready_list (MPI_PROC_NULL)");
+        }
+
+        /* A receive from MPI_PROC_NULL "succeeds ... as soon as possible":
+           every partition is arrived, without any peer ever sending. */
+        for (i = 0; i < PARTITIONS; ++i) {
+            flag = 0;
+            rc = MPI_Parrived(rreq, i, &flag);
+            check_rc(rc, "MPI_Parrived (active, MPI_PROC_NULL)");
+            check(flag, "active MPI_PROC_NULL request: expected flag = true");
+        }
+
+        /* Completion must not block: there is no peer. */
+        rc = MPI_Wait(&sreq, MPI_STATUS_IGNORE);
+        check_rc(rc, "MPI_Wait (MPI_PROC_NULL send)");
+
+        status.MPI_SOURCE = 0;
+        status.MPI_TAG = 0;
+        rc = MPI_Wait(&rreq, &status);
+        check_rc(rc, "MPI_Wait (MPI_PROC_NULL receive)");
+
+        /* MPI-5.0 sec 3.10: source = MPI_PROC_NULL, tag = MPI_ANY_TAG,
+           count = 0, and the receive buffer is not modified. */
+        check(MPI_PROC_NULL == status.MPI_SOURCE,
+              "expected status.MPI_SOURCE = MPI_PROC_NULL");
+        check(MPI_ANY_TAG == status.MPI_TAG,
+              "expected status.MPI_TAG = MPI_ANY_TAG");
+        rc = MPI_Get_count(&status, MPI_DOUBLE, &count);
+        check_rc(rc, "MPI_Get_count");
+        check(0 == count, "expected status count = 0");
+        check_untouched(recvbuf, "MPI_PROC_NULL receive");
+    }
+
+    MPI_Request_free(&sreq);
+    MPI_Request_free(&rreq);
+
+    if (0 == failures) {
+        printf("PASS: partitioned_proc_null\n");
+    }
+
+    MPI_Finalize();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Backport of PR #14155 to v5.0.x — partitioned communication correctness fixes

Backports three commits from PR #14155 (merged to main) to v5.0.x. Each commit is a standalone correctness or conformance fix for partitioned communication. Companion to issue #14157.

Commit 1 — part/persist: cancel the setup handshake when freeing a request

MPI_Psend_init/MPI_Precv_init post a receive for peer setup info on the user's communicator/peer/tag into a buffer inside the request object. Freeing a never-started request left that receive posted against freed memory. Because it was posted on the user's communicator/peer/tag, it would match the setup message of the next partitioned operation using the same communicator/peer/tag, causing that operation to never initialize, MPI_Parrived to never report arrival, and MPI_Wait to deadlock. Fixed by cancelling the setup receive in mca_part_persist_free().

Commit 2 — Fix MPI_Parrived for null and inactive requests

Refines the null/inactive fix landed in #14103. The previous fix returned early before the request-type check; this version correctly rejects non-partitioned inactive requests with MPI_ERR_REQUEST while still returning flag = true for null and inactive partitioned requests, as required by MPI-5.0 §4.2.2. Also adds MPI_ERR_ARG for a NULL flag argument. Includes a single-process regression test (parrived_null_inactive) that runs under make check.

Commit 3 — Support MPI_PROC_NULL in partitioned communication

MPI_Psend_init/MPI_Precv_init passed MPI_PROC_NULL straight to the PML, which indexed at offset -2 into the communicator's process array — undefined behavior. Fixed in the bindings (as MPI_Send_init/MPI_Recv_init already do) by returning a persistent no-op request. MPI_Pready, MPI_Pready_range, MPI_Pready_list, and MPI_Parrived are updated to accept such requests unconditionally. Includes a single-process regression test (partitioned_proc_null) that runs under make check.

v5.0.x adaptation notes: main uses .c.in binding templates; v5.0.x uses plain .c files — changes applied directly. Tests placed in test/part/ (matching v5.0.x layout) rather than ompi/test/part/. New test subdir wired into configure.ac and test/Makefile.am.

bot:notacherrypick