### PR TITLE
fbtl/posix: fix aio slot handling and error propagation

### DIFF
--- a/ompi/mca/common/ompio/common_ompio_file_read.c
+++ b/ompi/mca/common/ompio/common_ompio_file_read.c
@@ -509,7 +509,19 @@ int mca_common_ompio_file_iread (ompio_file_t *fh,
                                              &tbr, &spc,
                                              &fh->f_io_array, &fh->f_num_of_io_entries);
 
-            fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
+            ssize_t fbtl_ret = fh->f_fbtl->fbtl_ipreadv (fh, (ompi_request_t *) ompio_req);
+            if (0 > fbtl_ret) {
+                /* The fbtl operation failed synchronously, before it
+                   could attach a progress function to the request. If we
+                   left the request as-is, ompio progress would treat it
+                   as a completed parent request and finish it with an
+                   uninitialized MPI_ERROR. Complete it here with an error
+                   status instead. */
+                ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
+                ompio_req->req_ompi.req_status._ucount = 0;
+                ompi_request_complete (&ompio_req->req_ompi, false);
+                ret = OMPI_ERROR;
+            }
         }
     }
     else {

--- a/ompi/mca/common/ompio/common_ompio_file_write.c
+++ b/ompi/mca/common/ompio/common_ompio_file_write.c
@@ -453,7 +453,19 @@ int mca_common_ompio_file_iwrite (ompio_file_t *fh,
 					     &i, &total_bytes_written, &spc,
 					     &fh->f_io_array, &fh->f_num_of_io_entries);
 
-            fh->f_fbtl->fbtl_ipwritev (fh, (ompi_request_t *) ompio_req);
+            ssize_t fbtl_ret = fh->f_fbtl->fbtl_ipwritev (fh, (ompi_request_t *) ompio_req);
+            if (0 > fbtl_ret) {
+                /* The fbtl operation failed synchronously, before it
+                   could attach a progress function to the request. If we
+                   left the request as-is, ompio progress would treat it
+                   as a completed parent request and finish it with an
+                   uninitialized MPI_ERROR. Complete it here with an error
+                   status instead. */
+                ompio_req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
+                ompio_req->req_ompi.req_status._ucount = 0;
+                ompi_request_complete (&ompio_req->req_ompi, false);
+                ret = OMPI_ERROR;
+            }
         }
     } else {
         // This fbtl does not support non-blocking write operations

--- a/ompi/mca/fbtl/posix/fbtl_posix.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix.c
@@ -28,12 +28,16 @@
  */
 
 #include "ompi_config.h"
+#include "opal/opal_portable_platform.h"
 #include "mpi.h"
 
 #include <unistd.h>
 #include <sys/uio.h>
 #if HAVE_AIO_H
 #include <aio.h>
+#endif
+#if defined(PLATFORM_OS_DARWIN) && defined(HAVE_SYS_SYSCTL_H)
+#include <sys/sysctl.h>
 #endif
 
 int ompi_fbtl_posix_max_prd_active_reqs=2048;
@@ -104,10 +108,24 @@ int mca_fbtl_posix_component_file_unquery (ompio_file_t *file) {
 int mca_fbtl_posix_module_init (ompio_file_t *file) {
 
 #if defined (FBTL_POSIX_HAVE_AIO)
+#if defined(PLATFORM_OS_DARWIN) && defined(HAVE_SYS_SYSCTL_H)
+    /* On Darwin, sysconf(_SC_AIO_MAX) reports kern.aiomax, the limit on
+     * the number of outstanding aio requests across the entire machine.
+     * A single process is instead capped by kern.aioprocmax, which is
+     * much smaller. Submitting more than kern.aioprocmax requests at
+     * once fails with EAGAIN, so use the per-process limit here. */
+    int aioprocmax = 0;
+    size_t len = sizeof(aioprocmax);
+    if ( 0 == sysctlbyname("kern.aioprocmax", &aioprocmax, &len, NULL, 0) &&
+         0 < aioprocmax ) {
+        ompi_fbtl_posix_max_prd_active_reqs = aioprocmax;
+    }
+#else
     long val = sysconf(_SC_AIO_MAX);
     if ( -1 != val ) {
         ompi_fbtl_posix_max_prd_active_reqs = (int)val;
     }
+#endif
 #endif
     return OMPI_SUCCESS;
 }
@@ -190,8 +208,14 @@ bool mca_fbtl_posix_progress ( mca_ompio_request_t *req)
                 continue;
             }
             else {
-                /* an error occurred. Mark the request done, but
-                   set an error code in the status */
+                /* an error occurred. Call aio_return to release the
+                   resources associated with this aio request; without
+                   it the per-process aio slot is never freed. The
+                   return value is expected to be -1 here, since the
+                   operation failed (aio_error returned a real error),
+                   so we discard it. Mark the request done and set an
+                   error code in the status */
+                (void) aio_return ( &data->prd_aio.aio_reqs[i] );
                 req->req_ompi.req_status.MPI_ERROR = OMPI_ERROR;
                 req->req_ompi.req_status._ucount = data->prd_total_len;
                 ret = true;

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipreadv.c
@@ -114,15 +114,47 @@ ssize_t mca_fbtl_posix_ipreadv (ompio_file_t *fh,
 
     for (i=0; i < data->prd_last_active_req; i++) {
         int counter=0;
-        while ( MAX_ATTEMPTS > counter ) { 
+        while ( MAX_ATTEMPTS > counter ) {
             if  ( -1 != aio_read(&data->prd_aio.aio_reqs[i]) ) {
                 break;
             }
             counter++;
+            /* aio_read can fail transiently when the process is out of
+               aio slots (EAGAIN). Drive ompio progress here so that other
+               pending ompio requests can reap their completed operations
+               (via their req_progress_fn) and release slots, giving this
+               retry a chance to succeed. Note this cannot reap this
+               request's own already-posted operations: its req_progress_fn
+               is not assigned until after this submission loop completes. */
             mca_common_ompio_progress();
         }
         if ( MAX_ATTEMPTS == counter ) {
+           /* If aio_read failed because the process ran out of aio
+              slots (EAGAIN) but we have already queued at least one
+              request in this batch, then 'i' is the true per-process
+              limit. Shrink the batch size accordingly and stop posting;
+              the progress function will reap these operations and post
+              the remaining requests in subsequent batches. */
+           if ( EAGAIN == errno && i > data->prd_first_active_req ) {
+               data->prd_req_chunks      = i;
+               data->prd_last_active_req = i;
+               break;
+           }
            opal_output(1, "mca_fbtl_posix_ipreadv: error in aio_read(): errno %d %s", errno, strerror(errno));
+           /* Release the aio requests that were already posted in this
+              batch before the error. The aiocb array is freed below, so
+              each outstanding operation must first be canceled, drained
+              to completion, and reaped with aio_return; otherwise the
+              kernel could touch freed memory and the per-process aio
+              slots would leak. */
+           for ( int j=data->prd_first_active_req; j < i; j++ ) {
+               (void) aio_cancel(data->prd_aio.aio_reqs[j].aio_fildes,
+                                 &data->prd_aio.aio_reqs[j]);
+               while ( EINPROGRESS == aio_error(&data->prd_aio.aio_reqs[j]) ) {
+                   mca_common_ompio_progress();
+               }
+               (void) aio_return(&data->prd_aio.aio_reqs[j]);
+           }
            mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
            free(data->prd_aio.aio_reqs);
            free(data->prd_aio.aio_req_status);

--- a/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
+++ b/ompi/mca/fbtl/posix/fbtl_posix_ipwritev.c
@@ -117,10 +117,42 @@ ssize_t  mca_fbtl_posix_ipwritev (ompio_file_t *fh,
                 break;
             }
             counter++;
+            /* aio_write can fail transiently when the process is out of
+               aio slots (EAGAIN). Drive ompio progress here so that other
+               pending ompio requests can reap their completed operations
+               (via their req_progress_fn) and release slots, giving this
+               retry a chance to succeed. Note this cannot reap this
+               request's own already-posted operations: its req_progress_fn
+               is not assigned until after this submission loop completes. */
             mca_common_ompio_progress();
         }
         if ( MAX_ATTEMPTS == counter ) {
+            /* If aio_write failed because the process ran out of aio
+               slots (EAGAIN) but we have already queued at least one
+               request in this batch, then 'i' is the true per-process
+               limit. Shrink the batch size accordingly and stop posting;
+               the progress function will reap these operations and post
+               the remaining requests in subsequent batches. */
+            if ( EAGAIN == errno && i > data->prd_first_active_req ) {
+                data->prd_req_chunks      = i;
+                data->prd_last_active_req = i;
+                break;
+            }
             opal_output(1, "mca_fbtl_posix_ipwritev: error in aio_write():  %s", strerror(errno));
+            /* Release the aio requests that were already posted in this
+               batch before the error. The aiocb array is freed below, so
+               each outstanding operation must first be canceled, drained
+               to completion, and reaped with aio_return; otherwise the
+               kernel could touch freed memory and the per-process aio
+               slots would leak. */
+            for ( int j=data->prd_first_active_req; j < i; j++ ) {
+                (void) aio_cancel(data->prd_aio.aio_reqs[j].aio_fildes,
+                                  &data->prd_aio.aio_reqs[j]);
+                while ( EINPROGRESS == aio_error(&data->prd_aio.aio_reqs[j]) ) {
+                    mca_common_ompio_progress();
+                }
+                (void) aio_return(&data->prd_aio.aio_reqs[j]);
+            }
             mca_fbtl_posix_unlock ( &data->prd_lock, data->prd_fh, &data->prd_lock_counter);
             free(data->prd_aio.aio_req_status);
             free(data->prd_aio.aio_reqs);


### PR DESCRIPTION
Several related fixes to the non-blocking POSIX fbtl aio path, most of which surface as failures or silent data loss on macOS but also harden behavior under aio slot exhaustion on any platform.

On Darwin, sysconf(_SC_AIO_MAX) reports kern.aiomax, the machine-wide limit on outstanding aio requests, rather than the per-process limit. A single process is capped by kern.aioprocmax, which is much smaller. As a result the initial batch size was set far too high and the first oversized batch of aio_write/aio_read calls failed with EAGAIN. Query kern.aioprocmax via sysctl on Darwin and use that as the per-process limit; other platforms keep using sysconf(_SC_AIO_MAX), which is POSIX-conformant.

When an aio operation completes with an error, call aio_return so the per-process aio slot is released. Without it the slot was leaked for the lifetime of the process.

In the submission path, if aio_write/aio_read exhausts its retries with EAGAIN after at least one request in the batch was already queued, treat that count as the true per-process limit: shrink the batch size and let the progress function reap the posted operations and submit the rest in later batches, instead of failing the whole request. On the remaining hard-error paths, cancel, drain, and reap any operations already posted in the batch before freeing the aiocb array, avoiding both a use-after-free and a slot leak.

Finally, capture the return value of the fbtl ipwritev/ipreadv call in mca_common_ompio_file_iwrite/iread. Previously the return value was discarded, so a synchronous fbtl failure left the request without a progress function. ompio progress then misclassified it as a completed parent request and finished it with an uninitialized MPI_ERROR, which frequently read back as MPI_SUCCESS. Complete the request with an error status when the fbtl call fails synchronously.

Fixes: #14278