### PR TITLE
Fix compiler warnings across OPAL, OMPI, libnbc, ftmpi, and treematch

### DIFF
--- a/3rd-party/treematch/IntConstantInitializedVector.c
+++ b/3rd-party/treematch/IntConstantInitializedVector.c
@@ -24,13 +24,6 @@ void tm_intCIV_init(int_CIVector * v, int size, int init_value)
   v->vec = malloc(sizeof(int)*size);
 }
 
-static inline void intCIV_exit(int_CIVector * v)
-{
-  free(v->to);
-  free(v->from);
-  free(v->vec);
- }
-
 int tm_intCIV_set(int_CIVector * v, int i, int val)
 {
   if(v == NULL)

--- a/3rd-party/treematch/tm_bucket.c
+++ b/3rd-party/treematch/tm_bucket.c
@@ -34,12 +34,8 @@ static int verbose_level = ERROR;
 static bucket_list_t global_bl = {0};
 
 static int tab_cmp(const void*,const void*);
-static int old_bucket_id(int,int,bucket_list_t);
 static int bucket_id(int,int,bucket_list_t);
-static void display_bucket(bucket_t *);
-static void check_bucket(bucket_t *,double **,double, double);
 static void display_pivots(bucket_list_t);
-static void display_bucket_list(bucket_list_t);
 static void add_to_bucket(int,int,int,bucket_list_t);
 static void dfs(int,int,int,double *,double *,int,int);
 static void built_pivot_tree(bucket_list_t);
@@ -83,35 +79,6 @@ static int tab_cmp(const void* x1,const void* x2)
 }
 
 
-static inline int old_bucket_id(int i,int j,bucket_list_t bucket_list)
-{
-  double *pivot = NULL,val;
-  int n,sup,inf,p;
-
-  pivot = bucket_list->pivot;
-  n = bucket_list->nb_buckets;
-  val = bucket_list->tab[i][j];
-
-  inf = -1;
-  sup = n;
-
-  while( (sup - inf) > 1){
-    p = (sup + inf)/2;
-    /* printf("%f [%d,%d,%d]=%f\n",val,inf,p,sup,pivot[p]); */
-    if( val < pivot[p] ){
-      inf = p;
-      if( inf == sup )
-	inf--;
-    } else {
-      sup = p;
-      if( sup == inf )
-	sup++;
-    }
-  }
-  /*exit(-1);*/
-  return sup;
-}
-
 static int bucket_id(int i,int j,bucket_list_t bucket_list)
 {
   double *pivot_tree = NULL,val;
@@ -132,57 +99,12 @@ static int bucket_id(int i,int j,bucket_list_t bucket_list)
   return (int)pivot_tree[p];
 }
 
-static void  display_bucket(bucket_t *b)
-{
-  printf("\tb.bucket=%p\n",(void *)b->bucket);
-  printf("\tb.bucket_len=%d\n",(int)b->bucket_len);
-  printf("\tb.nb_elem=%d\n",(int)b->nb_elem);
-}
-
-static void check_bucket(bucket_t *b,double **tab,double inf, double sup)
-{
-  int i,j,k;
-  for( k = 0 ; k < b->nb_elem ; k++ ){
-    i = b->bucket[k].i;
-    j = b->bucket[k].j;
-    if((tab[i][j] < inf) || (tab[i][j] > sup)){
-      if(verbose_level >= CRITICAL)
-	fprintf(stderr,"[%d] (%d,%d):%f not in [%f,%f]\n",k,i,j,tab[i][j],inf,sup);
-      exit(-1);
-    }
-  }
-}
-
 static void display_pivots(bucket_list_t bucket_list)
 {
   int i;
   for( i = 0 ; i < bucket_list->nb_buckets-1 ; i++)
     printf("pivot[%d]=%f\n",i,bucket_list->pivot[i]);
   printf("\n");
-}
-
-static inline void display_bucket_list(bucket_list_t bucket_list)
-{
-  int i;
-  double inf,sup;
-
-  /*display_pivots(bucket_list);*/
-
-  for(i = 0 ; i < bucket_list->nb_buckets ; i++){
-    inf = bucket_list->pivot[i];
-    sup = bucket_list->pivot[i-1];
-    if( i == 0 )
-      sup=DBL_MAX;
-    if( i == bucket_list->nb_buckets - 1 )
-      inf = 0;
-    if(verbose_level >= DEBUG){
-      printf("Bucket %d:\n",i);
-      display_bucket(bucket_list->bucket_tab[i]);
-      printf("\n");
-    }
-    check_bucket(bucket_list->bucket_tab[i],bucket_list->tab,inf,sup);
-  }
-
 }
 
 static void add_to_bucket(int id,int i,int j,bucket_list_t bucket_list)

