### PR TITLE
mpi: implement MPI_Get_hw_resource_info version two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -536,6 +536,7 @@ test/runtime/orte_init_finalize
 test/threads/opal_condition
 test/threads/opal_thread
 test/threads/opal_atomic_thread_bench
+test/mpi/environment/hw_resource_info
 
 test/util/aaa
 test/util/test_session_dir_out

--- a/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
@@ -60,7 +60,8 @@ For ``MPI_COMM_TYPE_HW_GUIDED`` and ``MPI_COMM_TYPE_RESOURCE_GUIDED``,
 ``mpi_hw_resource_type`` accepts the hwloc URI values returned by
 :ref:`MPI_Get_hw_resource_info`: ``hwloc://NUMANode``,
 ``hwloc://Package``, ``hwloc://L3Cache``, ``hwloc://L2Cache``,
-``hwloc://L1Cache``, ``hwloc://Core``, and ``hwloc://PU``. The existing
+``hwloc://L1Cache``, ``hwloc://Core``, and ``hwloc://PU``. Open MPI also
+accepts ``hwloc://Machine`` (host). The existing
 Open MPI-specific values ``numanode``, ``socket``, ``l3cache``, ``l2cache``,
 ``l1cache``, ``core``, and ``hwthread`` are also accepted.
 

--- a/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
+++ b/docs/man-openmpi/man3/MPI_Comm_split_type.3.rst
@@ -56,6 +56,19 @@ MPI_COMM_TYPE_RESOURCE_GUIDED
    to the resource type specified by the ``mpi_hw_resource_type``
    or ``mpi_pset_name`` info key.
 
+For ``MPI_COMM_TYPE_HW_GUIDED`` and ``MPI_COMM_TYPE_RESOURCE_GUIDED``,
+``mpi_hw_resource_type`` accepts the hwloc URI values returned by
+:ref:`MPI_Get_hw_resource_info`: ``hwloc://NUMANode``,
+``hwloc://Package``, ``hwloc://L3Cache``, ``hwloc://L2Cache``,
+``hwloc://L1Cache``, ``hwloc://Core``, and ``hwloc://PU``. The existing
+Open MPI-specific values ``numanode``, ``socket``, ``l3cache``, ``l2cache``,
+``l1cache``, ``core``, and ``hwthread`` are also accepted.
+
+For a ``hwloc://`` URI value, Open MPI queries each process's current CPU binding.
+A process whose binding is unavailable or spans multiple instances of the
+requested resource receives ``MPI_COMM_NULL``. Other processes are grouped by
+the specific resource instance containing their binding.
+
 OMPI_COMM_TYPE_NODE
    Synonym for MPI_COMM_TYPE_SHARED.
 
@@ -130,3 +143,4 @@ ERRORS
    * :ref:`MPI_Comm_dup`
    * :ref:`MPI_Comm_free`
    * :ref:`MPI_Comm_split`
+   * :ref:`MPI_Get_hw_resource_info`

--- a/docs/man-openmpi/man3/MPI_Get_hw_resource_info.3.rst
+++ b/docs/man-openmpi/man3/MPI_Get_hw_resource_info.3.rst
@@ -1,30 +1,107 @@
-.. _mpi_info_get_hw_resource_info:
+.. _mpi_get_hw_resource_info:
 
 
-MPI_Info_get_hw_resource_info
-=============================
+MPI_Get_hw_resource_info
+========================
 
 .. include_body
 
-:ref:`MPI_Info_get_hw_resource_info` |mdash| Returns an info object containing information pertaining to the hardware platform 
-are used.
+:ref:`MPI_Get_hw_resource_info` |mdash| Returns information about the hardware
+resources on which the calling process can execute.
 
 .. The following file was automatically generated
 .. include:: ./bindings/mpi_get_hw_resource_info.rst
 
 OUTPUT PARAMETERS
 -----------------
-* ``info``: Info object created (handle).
+* ``info``: Info object containing local hardware resource information
+  (handle).
 * ``ierror``: Fortran only: Error status (integer).
 
 DESCRIPTION
 -----------
 
-:ref:`MPI_Info_get_hw_resource_info` an info object containing information pertaining to the hardware platform on 
-which the calling \MPI/ process is executing at the moment of the call.  The application is responsible for freeing
-the returned info object using :ref:`MPI_Info_free`.
+:ref:`MPI_Get_hw_resource_info` returns an info object describing hardware
+resource types associated with the calling \MPI/ process at the moment of the
+call. The application is responsible for freeing the returned info object with
+:ref:`MPI_Info_free`.
 
