### PR TITLE
Fix a typo and change async modex default

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -651,7 +651,7 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
                 if (PMIX_SUCCESS != rc) {
                     active = false;
                     if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -543,7 +543,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
                 if (PMIX_SUCCESS != rc) {
                     active = false;
                     if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -5,6 +5,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
 
 bool opal_pmix_collect_all_data = true;
 int opal_pmix_verbose_output = -1;
-bool opal_pmix_base_async_modex = false;
+bool opal_pmix_base_async_modex = true;
 opal_pmix_base_t opal_pmix_base = {.timeout = 0,
                                    .initialized = 0,
                                    .lock = {.mutex = OPAL_MUTEX_STATIC_INIT,
@@ -44,7 +45,7 @@ opal_pmix_base_t opal_pmix_base = {.timeout = 0,
 
 static int opal_pmix_base_frame_register(mca_base_register_flag_t flags)
 {
-    opal_pmix_base_async_modex = false;
+    opal_pmix_base_async_modex = true;
     (void) mca_base_var_register("opal", "pmix", "base", "async_modex",
                                  "Use asynchronous modex mode", MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,


### PR DESCRIPTION
The fence code in ompi_mpi_init correctly loaded a pmix_info_t, and then promptly forgot to include it in the PMIx_Fence_nb call, thereby losing the collect_data flag setting.

Change the default async_modex flag from false to true. There is no known reason to conduct a synchronous modex. We could just remove it altogether, but at least switching the default flag value is a reasonable first step.