--- a/3rd-party/treematch/tm_mapping.c
+++ b/3rd-party/treematch/tm_mapping.c
@@ -48,7 +48,6 @@ OMPI_HIDDEN tm_affinity_mat_t * tm_new_affinity_mat(double **mat, double *sum_ro
 OMPI_HIDDEN int tm_compute_nb_leaves_from_level(int depth,tm_topology_t *topology);
 static void depth_first(tm_tree_t *comm_tree, int *proc_list,int *i);
 OMPI_HIDDEN int  tm_fill_tab(int **new_tab,int *tab, int n, int start, int max_val, int shift);
-static long int init_mat(char *filename,int N, double **mat, double *sum_row);
 OMPI_HIDDEN void tm_map_topology(tm_topology_t *topology,tm_tree_t *comm_tree, int level,
 		  int *sigma, int nb_processes, int **k, int nb_compute_units);
 static int nb_leaves(tm_tree_t *comm_tree);
@@ -57,7 +56,6 @@ OMPI_HIDDEN void tm_print_1D_tab(int *tab,int N);
 tm_solution_t * tm_compute_mapping(tm_topology_t *topology,tm_tree_t *comm_tree);
 void tm_free_affinity_mat(tm_affinity_mat_t *aff_mat);
 OMPI_HIDDEN tm_affinity_mat_t *tm_load_aff_mat(char *filename);
-static void update_comm_speed(double **comm_speed,int old_size,int new_size);
 tm_affinity_mat_t * tm_build_affinity_mat(double **mat, int order);
 
 
@@ -112,60 +110,6 @@ static int nb_lines(char *filename)
   return N;
 }
 
-
-
-static inline long int  init_mat(char *filename,int N, double **mat, double *sum_row){
-  FILE *pf = NULL;
-  char *ptr= NULL;
-  char line[LINE_SIZE];
-  int i,j;
-  unsigned int vl = tm_get_verbose_level();
-  long int nnz = 0;
-
-  if(!(pf=fopen(filename,"r"))){
-    if(vl >= CRITICAL)
-      fprintf(stderr,"Cannot open %s\n",filename);
-    exit(-1);
-  }
-
-  j = -1;
-  i = 0;
-
-  while(fgets(line,LINE_SIZE,pf)){
-    char *l = line;
-    j = 0;
-    sum_row[i] = 0;
-    while((ptr=strtok(l," \t"))){
-      l = NULL;
-      if((ptr[0]!='\n')&&(!isspace(ptr[0]))&&(*ptr)){
-  	mat[i][j] = atof(ptr);
-	if(mat[i][j]) nnz++;
-  	sum_row[i] += mat [i][j];
-  	if(mat[i][j]<0){
-  	  if(vl >= WARNING)
-  	    fprintf(stderr,"Warning: negative value in com matrix! mat[%d][%d]=%f\n",i,j,mat[i][j]);
-  	}
-  	j++;
-      }
-    }
-    if( j != N){
-      if(vl >= CRITICAL)
-  	fprintf(stderr,"Error at %d %d (%d!=%d). Too many columns for %s\n",i,j,j,N,filename);
-      exit(-1);
-    }
-    i++;
-  }
-
-
-  if( i != N ){
-    if(vl >= CRITICAL)
-      fprintf(stderr,"Error at %d %d. Too many rows for %s\n",i,j,filename);
-    exit(-1);
-  }
-
-  fclose (pf);
-  return nnz;
-}
 
 
 static size_t get_filesize(char* filename) {
@@ -547,35 +491,6 @@ tm_solution_t * tm_compute_mapping(tm_topology_t *topology,tm_tree_t *comm_tree)
 
   return solution;
 }
-
-
-
-static inline void update_comm_speed(double **comm_speed,int old_size,int new_size)
-{
-  double *old_tab = NULL,*new_tab= NULL;
-  int i;
-  unsigned int vl = tm_get_verbose_level();
-
-  if(vl >= DEBUG)
-    printf("comm speed [%p]: ",(void *)*comm_speed);
-
-  old_tab = *comm_speed;
-  new_tab = (double*)MALLOC(sizeof(double)*new_size);
-  *comm_speed = new_tab;
-
-  for( i = 0 ; i < new_size ; i++ ){
-    if( i < old_size)
-      new_tab[i] = old_tab[i];
-    else
-      new_tab[i] = new_tab[i-1];
-
-    if(vl >= DEBUG)
-      printf("%f ",new_tab[i]);
-  }
-  if(vl >= DEBUG)
-    printf("\n");
-}
-
 
 
 

