### PR TITLE
CI: bound each example run with mpirun --timeout

### DIFF
--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -139,6 +139,12 @@ jobs:
         # extension (this skips sources, Makefiles, and macOS .dSYM
         # bundles).  OpenSHMEM examples are launched with oshrun; all
         # others with mpirun.
+        #
+        # Every example should finish in seconds.  The launcher-level
+        # --timeout turns a hung example (e.g., a rank deadlocked in a
+        # PMIx fence, issue #14125) into a prompt failure of that one
+        # example instead of stalling the job until the 6-hour GitHub
+        # runner timeout kills it.
         for exe in *; do
           [ -f "$exe" ] && [ -x "$exe" ] || continue
           case "$exe" in *.*) continue ;; esac
@@ -147,7 +153,7 @@ jobs:
             *)                 launcher=mpirun ;;
           esac
           echo "==== Running $exe (via $launcher) ===="
-          if ! "$launcher" --map-by ppr:1:core "./$exe"; then
+          if ! "$launcher" --timeout 300 --map-by ppr:1:core "./$exe"; then
             echo "==== $exe FAILED"
             status=1
           fi


### PR DESCRIPTION
A hung example previously stalled the "Run all built examples" step of the PR-builds workflow until GitHub's 6-hour job timeout killed the runner, burning an enormous amount of runner time for zero diagnostic value.  The most recent instance: the macOS hang of hello_sessions_c on PR #14288 (a symptom of the Sessions init/finalize fence race in issue #14125).

This change passes --timeout 300 to the launcher so that a wedged example is aborted by mpirun/oshrun itself after 5 minutes with a clear "time limit reached" message and a non-zero exit status; the step then reports that one example as FAILED and still runs the remaining examples.  Every example normally completes in seconds, so 300 seconds leaves a wide margin for slow, loaded runners.

Related to #14125.