-.. note:: Open MPI currently provides no hardware platform information in the returned ``info`` object.
+Open MPI obtains this information from hwloc. Each key uses the URI form
+``hwloc://<resource-type>``. The value is ``true`` if the calling process is
+restricted to a single instance of that resource type and ``false`` if its CPU
+binding spans multiple instances. Depending on the local topology, the returned
+keys can include:
+
+* ``hwloc://NUMANode``
+* ``hwloc://Package``
+* ``hwloc://L3Cache``
+* ``hwloc://L2Cache``
+* ``hwloc://L1Cache``
+* ``hwloc://Core``
+* ``hwloc://PU``
+
+Resource types absent from the local topology are omitted. Open MPI returns an
+empty info object if hardware topology or process binding information is not
+available. The routine may be called before :ref:`MPI_Init` and after
+:ref:`MPI_Finalize`; Open MPI returns an empty info object outside the active
+MPI lifetime.
+
+The returned keys can be passed as values of the ``mpi_hw_resource_type`` info
+key to :ref:`MPI_Comm_split_type` with ``MPI_COMM_TYPE_HW_GUIDED`` or
+``MPI_COMM_TYPE_RESOURCE_GUIDED``. A process receives ``MPI_COMM_NULL`` if its
+current binding is unavailable or spans multiple instances of the requested
+resource. For example:
+
+.. code-block:: c
+
+  MPI_Info hw_info;
+  MPI_Comm hw_comm;
+  int      nb_keys  = 0, flag = 0;
+  int      is_found = 0, is_restricted = 0; 
+  int      valuelen = 6; // max length between "false" and "true" + 1
+  char    *value    = calloc(valuelen, sizeof(char));
+  char    *hw_type  = calloc((MPI_MAX_INFO_KEY+1), sizeof(char));
+  
+  MPI_Get_hw_resource_info(&hw_info);
+  
+  MPI_Info_get_nkeys(hw_info, &nb_keys);
+  for(int index = 0 ; index < nb_keys ; index++){ 
+    MPI_Info_get_nthkey(hw_info, index, hw_type);
+    MPI_Info_get_string(hw_info, hw_type, &valuelen, value, &flag);     
+    if(strcmp(hw_type, "hwloc://NUMANode") == 0){
+      is_found = 1;
+      if(strcmp(value,"true") == 0)
+        is_restricted = 1; 
+      break; // Resource of type NUMANode found
+    }
+  } 
+
+  // The calling MPI process is restricted to a resource
+  // of the chosen type (NUMANode)
+  if(is_found  && is_restricted){
+    MPI_Info split_info;
+    int rank;
+    
+    MPI_Info_create(&split_info);
+     
+    // hw_type now serves as value for the "mpi_hw_resource_type" key
+    MPI_Info_set(split_info, "mpi_hw_resource_type", hw_type);
+  
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_RESOURCE_GUIDED,
+                        rank, split_info, &hw_comm);
+
+    // Check and use hw_comm from this point if it's a valid
+    // communicator or different from MPI_COMM_SELF or MPI_COMM_WORLD.
+  } else {
+    // If resource is not found or not restricted to it,
+    // the calling MPI process does not participate to the call
+    // hence the use of MPI_UNDEFINED as split_type and
+    // MPI_COMM_NULL is produced as output communicator
+
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_UNDEFINED,
+                        -1, MPI_INFO_NULL, &hw_comm);
+  } 
 
 ERRORS
 ------
@@ -33,3 +110,4 @@ ERRORS
 
 .. seealso::
    * :ref:`MPI_Info_free`
+   * :ref:`MPI_Comm_split_type`

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -36,6 +36,13 @@ Open MPI version v6.1.0
     operation using the same communicator, peer, and tag, which then
     never completed.
 
+- Implemented ``MPI_Get_hw_resource_info()`` using hwloc. The returned
+  info object now reports whether the calling process is restricted to
+  individual NUMA nodes, packages, caches, cores, and processing units.
+  The reported ``hwloc://`` resource keys can also be used with
+  ``MPI_Comm_split_type()`` for hardware- and resource-guided communicator
+  creation. Thanks to Musawer Ahmad Saqif for the contribution.
+
 - Renamed the ``--enable-weak-symbols`` configure option to
   ``--enable-weak-aliases``, which more accurately reflects the linker
   feature (weak symbol *aliases*) that Open MPI actually tests for and

--- a/ompi/communicator/Makefile.am
+++ b/ompi/communicator/Makefile.am
@@ -16,6 +16,7 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2025      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2026      Musawer Ahmad Saqif.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -27,7 +28,8 @@
 
 headers += \
         communicator/communicator.h \
-	communicator/comm_request.h
+        communicator/comm_split_type.h \
+        communicator/comm_request.h
 
 libopen_mpi_la_SOURCES += \
         communicator/comm_init.c \

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -74,7 +74,7 @@
  * topology to test for a MPI_COMM_TYPE_HW_UNGUIDED communicator split. Therefore,
  * the order in this array must be from largest topology class to smallest.
  */