--- a/3rd-party/treematch/tm_topology.c
+++ b/3rd-party/treematch/tm_topology.c
@@ -19,12 +19,10 @@ OMPI_HIDDEN void tm_free_topology(tm_topology_t *topology);
 OMPI_HIDDEN tm_topology_t *tm_load_topology(char *arch_filename, tm_file_type_t arch_file_type);
 OMPI_HIDDEN void tm_optimize_topology(tm_topology_t **topology);
 OMPI_HIDDEN int  tm_topology_add_binding_constraints(char *constraints_filename, tm_topology_t *topology);
-static int topo_nb_proc(hwloc_topology_t topology,int N);
 static void topology_arity_cpy(tm_topology_t *topology,int **arity,int *nb_levels);
 static void topology_constraints_cpy(tm_topology_t *topology,int **constraints,int *nb_constraints);
 static void topology_cost_cpy(tm_topology_t *topology,double **cost);
 static void topology_numbering_cpy(tm_topology_t *topology,int **numbering,int *nb_nodes);
-static double ** topology_to_arch(hwloc_topology_t topology);
 static void   build_synthetic_proc_id(tm_topology_t *topology);
 tm_topology_t  *tm_build_synthetic_topology(int *arity, double *cost, int nb_levels, int *core_numbering, int nb_core_per_nodes);
 OMPI_HIDDEN void tm_set_numbering(tm_numbering_t new_val); /* TM_NUMBERING_LOGICAL or TM_NUMBERING_PHYSICAL */
@@ -128,19 +126,6 @@ int tm_nb_processing_units(tm_topology_t *topology)
   return topology->nb_proc_units;
 }
 
-static inline int topo_nb_proc(hwloc_topology_t topology,int N)
-{
-  hwloc_obj_t *objs = NULL;
-  int nb_proc;
-
-  objs = (hwloc_obj_t*)MALLOC(sizeof(hwloc_obj_t)*N);
-  objs[0] = hwloc_get_next_obj_by_type(topology,HWLOC_OBJ_PU,NULL);
-  nb_proc = 1 + hwloc_get_closest_objs(topology,objs[0],objs+1,N-1);
-  FREE(objs);
-  return nb_proc;
-}
-
-
 static double link_cost(int depth)
 {
   /*
@@ -157,33 +142,6 @@ static double link_cost(int depth)
    return (depth+1);
    return (long int)pow(100,depth);
   */
-}
-
-static inline double ** topology_to_arch(hwloc_topology_t topology)
-{
-  int nb_proc,i,j;
-  hwloc_obj_t obj_proc1,obj_proc2,obj_res;
-  double **arch = NULL;
-
-  nb_proc = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
-  if (nb_proc < 0) {
-    return NULL;
-  }
-  arch = (double**)malloc(sizeof(double*)*nb_proc);
-  if (NULL == arch) {
-    return NULL;
-  }
-  for( i = 0 ; i < nb_proc ; i++ ){
-    obj_proc1 = hwloc_get_obj_by_type(topology,HWLOC_OBJ_PU,i);
-    arch[obj_proc1->os_index] = (double*)MALLOC(sizeof(double)*nb_proc);
-    for( j = 0 ; j < nb_proc ; j++ ){
-      obj_proc2 = hwloc_get_obj_by_type(topology,HWLOC_OBJ_PU,j);
-      obj_res = hwloc_get_common_ancestor_obj(topology,obj_proc1,obj_proc2);
-      /* printf("arch[%d][%d] <- %ld\n",obj_proc1->os_index,obj_proc2->os_index,*((long int*)(obj_res->userdatab))); */
-      arch[obj_proc1->os_index][obj_proc2->os_index]=link_cost(obj_res->depth+1);
-    }
-  }
-  return arch;
 }
 
 static int symetric(hwloc_topology_t topology)

--- a/3rd-party/treematch/tm_tree.c
+++ b/3rd-party/treematch/tm_tree.c
@@ -54,20 +54,15 @@ static void delete_group_list(group_list_t *);
 static int group_list_id(const void*, const void*);
 static int group_list_asc(const void*, const void*);
 static int group_list_dsc(const void*, const void*);
