### PR TITLE
docs: warn agents about misuse of OMPI_HIDDEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,21 @@ and [`docs/contributing.rst`](docs/contributing.rst):
 - **MPI back-end code must never call public `MPI_*()` APIs.** The
   bindings are thin wrappers; call the internal `ompi_*` routines, not
   the user-facing entry points.
+- **Be very careful with `OMPI_HIDDEN` (and `OPAL_HIDDEN` /
+  `OSHMEM_HIDDEN`).** These mark a symbol as *not* exported from the
+  shared library that defines it. As of Open MPI v6.0 the MPI interface
+  is split across `libmpi` (Open MPI ABI) and `libmpi_abi` (standard MPI
+  ABI), both linked against the internal `libopen_mpi`. If you hide an
+  `ompi_*` symbol that is defined in `libopen_mpi` but *used* from the
+  bindings compiled into `libmpi` and `libmpi_abi` (e.g., predefined
+  handle objects like `ompi_mpi_comm_parent`, or helpers like
+  `ompi_comm_split_type_hw_guided_support`), those two library links
+  fail with unresolved symbols. Rule of thumb: if a symbol crosses a
+  library boundary, use `OMPI_DECLSPEC` (or leave it un-annotated) —
+  never `OMPI_HIDDEN`. Only hide symbols you are certain are private to a
+  single DSO. See the "Symbol Visibility" section of
+  [`docs/developers/source-code.rst`](docs/developers/source-code.rst)
+  and [`ompi/mpi/README_ABI.md`](ompi/mpi/README_ABI.md).
 - **New files need the standard copyright/license header.** Copy the
   multi-institution BSD header block — including the `$COPYRIGHT$` and
   `$HEADER$` tokens — from a neighboring file. If you substantially

--- a/docs/developers/source-code.rst
+++ b/docs/developers/source-code.rst
@@ -292,3 +292,45 @@ is used to control what symbols are visible in the ``libmpi.so`` scope.
    `__declspec <https://docs.microsoft.com/en-us/cpp/cpp/declspec?view=msvc-170>`_.
    While support for Windows has been dropped from Open MPI, the symbol
    visibility macros remain.
+
+Hiding symbols with ``OMPI_HIDDEN``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The complement of ``OMPI_DECLSPEC`` is ``OMPI_HIDDEN`` (and, similarly,
+``OPAL_HIDDEN`` and ``OSHMEM_HIDDEN``).  It marks a symbol with "hidden"
+ELF visibility, meaning the symbol is *not* exported from the shared
+library in which it is defined and therefore cannot be resolved by any
+*other* shared library at link or run time.  Use it for symbols that are
+genuinely private to a single DSO.
+
+.. warning:: **Do not add ``OMPI_HIDDEN`` to a symbol that must be shared
+   across Open MPI's libraries.** As of Open MPI v6.0 the MPI interface
+   is split into multiple libraries that link against a shared internal
+   implementation library:
+
+   * ``libopen_mpi`` -- the internal OMPI implementation library
+   * ``libmpi`` -- the Open MPI ABI library (linked by ``mpicc``)
+   * ``libmpi_abi`` -- the standardized MPI ABI library (linked by
+     ``mpicc_abi``; only built with ``--enable-standard-abi``, which is
+     the default)
+
+   See ``ompi/mpi/README_ABI.md`` for the full picture of this library
+   structure.
+
+   Many ``ompi_*`` symbols are *defined* in ``libopen_mpi`` but *used*
+   from the binding code that is compiled into both ``libmpi`` and
+   ``libmpi_abi``.  If such a symbol is marked ``OMPI_HIDDEN``, it is not
+   exported from ``libopen_mpi``, so the links of ``libmpi`` **and**
+   ``libmpi_abi`` fail with unresolved-symbol errors.  This includes the
+   predefined MPI handle objects (for example,
+   ``ompi_mpi_comm_parent``) and internal helpers reached from the
+   bindings (for example, ``ompi_comm_split_type_hw_guided_support`` and
+   the ``ompi_comm_split_type_hwloc_*`` helpers).
+
+   The safe rule of thumb: if a symbol crosses a library boundary --
+   defined in one of the libraries above and referenced from another --
+   it must be ``OMPI_DECLSPEC`` (exported), never ``OMPI_HIDDEN``.  Only
+   mark a symbol ``OMPI_HIDDEN`` when you are certain every user of it is
+   compiled into the *same* DSO that defines it.  When in doubt, prefer
+   ``OMPI_DECLSPEC`` or leave the symbol un-annotated rather than risk a
+   link failure that only appears in an ABI-enabled build.


### PR DESCRIPTION
Add guidance explaining when it is (and is not) safe to annotate a symbol with OMPI_HIDDEN, so that contributors -- and AI coding agents in particular -- do not reintroduce the class of build breakage that need to be fixed in the initial version of code present in PR #14317.

As of Open MPI v6.0 the MPI interface is split across libmpi (Open MPI ABI) and libmpi_abi (standard MPI ABI), both of which link against the internal libopen_mpi.  Many ompi_* symbols are defined in libopen_mpi but used from the bindings compiled into libmpi and libmpi_abi (for example, predefined handle objects like ompi_mpi_comm_parent and helpers like ompi_comm_split_type_hw_guided_support).  Marking such a symbol OMPI_HIDDEN prevents it from being exported from libopen_mpi, so the links of both libmpi and libmpi_abi fail with unresolved symbols.

Two files are updated:

- AGENTS.md: add a "Golden rules" bullet describing the hazard and the rule of thumb -- if a symbol crosses a library boundary, use OMPI_DECLSPEC (or leave it un-annotated), never OMPI_HIDDEN.  Only hide symbols that are certainly private to a single DSO.

- docs/developers/source-code.rst: add a "Hiding symbols with OMPI_HIDDEN" subsection under Symbol Visibility that documents the v6.0 library structure and includes a warning admonition covering the unresolved-symbol failure mode and the same rule of thumb.

These are documentation-only changes.  CLAUDE.md is a symlink to AGENTS.md and is covered automatically.