-const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[] = {
+OMPI_DECLSPEC const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[] = {
     {.info_value = "cluster",  .split_type = OMPI_COMM_TYPE_CLUSTER,  .use_for_unguided = false},
     {.info_value = "nvlink",   .split_type = OMPI_COMM_TYPE_NVLINK,   .use_for_unguided = false},
     {.info_value = "cu",       .split_type = OMPI_COMM_TYPE_CU,       .use_for_unguided = true},

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -30,6 +30,7 @@
  * Copyright (c) 2025      BULL S.A.S. All rights reserved.
  * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Musawer Ahmad Saqif.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,6 +39,7 @@
  */
 
 #include "ompi_config.h"
+#include <limits.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -60,40 +62,118 @@
 #include "ompi/attribute/attribute.h"
 #include "ompi/communicator/communicator.h"
 #include "ompi/runtime/ompi_mpit_events.h"
+#include "ompi/communicator/comm_split_type.h"
 #include "ompi/mca/pml/pml.h"
 #include "ompi/request/request.h"
 #include "ompi/info/info_memkind.h"
 
 #include "ompi/runtime/params.h"
 
-struct ompi_comm_split_type_hw_guided_t {
-    const char *info_value;
-    int split_type;
-    bool use_for_unguided;
-};
-typedef struct ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_t;
-
 /*
  * The ompi_comm_split_unguided function uses this array to determine the next
  * topology to test for a MPI_COMM_TYPE_HW_UNGUIDED communicator split. Therefore,
  * the order in this array must be from largest topology class to smallest.
  */
-static const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[] = {
+const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[] = {
     {.info_value = "cluster",  .split_type = OMPI_COMM_TYPE_CLUSTER,  .use_for_unguided = false},
     {.info_value = "nvlink",   .split_type = OMPI_COMM_TYPE_NVLINK,   .use_for_unguided = false},
     {.info_value = "cu",       .split_type = OMPI_COMM_TYPE_CU,       .use_for_unguided = true},
-    {.info_value = "host",     .split_type = OMPI_COMM_TYPE_HOST,     .use_for_unguided = true},
+    {.info_value = "host", .hwloc_uri = "hwloc://Machine",
+     .hwloc_type = HWLOC_OBJ_MACHINE, .split_type = OMPI_COMM_TYPE_HOST,
+     .use_for_unguided = true},
     {.info_value = "mpi_shared_memory", .split_type = MPI_COMM_TYPE_SHARED, .use_for_unguided = true},
     {.info_value = "board",    .split_type = OMPI_COMM_TYPE_BOARD,    .use_for_unguided = true},
-    {.info_value = "numanode", .split_type = OMPI_COMM_TYPE_NUMA,     .use_for_unguided = true},
-    {.info_value = "socket",   .split_type = OMPI_COMM_TYPE_SOCKET,   .use_for_unguided = true},
-    {.info_value = "l3cache",  .split_type = OMPI_COMM_TYPE_L3CACHE,  .use_for_unguided = true},
-    {.info_value = "l2cache",  .split_type = OMPI_COMM_TYPE_L2CACHE,  .use_for_unguided = true},
-    {.info_value = "l1cache",  .split_type = OMPI_COMM_TYPE_L1CACHE,  .use_for_unguided = true},
-    {.info_value = "core",     .split_type = OMPI_COMM_TYPE_CORE,     .use_for_unguided = true},
-    {.info_value = "hwthread", .split_type = OMPI_COMM_TYPE_HWTHREAD, .use_for_unguided = true},
+    {.info_value = "numanode", .hwloc_uri = "hwloc://NUMANode",
+     .hwloc_type = HWLOC_OBJ_NUMANODE, .split_type = OMPI_COMM_TYPE_NUMA,
+     .use_for_unguided = true, .report_in_hw_resource_info = true},
+    {.info_value = "socket", .hwloc_uri = "hwloc://Package",
+     .hwloc_type = HWLOC_OBJ_PACKAGE, .split_type = OMPI_COMM_TYPE_SOCKET,
+     .use_for_unguided = true, .report_in_hw_resource_info = true},
+    {.info_value = "l3cache", .hwloc_uri = "hwloc://L3Cache",
+     .hwloc_type = HWLOC_OBJ_L3CACHE, .split_type = OMPI_COMM_TYPE_L3CACHE,
+     .use_for_unguided = true, .report_in_hw_resource_info = true},
+    {.info_value = "l2cache", .hwloc_uri = "hwloc://L2Cache",
+     .hwloc_type = HWLOC_OBJ_L2CACHE, .split_type = OMPI_COMM_TYPE_L2CACHE,
+     .use_for_unguided = true, .report_in_hw_resource_info = true},
+    {.info_value = "l1cache", .hwloc_uri = "hwloc://L1Cache",
+     .hwloc_type = HWLOC_OBJ_L1CACHE, .split_type = OMPI_COMM_TYPE_L1CACHE,
+     .use_for_unguided = true, .report_in_hw_resource_info = true},
+    {.info_value = "core", .hwloc_uri = "hwloc://Core", .hwloc_type = HWLOC_OBJ_CORE,
+     .split_type = OMPI_COMM_TYPE_CORE, .use_for_unguided = true,
+     .report_in_hw_resource_info = true},
+    {.info_value = "hwthread", .hwloc_uri = "hwloc://PU", .hwloc_type = HWLOC_OBJ_PU,
+     .split_type = OMPI_COMM_TYPE_HWTHREAD, .use_for_unguided = true,
+     .report_in_hw_resource_info = true},
     {.info_value = NULL},
 };
+
+enum {
+    OMPI_COMM_SPLIT_TYPE_HWLOC_UNKNOWN,
+    OMPI_COMM_SPLIT_TYPE_HWLOC_AVAILABLE,
+    OMPI_COMM_SPLIT_TYPE_HWLOC_UNAVAILABLE
+};
+
+static opal_mutex_t ompi_comm_split_type_hwloc_lock = OPAL_MUTEX_STATIC_INIT;
+static int ompi_comm_split_type_hwloc_status = OMPI_COMM_SPLIT_TYPE_HWLOC_UNKNOWN;
+
+bool ompi_comm_split_type_hwloc_topology_available(void)
+{
+    bool available;
+
+    /*
+     * Singleton processes may not receive a topology from PMIx. Serialize
+     * their first discovery so a second MPI_THREAD_MULTIPLE caller cannot
+     * observe opal_hwloc_topology while hwloc is still loading it.
+     */
+    opal_mutex_lock(&ompi_comm_split_type_hwloc_lock);
+    if (OMPI_COMM_SPLIT_TYPE_HWLOC_UNKNOWN == ompi_comm_split_type_hwloc_status) {
+        if (NULL != opal_hwloc_topology
+            || OPAL_SUCCESS == opal_hwloc_base_get_topology()) {
+            ompi_comm_split_type_hwloc_status = OMPI_COMM_SPLIT_TYPE_HWLOC_AVAILABLE;
+        } else {
+            ompi_comm_split_type_hwloc_status = OMPI_COMM_SPLIT_TYPE_HWLOC_UNAVAILABLE;
+        }
+    }
+    available = OMPI_COMM_SPLIT_TYPE_HWLOC_AVAILABLE == ompi_comm_split_type_hwloc_status;
+    opal_mutex_unlock(&ompi_comm_split_type_hwloc_lock);
+
+    return available;
+}
+
+int ompi_comm_split_type_hwloc_get_process_cpuset(hwloc_cpuset_t cpuset)
+{
+    if (!ompi_comm_split_type_hwloc_topology_available()
+        || 0 != hwloc_get_cpubind(opal_hwloc_topology, cpuset, HWLOC_CPUBIND_PROCESS)
+        || hwloc_bitmap_iszero(cpuset)) {
+        return OMPI_ERR_NOT_FOUND;
+    }
+
+    return OMPI_SUCCESS;
+}
+
+bool ompi_comm_split_type_hwloc_get_object(hwloc_const_cpuset_t cpuset,
+                                           hwloc_obj_type_t type,
+                                           hwloc_obj_t *resource_object)
+{
+    int count = hwloc_get_nbobjs_by_type(opal_hwloc_topology, type);
+    bool has_cpuset = false;
+
+    *resource_object = NULL;
+    for (int i = 0; i < count; ++i) {
+        hwloc_obj_t object = hwloc_get_obj_by_type(opal_hwloc_topology, type, i);
+        if (NULL == object || NULL == object->cpuset || hwloc_bitmap_iszero(object->cpuset)) {
+            continue;
+        }
+
+        has_cpuset = true;
+        if (hwloc_bitmap_isincluded(cpuset, object->cpuset)) {
+            *resource_object = object;
+            break;
+        }
+    }
+
+    return has_cpuset;
+}
 
 static const char * ompi_comm_split_type_to_str(int split_type) {
     for (int i = 0; NULL != ompi_comm_split_type_hw_guided_support[i].info_value; ++i) {
@@ -1447,6 +1527,57 @@ static int ompi_comm_split_unguided(ompi_communicator_t *comm, int split_type, i
 }
 
 /*
+ * Split URI-guided processes by their resource instance at call time. The
+ * temporary shared-memory split makes hwloc logical indexes node-local, and
+ * the second split excludes a process when its live binding is unavailable or
+ * spans more than one instance of the requested resource.
+ */
+static int ompi_comm_split_type_hwloc(ompi_communicator_t *comm,
+                                      const ompi_comm_split_type_hw_guided_t *resource,
+                                      int original_split_type, int key,
+                                      bool need_split, bool no_undefined,
+                                      opal_info_t *info,
+                                      ompi_communicator_t **newcomm)
+{
+    ompi_communicator_t *node_comm = MPI_COMM_NULL;
+    if (NULL == resource) {
+        *newcomm = MPI_COMM_NULL;
+        return OMPI_SUCCESS;
+    }
+
+    int node_split_type = MPI_UNDEFINED == original_split_type
+                              ? MPI_UNDEFINED : MPI_COMM_TYPE_SHARED;
+    int rc = ompi_comm_split_type_core(comm, MPI_COMM_TYPE_SHARED,
+                                       node_split_type, 0, need_split, true,
+                                       no_undefined, info, &node_comm);
+    if (OMPI_SUCCESS != rc || MPI_COMM_NULL == node_comm) {
+        *newcomm = MPI_COMM_NULL;
+        return rc;
+    }
+
+    int color = MPI_UNDEFINED;
+    hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();
+    if (NULL != cpuset
+        && OMPI_SUCCESS == ompi_comm_split_type_hwloc_get_process_cpuset(cpuset)) {
+        hwloc_obj_t object;
+        if (ompi_comm_split_type_hwloc_get_object(cpuset, resource->hwloc_type,
+                                                  &object)
+            && NULL != object && object->logical_index <= (unsigned) INT_MAX) {
+            color = (int) object->logical_index;
+        }
+    }
+
+    rc = ompi_comm_split(node_comm, color, key, newcomm, false);
+
+    if (NULL != cpuset) {
+        hwloc_bitmap_free(cpuset);
+    }
+    ompi_comm_free(&node_comm);
+
+    return rc;
+}
+
+/*
  * ompi_comm_split_type: Performs a communicator split. This function performs initial
  *                       processing to set up a  MPI_COMM_TYPE_HW_GUIDED split and
  *                       validation of input parameters.
@@ -1462,11 +1593,13 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
 {
     bool need_split = false, no_reorder = false, no_undefined = false;
     int inter;
-    int global_split_type, global_orig_split_type, ok[2], tmp[6];
+    int global_split_type, global_orig_split_type, global_hwloc_guided;
+    int ok[3], tmp[8];
     int rc;
     int orig_split_type = split_type;
     int flag;
     opal_cstring_t *value = NULL;
+    const ompi_comm_split_type_hw_guided_t *hwloc_resource = NULL;
 
     /* silence clang warning. newcomm should never be NULL */
     if (OPAL_UNLIKELY(NULL == newcomm)) {
@@ -1497,10 +1630,24 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
          */
         flag = 0;
         for (int i = 0; NULL != ompi_comm_split_type_hw_guided_support[i].info_value; ++i) {
+            bool legacy_match = false;
+            bool uri_match = false;
             if (0 == strncasecmp(value->string,
                                  ompi_comm_split_type_hw_guided_support[i].info_value,
                                  strlen(ompi_comm_split_type_hw_guided_support[i].info_value))) {
+               legacy_match = true;
+            }
+
+            if ((NULL != ompi_comm_split_type_hw_guided_support[i].hwloc_uri) &&
+                             (0 == strcasecmp(value->string,
+                                                ompi_comm_split_type_hw_guided_support[i].hwloc_uri))) {
+                uri_match = true;
+            }
+            if (legacy_match || uri_match) {
                 split_type = ompi_comm_split_type_hw_guided_support[i].split_type;
+                if (uri_match) {
+                    hwloc_resource = &ompi_comm_split_type_hw_guided_support[i];
+                }
                 flag = 1;
                 break;
             }
@@ -1525,8 +1672,10 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
      */
     tmp[4] = split_type;
     tmp[5] = -split_type;
+    tmp[6] = NULL != hwloc_resource;
+    tmp[7] = -tmp[6];
 
-    rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &tmp, 6, MPI_INT, MPI_MAX, comm,
+    rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &tmp, 8, MPI_INT, MPI_MAX, comm,
                                       comm->c_coll->coll_allreduce_module);
     if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
         return rc;
@@ -1534,13 +1683,16 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
 
     global_orig_split_type = tmp[0];
     global_split_type = tmp[4];
+    global_hwloc_guided = tmp[6];
 
-    if (tmp[0] != -tmp[1] || tmp[4] != -tmp[5] || inter) {
+    if (tmp[0] != -tmp[1] || tmp[4] != -tmp[5] || tmp[6] != -tmp[7] || inter) {
         /* at least one rank supplied a different split type check if our split_type is ok */
         ok[0] = (MPI_UNDEFINED == orig_split_type) || global_orig_split_type == orig_split_type;
         ok[1] = (MPI_UNDEFINED == orig_split_type) || global_split_type == split_type;
+        ok[2] = (MPI_UNDEFINED == orig_split_type)
+                || global_hwloc_guided == (NULL != hwloc_resource);
 
-        rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &ok, 2, MPI_INT, MPI_MIN, comm,
+        rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &ok, 3, MPI_INT, MPI_MIN, comm,
                                           comm->c_coll->coll_allreduce_module);
         if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
             return rc;
@@ -1548,14 +1700,14 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
 
         if (inter) {
             /* need an extra allreduce to ensure that all ranks have the same result */
-            rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &ok, 2, MPI_INT, MPI_MIN, comm,
+            rc = comm->c_coll->coll_allreduce (MPI_IN_PLACE, &ok, 3, MPI_INT, MPI_MIN, comm,
                                               comm->c_coll->coll_allreduce_module);
             if (OPAL_UNLIKELY(OMPI_SUCCESS != rc)) {
                 return rc;
             }
         }
 
-        if (OPAL_UNLIKELY(!ok[0] || !ok[1])) {
+        if (OPAL_UNLIKELY(!ok[0] || !ok[1] || !ok[2])) {
             if (0 == ompi_comm_rank(comm)) {
                 opal_info_get(info, "mpi_hw_resource_type", &value, &flag);
                 if (!flag) {
@@ -1585,7 +1737,22 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
         return OMPI_SUCCESS;
     }
 
-    if (MPI_COMM_TYPE_HW_UNGUIDED == global_orig_split_type) {
+    if (global_hwloc_guided) {
+        if (NULL == hwloc_resource) {
+            for (int i = 0;
+                 NULL != ompi_comm_split_type_hw_guided_support[i].info_value; ++i) {
+                if (global_split_type
+                    == ompi_comm_split_type_hw_guided_support[i].split_type
+                    && NULL != ompi_comm_split_type_hw_guided_support[i].hwloc_uri) {
+                    hwloc_resource = &ompi_comm_split_type_hw_guided_support[i];
+                    break;
+                }
+            }
+        }
+        return ompi_comm_split_type_hwloc(comm, hwloc_resource,
+                                          orig_split_type, key, need_split,
+                                          no_undefined, info, newcomm);
+    } else if (MPI_COMM_TYPE_HW_UNGUIDED == global_orig_split_type) {
         /* Handle MPI_COMM_TYPE_HW_UNGUIDED communicator split. */
         return ompi_comm_split_unguided( comm, split_type,
                                          key, need_split, no_reorder,

--- a/ompi/communicator/comm_split_type.h
+++ b/ompi/communicator/comm_split_type.h
@@ -1,0 +1,41 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Musawer Ahmad Saqif.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef OMPI_COMM_SPLIT_TYPE_H
+#define OMPI_COMM_SPLIT_TYPE_H
+
+#include "ompi_config.h"
+
+#include "opal/mca/hwloc/base/base.h"
+
+#include "mpi.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    const char *info_value;
+    const char *hwloc_uri;
+    hwloc_obj_type_t hwloc_type;
+    int split_type;
+    bool use_for_unguided;
+    bool report_in_hw_resource_info;
+} ompi_comm_split_type_hw_guided_t;
+
+extern const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[];
+
+bool ompi_comm_split_type_hwloc_topology_available(void);
+int ompi_comm_split_type_hwloc_get_process_cpuset(hwloc_cpuset_t cpuset);
+bool ompi_comm_split_type_hwloc_get_object(
+    hwloc_const_cpuset_t cpuset, hwloc_obj_type_t type,
+    hwloc_obj_t *resource_object);
+
+END_C_DECLS
+
+#endif /* OMPI_COMM_SPLIT_TYPE_H */

--- a/ompi/communicator/comm_split_type.h
+++ b/ompi/communicator/comm_split_type.h
@@ -28,11 +28,11 @@ typedef struct {
     bool report_in_hw_resource_info;
 } ompi_comm_split_type_hw_guided_t;
 
-extern const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[];
+OMPI_DECLSPEC extern const ompi_comm_split_type_hw_guided_t ompi_comm_split_type_hw_guided_support[];
 
-bool ompi_comm_split_type_hwloc_topology_available(void);
-int ompi_comm_split_type_hwloc_get_process_cpuset(hwloc_cpuset_t cpuset);
-bool ompi_comm_split_type_hwloc_get_object(
+OMPI_DECLSPEC bool ompi_comm_split_type_hwloc_topology_available(void);
+OMPI_DECLSPEC int ompi_comm_split_type_hwloc_get_process_cpuset(hwloc_cpuset_t cpuset);
+OMPI_DECLSPEC bool ompi_comm_split_type_hwloc_get_object(
     hwloc_const_cpuset_t cpuset, hwloc_obj_type_t type,
     hwloc_obj_t *resource_object);
 

--- a/ompi/mpi/c/get_hw_resource_info.c.in
+++ b/ompi/mpi/c/get_hw_resource_info.c.in
@@ -14,6 +14,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2025 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2026      Musawer Ahmad Saqif.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,6 +27,7 @@
 #include "ompi/mpi/c/bindings.h"
 #include "ompi/runtime/params.h"
 #include "ompi/communicator/communicator.h"
+#include "ompi/communicator/comm_split_type.h"
 #include "ompi/errhandler/errhandler.h"
 #include "ompi/info/info.h"
 
@@ -50,16 +52,56 @@ PROTOTYPE ERROR_CLASS get_hw_resource_info(INFO_OUT info)
         }
     }
 
-    /* 
-     * Just allocate an info object.  No resources currently being
-     * specified so just return empty info object.
-     */
-     
     *info = ompi_info_allocate ();
     if (NULL == (*info)) {
         return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM,
                                       FUNC_NAME);
     }
+
+    /*
+     * MPI_Get_hw_resource_info is callable before MPI_Init and after
+     * MPI_Finalize. Return the required info object without consulting OPAL
+     * state outside the active MPI lifetime.
+     */
+    int32_t state = ompi_mpi_state;
+    if (OMPI_MPI_STATE_INIT_COMPLETED != state) {
+        return MPI_SUCCESS;
+    }
+
+    hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();
+    if (NULL == cpuset) {
+        ompi_info_free(info);
+        return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM, FUNC_NAME);
+    }
+
+    if (OMPI_SUCCESS != ompi_comm_split_type_hwloc_get_process_cpuset(cpuset)) {
+        hwloc_bitmap_free(cpuset);
+        return MPI_SUCCESS;
+    }
+
+    for (int i = 0; NULL != ompi_comm_split_type_hw_guided_support[i].info_value; ++i) {
+        const ompi_comm_split_type_hw_guided_t *resource
+            = &ompi_comm_split_type_hw_guided_support[i];
+        if (!resource->report_in_hw_resource_info) {
+            continue;
+        }
+
+        hwloc_obj_t resource_object;
+        if (!ompi_comm_split_type_hwloc_get_object(cpuset, resource->hwloc_type,
+                                                   &resource_object)) {
+            continue;
+        }
+
+        int rc = ompi_info_set(*info, resource->hwloc_uri,
+                               NULL != resource_object ? "true" : "false");
+        if (OMPI_SUCCESS != rc) {
+            hwloc_bitmap_free(cpuset);
+            ompi_info_free(info);
+            return OMPI_ERRHANDLER_NOHANDLE_INVOKE(MPI_ERR_NO_MEM, FUNC_NAME);
+        }
+    }
+
+    hwloc_bitmap_free(cpuset);
 
     return MPI_SUCCESS;
 }

--- a/ompi/test/general/Makefile.am
+++ b/ompi/test/general/Makefile.am
@@ -46,7 +46,8 @@ check_PROGRAMS = \
 	instance \
 	file \
 	message \
-	abi_fortran
+	abi_fortran \
+	hw_resource_info
 
 TESTS = $(check_PROGRAMS)
 
@@ -131,6 +132,10 @@ message_DEPENDENCIES = $(ompi_test_ldadd)
 abi_fortran_SOURCES = abi_fortran.c
 abi_fortran_LDADD = $(ompi_test_ldadd)
 abi_fortran_DEPENDENCIES = $(ompi_test_ldadd)
+
+hw_resource_info_SOURCES = hw_resource_info.c
+hw_resource_info_LDADD = $(ompi_test_ldadd)
+hw_resource_info_DEPENDENCIES = $(ompi_test_ldadd)
 
 # The Fortran attribute test drives the Fortran attribute back-end
 # (ompi_attr_create_keyval_fint / set_fint / get_fint), which is only

--- a/ompi/test/general/hw_resource_info.c
+++ b/ompi/test/general/hw_resource_info.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026      Musawer Ahmad Saqif.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Tests for MPI_Get_hw_resource_info and URI-guided communicator splitting.
+ */
+
+#include "ompi_config.h"
+
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "support.h"
+
+#include "opal/mca/hwloc/hwloc-internal.h"
+
+#include "mpi.h"
+
+#define HW_RESOURCE_THREAD_COUNT 8
+
+static bool get_boolean_value(MPI_Info info, const char *key, bool *value)
+{
+    char string_value[6];
+    int length = sizeof(string_value);
+    int flag = 0;
+    int rc = MPI_Info_get_string(info, key, &length, string_value, &flag);
+    if (MPI_SUCCESS != rc || 0 == flag) {
+        return false;
+    }
+
+    if (0 == strcmp(string_value, "true")) {
+        *value = true;
+        return true;
+    }
+    if (0 == strcmp(string_value, "false")) {
+        *value = false;
+        return true;
+    }
+
+    return false;
+}
+
+static void test_outside_mpi_lifetime(const char *stage)
+{
+    char message[128];
+    MPI_Info info = MPI_INFO_NULL;
+    int rc = MPI_Get_hw_resource_info(&info);
+
+    snprintf(message, sizeof(message), "%s call succeeds", stage);
+    test_verify(message, MPI_SUCCESS == rc && MPI_INFO_NULL != info);
+    if (MPI_SUCCESS != rc || MPI_INFO_NULL == info) {
+        return;
+    }
+
+    int nkeys = -1;
+    rc = MPI_Info_get_nkeys(info, &nkeys);
+    snprintf(message, sizeof(message), "%s call returns empty info", stage);
+    test_verify(message, MPI_SUCCESS == rc && 0 == nkeys);
+
+    rc = MPI_Info_free(&info);
+    snprintf(message, sizeof(message), "%s info can be freed", stage);
+    test_verify(message, MPI_SUCCESS == rc && MPI_INFO_NULL == info);
+}
+
+static void test_uri_split(MPI_Comm comm, const char *key, bool restricted,
+                           int split_type, const char *message)
+{
+    MPI_Info split_info = MPI_INFO_NULL;
+    MPI_Comm split_comm = MPI_COMM_NULL;
+    int rc = MPI_Info_create(&split_info);
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Info_set(split_info, "mpi_hw_resource_type", key);
+    }
+    if (MPI_SUCCESS == rc) {
+        rc = MPI_Comm_split_type(comm, split_type, 0, split_info, &split_comm);
+    }
+
+    test_verify(message, MPI_SUCCESS == rc
+                             && (restricted
+                                     ? MPI_COMM_NULL != split_comm
+                                     : MPI_COMM_NULL == split_comm));
+
+    if (MPI_COMM_NULL != split_comm) {
+        MPI_Comm_free(&split_comm);
+    }
+    if (MPI_INFO_NULL != split_info) {
+        MPI_Info_free(&split_info);
+    }
+}
+
+typedef struct {
+    int get_rc;
+    int nkeys_rc;
+    int nkeys;
+    int free_rc;
+    bool valid_info;
+} hw_resource_thread_result_t;
+
+static atomic_bool hw_resource_threads_start = false;
+
+static void *test_thread_get_hw_resource_info(void *context)
+{
+    hw_resource_thread_result_t *result = context;
+    MPI_Info info = MPI_INFO_NULL;
+
+    while (!atomic_load_explicit(&hw_resource_threads_start, memory_order_acquire)) {
+        sched_yield();
+    }
+
+    result->get_rc = MPI_Get_hw_resource_info(&info);
+    result->valid_info = MPI_INFO_NULL != info;
+    if (MPI_SUCCESS == result->get_rc && result->valid_info) {
+        result->nkeys_rc = MPI_Info_get_nkeys(info, &result->nkeys);
+        result->free_rc = MPI_Info_free(&info);
+    }
+
+    return NULL;
+}
+
+static void test_thread_multiple_calls(int provided)
+{
+    if (MPI_THREAD_MULTIPLE != provided) {
+        test_comment("MPI_THREAD_MULTIPLE unavailable; concurrent query test skipped");
+        return;
+    }
+
+    pthread_t threads[HW_RESOURCE_THREAD_COUNT];
+    hw_resource_thread_result_t results[HW_RESOURCE_THREAD_COUNT] = {0};
+    bool created[HW_RESOURCE_THREAD_COUNT] = {false};
+
+    for (int i = 0; i < HW_RESOURCE_THREAD_COUNT; ++i) {
+        results[i].get_rc = MPI_ERR_OTHER;
+        results[i].nkeys_rc = MPI_ERR_OTHER;
+        results[i].nkeys = -1;
+        results[i].free_rc = MPI_ERR_OTHER;
+        int rc = pthread_create(&threads[i], NULL, test_thread_get_hw_resource_info,
+                                &results[i]);
+        created[i] = 0 == rc;
+        test_verify("hardware query thread can be created", created[i]);
+    }
+
+    atomic_store_explicit(&hw_resource_threads_start, true, memory_order_release);
+
+    for (int i = 0; i < HW_RESOURCE_THREAD_COUNT; ++i) {
+        if (!created[i]) {
+            continue;
+        }
+
+        int rc = pthread_join(threads[i], NULL);
+        test_verify("hardware query thread can be joined", 0 == rc);
+        test_verify("concurrent hardware query succeeds",
+                    MPI_SUCCESS == results[i].get_rc && results[i].valid_info);
+        test_verify("concurrent hardware info can be inspected",
+                    MPI_SUCCESS == results[i].nkeys_rc && 0 <= results[i].nkeys);
+        test_verify("concurrent hardware info can be freed",
+                    MPI_SUCCESS == results[i].free_rc);
+    }
+}
+
+static void test_info_contents(void)
+{
+    MPI_Info info = MPI_INFO_NULL;
+    int rc = MPI_Get_hw_resource_info(&info);
+    test_verify("Get_hw_resource_info succeeds",
+                MPI_SUCCESS == rc && MPI_INFO_NULL != info);
+    if (MPI_SUCCESS != rc || MPI_INFO_NULL == info) {
+        return;
+    }
+
+    int nkeys = 0;
+    rc = MPI_Info_get_nkeys(info, &nkeys);
+    test_verify("hardware info key count can be read", MPI_SUCCESS == rc && 0 <= nkeys);
+
+    for (int i = 0; i < nkeys; ++i) {
+        char key[MPI_MAX_INFO_KEY] = {0};
+        rc = MPI_Info_get_nthkey(info, i, key);
+        test_verify("hardware key can be read", MPI_SUCCESS == rc);
+        test_verify("hardware key uses a hwloc URI", 0 == strncmp(key, "hwloc://", 8));
+
+        bool value;
+        test_verify("hardware value is boolean", get_boolean_value(info, key, &value));
+    }
+
+    if (0 == nkeys) {
+        test_comment("No live topology or binding information; key checks skipped");
+    }
+
+    bool core_restricted = false;
+    (void) get_boolean_value(info, "hwloc://Core", &core_restricted);
+    test_uri_split(MPI_COMM_WORLD, "hwloc://Core", core_restricted,
+                   MPI_COMM_TYPE_RESOURCE_GUIDED,
+                   "resource-guided split follows the current Core restriction");
+    test_uri_split(MPI_COMM_WORLD, "hwloc://Core", core_restricted,
+                   MPI_COMM_TYPE_HW_GUIDED,
+                   "hardware-guided split follows the current Core restriction");
+
+    rc = MPI_Info_free(&info);
+    test_verify("hardware info can be freed", MPI_SUCCESS == rc && MPI_INFO_NULL == info);
+}
+
+static bool find_allowed_cores(hwloc_const_cpuset_t allowed, hwloc_obj_t *first,
+                               hwloc_obj_t *second)
+{
+    *first = NULL;
+    *second = NULL;
+
+    int count = hwloc_get_nbobjs_by_type(opal_hwloc_topology, HWLOC_OBJ_CORE);
+    for (int i = 0; i < count; ++i) {
+        hwloc_obj_t core = hwloc_get_obj_by_type(opal_hwloc_topology, HWLOC_OBJ_CORE, i);
+        if (NULL == core || NULL == core->cpuset || !hwloc_bitmap_intersects(allowed, core->cpuset)) {
+            continue;
+        }
+        if (NULL == *first) {
+            *first = core;
+        } else {
+            *second = core;
+            break;
+        }
+    }
+
+    return NULL != *first;
+}
+
+static void test_binding_refresh(void)
+{
+    if (NULL == opal_hwloc_topology) {
+        test_comment("No hwloc topology; binding refresh test skipped");
+        return;
+    }
+
+    hwloc_cpuset_t original = hwloc_bitmap_alloc();
+    hwloc_cpuset_t requested = hwloc_bitmap_alloc();
+    if (NULL == original || NULL == requested) {
+        test_failure("Could not allocate hwloc bitmaps");
+        goto cleanup;
+    }
+
+    if (0 != hwloc_get_cpubind(opal_hwloc_topology, original, HWLOC_CPUBIND_PROCESS)) {
+        test_comment("Process binding cannot be queried; binding refresh test skipped");
+        goto cleanup;
+    }
+
+    hwloc_obj_t first, second;
+    if (!find_allowed_cores(original, &first, &second)) {
+        test_comment("No allowed core found; binding refresh test skipped");
+        goto cleanup;
+    }
+
+    hwloc_bitmap_and(requested, original, first->cpuset);
+    if (hwloc_bitmap_iszero(requested)
+        || 0 != hwloc_set_cpubind(opal_hwloc_topology, requested, HWLOC_CPUBIND_PROCESS)) {
+        test_comment("Process binding cannot be changed; binding refresh test skipped");
+        goto cleanup;
+    }
+
+    MPI_Info info = MPI_INFO_NULL;
+    int rc = MPI_Get_hw_resource_info(&info);
+    bool restricted = false;
+    test_verify("single-core binding is reported as restricted",
+                MPI_SUCCESS == rc && MPI_INFO_NULL != info
+                    && get_boolean_value(info, "hwloc://Core", &restricted)
+                    && restricted);
+    if (MPI_INFO_NULL != info) {
+        MPI_Info_free(&info);
+    }
+    test_uri_split(MPI_COMM_SELF, "hwloc://Core", true,
+                   MPI_COMM_TYPE_RESOURCE_GUIDED,
+                   "single-core binding participates in a Core split");
+
+    if (NULL != second) {
+        hwloc_bitmap_and(requested, original, first->cpuset);
+        hwloc_bitmap_t second_allowed = hwloc_bitmap_alloc();
+        if (NULL != second_allowed) {
+            hwloc_bitmap_and(second_allowed, original, second->cpuset);
+            hwloc_bitmap_or(requested, requested, second_allowed);
+            hwloc_bitmap_free(second_allowed);
+
+            if (0 == hwloc_set_cpubind(opal_hwloc_topology, requested, HWLOC_CPUBIND_PROCESS)) {
+                rc = MPI_Get_hw_resource_info(&info);
+                restricted = true;
+                test_verify("two-core binding is reported as unrestricted",
+                            MPI_SUCCESS == rc && MPI_INFO_NULL != info
+                                && get_boolean_value(info, "hwloc://Core", &restricted)
+                                && !restricted);
+                if (MPI_INFO_NULL != info) {
+                    MPI_Info_free(&info);
+                }
+                test_uri_split(MPI_COMM_SELF, "hwloc://Core", false,
+                               MPI_COMM_TYPE_RESOURCE_GUIDED,
+                               "two-core binding is excluded from a Core split");
+            } else {
+                test_comment("Two-core process binding is unsupported; false-path test skipped");
+            }
+        }
+    }
+
+    if (0 != hwloc_set_cpubind(opal_hwloc_topology, original, HWLOC_CPUBIND_PROCESS)) {
+        test_failure("Could not restore original process binding");
+    }
+
+cleanup:
+    if (NULL != requested) {
+        hwloc_bitmap_free(requested);
+    }
+    if (NULL != original) {
+        hwloc_bitmap_free(original);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    test_init("MPI hardware resource information");
+
+    test_outside_mpi_lifetime("pre-init hardware query");
+
+    int provided = MPI_THREAD_SINGLE;
+    int rc = MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    test_verify("MPI_Init_thread succeeds", MPI_SUCCESS == rc);
+
+    if (MPI_SUCCESS == rc) {
+        test_thread_multiple_calls(provided);
+        test_info_contents();
+        test_binding_refresh();
+
+        rc = MPI_Finalize();
+        test_verify("MPI_Finalize succeeds", MPI_SUCCESS == rc);
+
+        if (MPI_SUCCESS == rc) {
+            test_outside_mpi_lifetime("post-finalize hardware query");
+        }
+    }
+
+    return test_finalize();
+}


### PR DESCRIPTION
Populate URI-form hardware resource information from hwloc and accept the returned keys in hardware-guided communicator splitting.

Signed-off-by: Musawer Ahmad Saqif <saqif@umich.edu>