-static int weighted_degree_asc(const void*, const void*);
 static int weighted_degree_dsc(const void*, const void*);
 static int  select_independent_groups(group_list_t **, int, int, int, double *, group_list_t **, int, double);
 static int  select_independent_groups_by_largest_index(group_list_t **, int, int, int, double *,
                                                        group_list_t **, int, double);
 static void list_to_tab(group_list_t *, group_list_t **, int);
-static void display_tab_group(group_list_t **, int, int);
 static int independent_tab(tm_tree_t **, tm_tree_t **, int);
 static void compute_weighted_degree(group_list_t **, int, int);
 void  group(tm_affinity_mat_t *, tm_tree_t *, tm_tree_t *, int, int, int, double *, tm_tree_t **);
 static void  fast_group(tm_affinity_mat_t *, tm_tree_t *, tm_tree_t *, int, int, int, double *, tm_tree_t **, int *, int);
-static int adjacency_asc(const void*, const void*);
-static int adjacency_dsc(const void*, const void*);
-static void super_fast_grouping(tm_affinity_mat_t *, tm_tree_t *, tm_tree_t *, int, int);
 static tm_affinity_mat_t *build_cost_matrix(tm_affinity_mat_t *, double *, double);
 static void group_nodes(tm_affinity_mat_t *, tm_tree_t *, tm_tree_t *, int , int, double*, double);
 static double fast_grouping(tm_affinity_mat_t *, tm_tree_t *, tm_tree_t *, int, int, double);
@@ -82,7 +77,6 @@ static tm_tree_t *bottom_up_build_tree_from_topology(tm_topology_t *, tm_affinit
 static void free_non_constraint_tree(tm_tree_t *);
 static void free_constraint_tree(tm_tree_t *);
 static void free_tab_double(double**, int);
-static void free_tab_int(int**, int );
 static void partial_aggregate_aff_mat (int, void **, int);
 static void free_affinity_mat(tm_affinity_mat_t *aff_mat);
 OMPI_HIDDEN int tm_int_cmp_inc(const void* x1, const void* x2);
@@ -364,31 +358,18 @@ static void free_tab_double(double**tab, int mat_order)
   FREE(tab);
 }
 
-static inline void free_tab_int(int**tab, int mat_order)
-{
-  int i;
-  for( i = 0 ; i < mat_order ; i++ )
-    FREE(tab[i]);
-  FREE(tab);
-}
-
 void tm_display_tab(double **tab, int mat_order)
 {
   int i, j;
-  double line, total = 0;
   int vl = tm_get_verbose_level();
 
   for( i = 0 ; i < mat_order ; i++ ){
-    line = 0;
     for( j = 0 ; j < mat_order ; j++ ){
       if(vl >= WARNING)
 	printf("%g ", tab[i][j]);
       else
 	fprintf(stderr, "%g ", tab[i][j]);
-      line += tab[i][j];
     }
-    total += line;
-    /* printf(": %g", line);*/
     if(vl >= WARNING)
       printf("\n");
     else
@@ -651,16 +632,6 @@ static int group_list_dsc(const void* x1, const void* x2)
   e2 = *((group_list_t**)x2);
 
   return (e1->val > e2->val) ? -1 : 1;
-}
-
-static inline int weighted_degree_asc(const void* x1, const void* x2)
-{
-  group_list_t *e1= NULL, *e2 = NULL;
-
-  e1 = *((group_list_t**)x1);
-  e2 = *((group_list_t**)x2);
-
-  return (e1->wg > e2->wg) ? 1 : -1;
 }
 
 static int weighted_degree_dsc(const void* x1, const void* x2)
@@ -1439,18 +1410,6 @@ static void list_to_tab(group_list_t *list, group_list_t **tab, int n)
   }
 }
 
-static inline void display_tab_group(group_list_t **tab, int n, int arity)
-{
-  int i, j;
-  if(verbose_level<DEBUG)
-    return;
-  for( i = 0 ; i < n ; i++ ){
-    for( j = 0 ; j < arity ; j++ )
-      printf("%d ", tab[i]->tab[j]->id);
-    printf(": %.2f %.2f\n", tab[i]->val, tab[i]->wg);
-  }
-}
-
 static int independent_tab(tm_tree_t **tab1, tm_tree_t **tab2, int arity)
 {
   int ii, jj;
@@ -1615,88 +1574,6 @@ static double k_partition_grouping(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_no
 
   return val;
 
-}
-
-static inline int adjacency_asc(const void* x1, const void* x2)
-{
-  adjacency_t *e1 = NULL, *e2 = NULL;
-
-  e1 = ((adjacency_t*)x1);
-  e2 = ((adjacency_t*)x2);
-
-  return (e1->val < e2->val) ? - 1 : 1;
-}
-
-static int adjacency_dsc(const void* x1, const void* x2)
-{
-  adjacency_t *e1 = NULL, *e2 = NULL;
-
-  e1 = ((adjacency_t*)x1);
-  e2 = ((adjacency_t*)x2);
-
-
-  return (e1->val > e2->val) ? -1 : 1;
-}
-
-static inline void super_fast_grouping(tm_affinity_mat_t *aff_mat, tm_tree_t *tab_node, tm_tree_t *new_tab_node, int arity, int solution_size)
-{
-  double val = 0, duration;
-  adjacency_t *graph;
-  int i, j, e, l, nb_groups;
-  int mat_order = aff_mat->order;
-  double **mat = aff_mat->mat;
-
-  assert( 2 == arity);
-
-  TIC;
-  graph = (adjacency_t*)MALLOC(sizeof(adjacency_t)*((mat_order*mat_order-mat_order)/2));
-  e = 0;
-  for( i = 0 ; i < mat_order ; i++ )
-    for( j = i+1 ; j < mat_order ; j++){
-      graph[e].i = i;
-      graph[e].j = j;
-      graph[e].val = mat[i][j];
-      e++;
-    }
-
-  duration = TOC;
-  if(verbose_level>=DEBUG)
-    printf("linearization=%fs\n", duration);
-
-
-  assert( e == (mat_order*mat_order-mat_order)/2);
-  TIC;
-  qsort(graph, e, sizeof(adjacency_t), adjacency_dsc);
-  duration = TOC;
-  if(verbose_level>=DEBUG)
-    printf("sorting=%fs\n", duration);
-
-  TIC;
-
-TIC;
-  l = 0;
-  nb_groups = 0;
-  for( i = 0 ; (i < e) && (l < solution_size) ; i++ )
-    if(tm_try_add_edge(tab_node, &new_tab_node[l], arity, graph[i].i, graph[i].j, &nb_groups))
-      l++;
-
-  for( l = 0 ; l < solution_size ; l++ ){
-    tm_update_val(aff_mat, &new_tab_node[l]);
-    val += new_tab_node[l].val;
-  }
-
-  duration = TOC;
-  if(verbose_level>=DEBUG)
-    printf("Grouping=%fs\n", duration);
-
-
-  if(verbose_level>=DEBUG)
-    printf("val=%f\n", val);
-
-
-  display_grouping(new_tab_node, solution_size, arity, val);
-
-  FREE(graph);
 }
 
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,8 @@ install-exec-hook:
 	        --top_builddir=$(top_builddir) \
 	        --top_srcdir=$(top_srcdir) \
 	        --objext=$(OBJEXT) \
-	        --skipdir=3rd-party ; \
+	        --skipdir=3rd-party \
+	        --skipdir=test ; \
 	fi
 
 ACLOCAL_AMFLAGS = -I config

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -2202,7 +2202,7 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
     /*
      * append the pmix CONTEXT_ID obtained when creating the leader comm as discriminator
      */
-    opal_asprintf (&sub_tag, "%s-%ld", tag, data[1]);
+    opal_asprintf (&sub_tag, "%s-%" PRIu64, tag, data[1]);
     if (OPAL_UNLIKELY(NULL == sub_tag)) {
         return OMPI_ERR_OUT_OF_RESOURCE;
     }

--- a/ompi/communicator/comm_cid.c
+++ b/ompi/communicator/comm_cid.c
@@ -882,7 +882,7 @@ static inline void ompi_comm_set_disjointness_nb_complete(ompi_comm_cid_context_
 static int ompi_comm_activate_complete (ompi_comm_cid_context_t *context)
 {
     int ret;
-    ompi_communicator_t **newcomm = context->newcommp, *comm = context->comm;
+    ompi_communicator_t **newcomm = context->newcommp;
 
     /**
      * Determine the new communicator's disjointness based on

--- a/ompi/mca/coll/han/coll_han_alltoallv.c
+++ b/ompi/mca/coll/han/coll_han_alltoallv.c
@@ -187,7 +187,7 @@ static size_t ddt_unpack_datatype(opal_datatype_t* type, uint8_t* buf)
       provider attempts to use CMA to implement send/recv, then errors will
       occur!
 */
-static inline int alltoallv_sendrecv_w_direct_for_debugging(
+static inline int __opal_attribute_unused__ alltoallv_sendrecv_w_direct_for_debugging(
             void **send_from_addrs,
             size_t *send_counts,
             opal_datatype_t **send_types,
@@ -201,7 +201,7 @@ static inline int alltoallv_sendrecv_w_direct_for_debugging(
             struct ompi_communicator_t *comm) {
 
 
-    const int MAX_BUF_COUNT=8;
+    enum { MAX_BUF_COUNT = 8 };
     int nreqs = MAX_BUF_COUNT;
     ompi_request_t *requests[MAX_BUF_COUNT];
     const char* problem_hint;
@@ -309,7 +309,7 @@ static int alltoallv_sendrecv_w(
 
 
 
-    const int MAX_BUF_COUNT=8;
+    enum { MAX_BUF_COUNT = 8 };
     ompi_request_t *requests[MAX_BUF_COUNT];
     opal_free_list_item_t *buf_items[MAX_BUF_COUNT];
 
@@ -321,7 +321,7 @@ static int alltoallv_sendrecv_w(
             nbufs = jbuf;
             opal_output_verbose(30, mca_coll_han_component.han_output,
                 "alltoallv_sendrecv_w: Number of buffers reduced to %d instead of %d.  "
-                "Check mca parameter coll_han_packbuf_max_count (currently %ld).\n",
+                "Check mca parameter coll_han_packbuf_max_count (currently %" PRId64 ").\n",
                 nbufs, MAX_BUF_COUNT, mca_coll_han_component.han_packbuf_max_count);
             break;
         }
@@ -333,14 +333,14 @@ static int alltoallv_sendrecv_w(
     if (nbufs < 2) {
         opal_output_verbose(1, mca_coll_han_component.han_output,
                     "ERROR: Need at least 2 buffers from HAN pack buffers!  "
-                    "Check mca parameter coll_han_packbuf_max_count (currently %ld)\n",
+                    "Check mca parameter coll_han_packbuf_max_count (currently %" PRId64 ")\n",
                     mca_coll_han_component.han_packbuf_max_count);
         return MPI_ERR_NO_MEM;
     }
     if (buf_len < 16) {
         opal_output_verbose(1, mca_coll_han_component.han_output,
                     "ERROR: Need a buffer that can hold at least 16 bytes!  "
-                    "Check mca parameter coll_han_packbuf_bytes (currently %ld)\n",
+                    "Check mca parameter coll_han_packbuf_bytes (currently %" PRId64 ")\n",
                     mca_coll_han_component.han_packbuf_bytes);
         return MPI_ERR_NO_MEM;
     }
@@ -743,7 +743,7 @@ cleanup1:
     if (comm_rank == 0) {
         opal_output_verbose(10, mca_coll_han_component.han_output, "alltoallv: decide_to_use_smsc_alg: "
             "Ranks with GPU buffers: %lld (limit is 0).  "
-            "Average send_size: %.1f bytes (limit is %ld).  "
+            "Average send_size: %.1f bytes (limit is %" PRId64 ").  "
             "Fraction with non-contiguous buffers: %.3f (activation limit: %.3f).  "
             "Continue with SMSC? ==>%s.\n",
             reduce_buf_output[0],

--- a/ompi/mca/coll/han/coll_han_dynamic.c
+++ b/ompi/mca/coll/han/coll_han_dynamic.c
@@ -297,7 +297,7 @@ get_module(COLLTYPE_T coll_id,
      * No dynamic rule from file
      * Use rule from mca parameter
      */
-    if(mca_rule_component < 0 || mca_rule_component >= COMPONENTS_COUNT) {
+    if(mca_rule_component >= COMPONENTS_COUNT) {
         /*
          * Invalid MCA parameter value
          * Warn the user and return NULL

--- a/ompi/mca/coll/han/coll_han_subcomms.c
+++ b/ompi/mca/coll/han/coll_han_subcomms.c
@@ -55,7 +55,7 @@
 int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
                                  mca_coll_han_module_t *han_module)
 {
-    int low_rank, low_size, up_rank, w_rank, w_size, node_leader_w_rank;
+    int low_rank, low_size, up_rank, w_size, node_leader_w_rank;
     ompi_communicator_t **low_comm = &(han_module->sub_comm[INTRA_NODE]);
     ompi_communicator_t **up_comm = &(han_module->sub_comm[INTER_NODE]);
     mca_coll_han_collectives_fallback_t fallbacks;
@@ -129,7 +129,6 @@ int mca_coll_han_comm_create_new(struct ompi_communicator_t *comm,
     OBJ_CONSTRUCT(&comm_info, opal_info_t);
 
     /* Create topological sub-communicators */
-    w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
 
     /*
@@ -282,7 +281,7 @@ return_with_error:
 int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
                              mca_coll_han_module_t *han_module)
 {
-    int low_rank, low_size, up_rank, w_rank, w_size, node_leader_w_rank;
+    int low_rank, low_size, up_rank, w_size, node_leader_w_rank;
     mca_coll_han_collectives_fallback_t fallbacks;
     ompi_communicator_t **low_comms = NULL, **up_comms = NULL;
     int vrank, *vranks = NULL;
@@ -356,7 +355,6 @@ int mca_coll_han_comm_create(struct ompi_communicator_t *comm,
     }
 
     /* create communicators if there is no cached communicator */
-    w_rank = ompi_comm_rank(comm);
     w_size = ompi_comm_size(comm);
     low_comms = (struct ompi_communicator_t **)calloc(COLL_HAN_LOW_MODULES,
                                                       sizeof(struct ompi_communicator_t *));

--- a/ompi/mca/coll/libnbc/nbc_internal.h
+++ b/ompi/mca/coll/libnbc/nbc_internal.h
@@ -60,10 +60,6 @@ ceil_of_log2 (int val) {
     return ret;
 }
 
-/* true/false */
-#define true 1
-#define false 0
-
 /* all collectives */
 #define NBC_ALLGATHER 0
 #define NBC_ALLGATHERV 1

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_file.c
@@ -76,7 +76,7 @@ static int coll_tuned_read_alg(const opal_json_t *msg_rule, ompi_coll_msg_rule_t
     } else if (rc_as_int == OPAL_SUCCESS) {
         rc_validation = coll_tuned_alg_to_str( coll_id, int_val, NULL );
         if (rc_validation != OPAL_SUCCESS) {
-            snprintf(int_as_str, 23, "%ld", int_val);
+            snprintf(int_as_str, 23, "%" PRId64, int_val);
             int_as_str[23] = '\0';
             string_buf = int_as_str;
         } else {

--- a/ompi/mca/coll/tuned/coll_tuned_dynamic_rules.c
+++ b/ompi/mca/coll/tuned/coll_tuned_dynamic_rules.c
@@ -445,7 +445,7 @@ static const char* coll_rules_comm_rank_distro_table[] = {
 
 const char* coll_rules_comm_rank_distro_to_str(enum comm_rank_distro_t distro)
 {
-    if( (distro < 0) || (distro >= COLL_RULES_DISTRO_COUNT) ) {
+    if( distro >= COLL_RULES_DISTRO_COUNT ) {
         return NULL;
     }
     return coll_rules_comm_rank_distro_table[distro];

--- a/ompi/mca/coll/xhc/coll_xhc_component.c
+++ b/ompi/mca/coll/xhc/coll_xhc_component.c
@@ -160,7 +160,7 @@ int mca_coll_xhc_component_init_query(bool enable_progress_threads,
 }
 
 COLLTYPE_T mca_coll_xhc_colltype_to_universal(XHC_COLLTYPE_T xhc_colltype) {
-    if(xhc_colltype < 0 || xhc_colltype >= XHC_COLLCOUNT) {
+    if(xhc_colltype >= XHC_COLLCOUNT) {
         return -1;
     }
 
@@ -172,7 +172,7 @@ const char *mca_coll_xhc_colltype_to_str(XHC_COLLTYPE_T colltype) {
 }
 
 const char *mca_coll_xhc_config_source_to_str(xhc_config_source_t source) {
-    return (source >= 0 && source < XHC_CONFIG_SOURCE_COUNT ?
+    return (source < XHC_CONFIG_SOURCE_COUNT ?
         xhc_config_source_to_str_map[source] : NULL);
 }
 

--- a/ompi/mpi/fortran/base/strings.c
+++ b/ompi/mpi/fortran/base/strings.c
@@ -101,12 +101,12 @@ int ompi_fortran_string_c2f(const char *cstr, char *fstr, int len)
     // trailing \0 into the last position in fstr.  This is not what
     // Fortran wants; overwrite that \0 with the actual last character
     // that will fit into fstr.
-    if (len <= strlen(cstr)) {
+    if (len <= (int) strlen(cstr)) {
         fstr[len - 1] = cstr[len - 1];
     } else {
         // Otherwise, pad the end of the resulting Fortran string with
         // spaces.
-        for (i = strlen(cstr); i < len; ++i) {
+        for (i = (int) strlen(cstr); i < len; ++i) {
             fstr[i] = ' ';
         }
     }

--- a/ompi/mpiext/ftmpi/c/comm_ishrink.c
+++ b/ompi/mpiext/ftmpi/c/comm_ishrink.c
@@ -18,14 +18,14 @@
 #include "ompi/proc/proc.h"
 #include "ompi/op/op.h"
 
+#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
+
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_ALIASES
 #pragma weak MPIX_Comm_ishrink = PMPIX_Comm_ishrink
 #endif
 #define MPIX_Comm_ishrink PMPIX_Comm_ishrink
 #endif
-
-#include "ompi/mpiext/ftmpi/c/mpiext_ftmpi_c.h"
 
 static const char FUNC_NAME[] = "MPIX_Comm_ishrink";
 

--- a/opal/mca/base/mca_base_event.c
+++ b/opal/mca/base/mca_base_event.c
@@ -274,7 +274,7 @@ static int event_compute_buffer_size(int num_elements, const mca_base_var_type_t
     for (i = 0; i < num_elements; ++i) {
         size_t tsize, end;
 
-        if (element_types[i] < 0 || element_types[i] >= MCA_BASE_VAR_TYPE_MAX) {
+        if (element_types[i] >= MCA_BASE_VAR_TYPE_MAX) {
             return OPAL_ERR_BAD_PARAM;
         }
         tsize = ompi_var_type_sizes[element_types[i]];

--- a/opal/mca/base/mca_base_event.h
+++ b/opal/mca/base/mca_base_event.h
@@ -455,6 +455,14 @@ OPAL_DECLSPEC bool mca_base_event_memory_test_bump(int64_t count, int64_t bytes)
     a test.  Set before attaching a listener. */
 OPAL_DECLSPEC void mca_base_event_memory_test_suppress_hook(bool suppress);
 
+/** Test-only seam: return the number of times an instance was acquired from
+    the pool (useful for verifying drop-restore behaviour). */
+OPAL_DECLSPEC int64_t mca_base_event_test_pool_acquires(void);
+
+/** Test-only seam: when set to true, make the instance pool appear exhausted
+    so the drop-restore path can be exercised without a size-1 pool. */
+OPAL_DECLSPEC void mca_base_event_test_set_force_exhaustion(bool v);
+
 END_C_DECLS
 
 #endif /* OPAL_MCA_BASE_EVENT_H */

--- a/opal/mca/base/mca_base_event_dispatch.c
+++ b/opal/mca/base/mca_base_event_dispatch.c
@@ -734,7 +734,7 @@ int mca_base_event_register_callback(mca_base_event_registration_t *reg,
     mca_base_event_cb_t *old_slot, *new_slot = NULL;
     bool was_active;
 
-    if (cb_safety < 0 || cb_safety >= MCA_BASE_EVENT_CB_REQUIRE_MAX) {
+    if (cb_safety >= MCA_BASE_EVENT_CB_REQUIRE_MAX) {
         return OPAL_ERR_BAD_PARAM;
     }
 


### PR DESCRIPTION
Despite all the prior efforts there were quite a few warnings left over. I just want them all gone.

  - treematch (3rd-party, locally carried): delete dead static functions that were never called (intCIV_exit, init_mat, update_comm_speed, topo_nb_proc, topology_to_arch, and several display/bucket/tree helpers).
  - libnbc: remove #define true 1 / #define false 0 that shadowed C11 keywords and triggered -Wkeyword-macro.
  - ftmpi/comm_ishrink.c: fix include ordering so the compiler sees the MPIX_Comm_ishrink prototype before the profiling-layer macro expands it, eliminating a missing-prototype warning.
  - OPAL/OMPI (misc): fix unused variables, unsigned-enum < 0 comparisons that are always false, %ld format specifiers used for int64_t/uint64_t (replaced with PRId64/PRIu64), a VLA-folded-to-constant array bound (replaced const int N with enum { N }), and a sign-compare between a Fortran hidden-length int and strlen().
  - Makefile.am: exclude test/ from the find_common_syms scan at install time; test programs legitimately carry uninitialized globals and were never meant to be checked by that hook.