### PR TITLE
[v6.0.x] Fix the asynchronous modex endpoint wire-up race

### DIFF
--- a/.github/workflows/ompi-pr-builds.yaml
+++ b/.github/workflows/ompi-pr-builds.yaml
@@ -125,6 +125,15 @@ jobs:
         PRTE_MCA_rmaps_default_mapping_policy: ":OVERSUBSCRIBE"
       run: make -C ompi/test/mpi-abi check-abi VERBOSE=1
 
+    - name: Run the tests that need mpirun
+      # Like check-abi above, this runs after "make install": "make check"
+      # can only run non-MPI tests and MPI singletons (Automake runs each
+      # test binary directly), and the build-tree mpirun is only a wrapper
+      # that exec's the *installed* prterun.  Nothing else in CI enables
+      # the asynchronous modex, so without this step that code path gets
+      # no coverage at all.
+      run: make -C ompi/test/mpirun check-mpirun
+
     - name: Build all examples
       run: |
         cd examples

--- a/.gitignore
+++ b/.gitignore
@@ -382,6 +382,8 @@ opal/tools/wrappers/opal.pc
 opal/util/show_help_content.c
 opal/util/keyval/keyval_lex.c
 
+ompi/test/mpirun/async_modex_wireup
+
 test/simple/abort
 test/simple/accept
 test/simple/attach

--- a/config/ompi_config_files.m4
+++ b/config/ompi_config_files.m4
@@ -35,6 +35,7 @@ AC_DEFUN([OMPI_CONFIG_FILES],[
         ompi/test/monitoring/Makefile
         ompi/test/spc/Makefile
         ompi/test/mpi-abi/Makefile
+        ompi/test/mpirun/Makefile
         ompi/test/reexport/Makefile
         ompi/test/bindings-generator/Makefile
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -745,6 +745,20 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
     }
 
 
+    /* If the modex fence was launched in the background, it must complete
+     * before we go any further: everything below this point reads peer
+     * modex data (proc archs/locality, and the BTL/SMSC endpoint blobs
+     * fetched during add_procs).  PMIx does not defer a get for a peer
+     * that has not yet committed its data -- it returns NOT_FOUND -- so a
+     * peer that is merely slow to reach its fence reads as a peer that
+     * posted nothing, and its endpoint is silently never wired up.
+     * Waiting here still overlaps the fence with all of the framework
+     * initialization above.
+     */
+    if (background_fence && active) {
+        OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+    }
+
     /* identify the architectures of remote procs and setup
      * their datatype convertors, if required
      */

--- a/ompi/test/Makefile.am
+++ b/ompi/test/Makefile.am
@@ -22,4 +22,4 @@
 # t, file, datatype, general, mpi-abi, reexport, and bindings-generator are run by
 # "make check".  spc and monitoring are multi-process tests: they are
 # built, but not run by "make check".
-SUBDIRS = t file datatype general monitoring part spc mpi-abi reexport bindings-generator
+SUBDIRS = t file datatype general monitoring part spc mpi-abi mpirun reexport bindings-generator

--- a/ompi/test/mpirun/Makefile.am
+++ b/ompi/test/mpirun/Makefile.am
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Tests that have to be launched by mpirun.
+#
+# Everything run by "make check" elsewhere in the tree is either a
+# non-MPI unit test or an MPI singleton, because Automake runs each test
+# binary directly.  Some behavior, though, only exists between two ranks
+# of a real job -- endpoint wire-up being the obvious example -- and
+# cannot be reached without a launcher.  Those tests live here.
+#
+# Like ompi/test/mpi-abi's check-abi, this target requires Open MPI to
+# have been INSTALLED first, and the installation's bin directory to be
+# in the PATH.  "make check" deliberately runs before "make install", so
+# these tests cannot be part of it.  Requiring the install is not just a
+# scheduling convenience: the mpirun in the build tree is a thin wrapper
+# that exec's $(bindir)/prterun, so it does not work until Open MPI has
+# been installed.  Testing the installed tree also means the wrapper
+# compiler, the launcher, and the component DSOs are all exactly what a
+# user would get.
+#
+#     make install
+#     PATH=$prefix/bin:$PATH make -C ompi/test/mpirun check-mpirun
+#
+# Ground rules for anything added here:
+#
+# 1. Use no more than 2 ranks.  These run on CI machines with very few
+#    cores, alongside whatever else the job is doing; a test that needs
+#    a big job does not belong here.
+#
+# 2. Always pass --timeout.  A bug in this area is at least as likely to
+#    hang as it is to fail, and a hang must not stall CI until the
+#    job-level timeout kills it.
+
+EXTRA_DIST = \
+        async_modex_wireup.c
+
+# Deliberately built by the check-mpirun target rather than by Automake:
+# these are compiled with the *installed* wrapper compiler.
+MPICC = mpicc
+MPIRUN = mpirun
+
+# Rule 1 above: no more than 2 ranks.
+MPIRUN_NP = 2
+
+# Rule 2 above: never let a hung test run forever.
+MPIRUN_TIMEOUT = 60
+
+mpirun_runner = $(MPIRUN) --timeout $(MPIRUN_TIMEOUT) \
+        -n $(MPIRUN_NP) --map-by ppr:$(MPIRUN_NP):node
+
+# The asynchronous modex has to be enabled in the *MPI processes'*
+# environment; "mpirun --mca pmix_base_async_modex 1" does not reach
+# them.
+#
+# Run the wire-up test twice: once with only the shared memory BTL,
+# where a wire-up failure shows up as a prompt "unable to reach" abort,
+# and once with the default transports, where a fallback transport turns
+# the same failure into a hang.  Both must pass.
+#
+# Not an Automake-recognized hook, so declare it phony to keep make from
+# skipping it if a like-named file ever appears here.
+.PHONY: check-mpirun
+
+check-mpirun:
+	@if ! command -v $(MPICC) >/dev/null 2>&1 || \
+	    ! command -v $(MPIRUN) >/dev/null 2>&1; then \
+	    echo "SKIP: $(MPICC)/$(MPIRUN) not found in PATH (is Open MPI installed?)"; \
+	else \
+	    set -e; \
+	    $(MPICC) -g "$(srcdir)/async_modex_wireup.c" -o async_modex_wireup; \
+	    echo "=== async modex wire-up, shared memory only ==="; \
+	    OMPI_MCA_pmix_base_async_modex=1 \
+	        $(mpirun_runner) --mca btl self,sm ./async_modex_wireup; \
+	    echo "=== async modex wire-up, default transports ==="; \
+	    OMPI_MCA_pmix_base_async_modex=1 \
+	        $(mpirun_runner) ./async_modex_wireup; \
+	fi
+
+clean-local:
+	rm -rf async_modex_wireup async_modex_wireup.dSYM

--- a/ompi/test/mpirun/async_modex_wireup.c
+++ b/ompi/test/mpirun/async_modex_wireup.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Regression test for the asynchronous modex endpoint wire-up race.
+ *
+ * When the asynchronous modex is enabled (pmix_base_async_modex), the
+ * job-wide data-collecting fence is launched in the background and
+ * MPI_Init continues while it is in flight.  Endpoint wire-up (the
+ * BTL/SMSC add_procs path) reads each peer's modex blob; PMIx does not
+ * defer a get for a peer that has not yet committed its data -- it
+ * returns NOT_FOUND -- so any peer that is merely slow to reach its
+ * fence reads as a peer that posted nothing.  Its endpoint is then
+ * never wired up, and, because the peer wires up *our* endpoint
+ * normally, messages it sends us land in a transport we are not
+ * polling.  Depending on which transports are available, that presents
+ * either as an "unable to reach" abort or as a silent hang the first
+ * time this process has to receive.
+ *
+ * Rather than rely on timing luck, this test *forces* the window: every
+ * non-zero rank sleeps before calling MPI_Init, guaranteeing that rank
+ * 0 performs its wire-up before its peers have committed anything.  The
+ * subsequent collectives require traffic in both directions, so a
+ * half-wired endpoint cannot go unnoticed.
+ *
+ * This test must be run with the asynchronous modex explicitly enabled
+ * (see the run-tests target in this directory's Makefile); it passes
+ * trivially otherwise.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/* How long non-zero ranks stall before MPI_Init.  Long enough that rank
+   0 is reliably through add_procs first, short enough to keep the test
+   fast in CI. */
+#define STALL_SECONDS 3
+
+int main(int argc, char *argv[])
+{
+    int rank, size, sum, expected;
+    const char *rank_str;
+
+    /* We have to decide whether to stall *before* MPI_Init, so use the
+       environment rather than MPI_Comm_rank().  If the variable is not
+       set (i.e., we were not launched by mpirun), no rank stalls and
+       the test still runs correctly -- it just is not a useful race
+       test. */
+    rank_str = getenv("OMPI_COMM_WORLD_RANK");
+    if (NULL != rank_str && 0 != atoi(rank_str)) {
+        sleep(STALL_SECONDS);
+    }
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size < 2) {
+        if (0 == rank) {
+            fprintf(stderr, "ERROR: this test requires at least 2 ranks\n");
+        }
+        MPI_Abort(MPI_COMM_WORLD, 1);
+        return 1;
+    }
+
+    /* An allreduce forces rank 0 to receive from every peer -- which is
+       precisely the direction a half-wired endpoint loses. */
+    sum = rank;
+    MPI_Allreduce(MPI_IN_PLACE, &sum, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+    expected = size * (size - 1) / 2;
+    if (sum != expected) {
+        fprintf(stderr, "ERROR: rank %d: allreduce gave %d, expected %d\n", rank, sum, expected);
+        MPI_Abort(MPI_COMM_WORLD, 1);
+        return 1;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (0 == rank) {
+        printf("async modex wire-up test: PASSED (%d ranks)\n", size);
+    }
+
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
Backport of #14321 to `v6.0.x`.

---

The asynchronous modex (`pmix_base_async_modex`) is broken, and has been since February 2020. Nothing in CI enables it, so nobody noticed. This fixes it and adds the missing coverage.

This is the OMPI-side bug that #14316 trips over: with that PR's default flip, CI hangs. That is not a reason to hold the flip — as @rhc54 put it there, the thing to do is fix async modex and get it into CI. This PR does that, and is independent of #14316: it changes nothing when the asynchronous modex is off (the default on `main`), so it can land first and make #14316's flip safe.

### The bug

`ompi_mpi_instance_init_common()` launches the data-collecting fence in the background and continues, waiting for it only at the very end. But endpoint wire-up happens *inside* that window: `add_procs()` has each BTL/SMSC fetch every peer's modex blob.

That is only correct if a modex get for a peer that has not yet committed blocks until the data shows up. It does not. PMIx returns `PMIX_ERR_NOT_FOUND` — and, importantly, it does so for the **waiting** form of the get just as for the `PMIX_IMMEDIATE` form. So a peer that is merely slow to reach its fence is indistinguishable from a peer that posted nothing, and its endpoint is silently never wired up.

The failure is then asymmetric, which is what makes it so confusing: the slow peer wires up *our* endpoint normally once its data is in hand, so it sends to us over a transport whose progress function we never registered. With a fallback transport present, the job hangs the first time the affected rank has to receive. With only shared memory available, it aborts with "unable to reach".

### Evidence

A deterministic reproducer (non-zero ranks stall before `MPI_Init`, forcing the window — this is the test added here), np=2, before this fix:

| transports | async modex | result |
|---|---|---|
| `self,sm` | on | fails every run — "unable to reach ... BTLs attempted: self sm" |
| `self,sm,tcp` | on | hangs (or aborts — it varies) |
| either | off | passes |

And under CPU load with the ordinary ABI probes, no artificial delay: async modex on gave 21 failures in 30 runs, async modex off gave 0 in 40. After this fix, every one of those configurations passes, including 25/25 under load.

Instrumenting `init_sm_endpoint()` shows the mechanism directly: the peer's local-rank get succeeds (`rc=0`) while the blob get returns `rc=-46` = `PMIX_ERR_NOT_FOUND`. With this fix, that same get returns 0.

### The fix

Wait for the background fence to complete before the first code that reads peer modex data. The fence still overlaps with all the framework initialization above that point — where the bulk of the asynchronous modex's benefit comes from — but wire-up, which cannot be done correctly without the data, no longer races it.

Note this is deliberately *not* a per-BTL fix. Every transport that resolves peers during `add_procs` is exposed (`tcp`, `ofi`, `uct`, `portals4`, `usnic`, `smcuda`, and both `smsc` components, as well as `sm`), so the fix belongs in the one place that owns the fence.

### Where this came from

`OPAL_MODEX_RECV_IMMEDIATE` arrived in 9e2db26732 ("Fix vader local modex", Feb 2020), which changed the endpoint blob read from the waiting `OPAL_MODEX_RECV` to the immediate form. That is *not* the root cause — the waiting form fails here too — but it is when the code stopped even nominally honoring the "modex_recv calls are cached until the background modex completes" contract that the comment in `instance.c` still claims. Worth knowing that comment is not accurate.

### CI coverage

The second commit adds `ompi/test/mpirun/`, a home for tests that need a launcher, run by a new `check-mpirun` target.

Why not `make check`? Every test it runs is either a non-MPI unit test or an MPI singleton, because Automake runs each test binary directly. Endpoint wire-up only exists between two ranks of a real job. And `check-mpirun` requires `make install` first, like `check-abi`: the build-tree `mpirun` is only a wrapper that exec's `$(bindir)/prterun`, so it cannot work uninstalled (verified — a clean VPATH build fails with "prterun: No such file or directory" on both platforms). Testing the installed tree also means the wrapper compiler, launcher, and component DSOs are exactly what a user gets. Two ground rules are documented for anything added there later: no more than 2 ranks, and always pass `--timeout`.

The test forces the race deterministically instead of waiting for luck, and runs twice: shared-memory-only (where the failure aborts) and default transports (where a fallback turns it into a hang).

### Verification

Clean VPATH builds from a `distclean`ed srcdir on macOS (native) and AlmaLinux 10 (container):

| stage | macOS | Linux |
|---|---|---|
| configure / build | pass | pass |
| `make check` | pass | pass |
| `check-mpirun` (after `make install`) | pass | pass |

### Not addressed here

* `sm_add_procs()` sets a peer's reachability bit *before* `init_sm_endpoint()` can fail (`btl_sm_module.c`). Harmless today, because `bml_r2` discards the whole BTL when `add_procs` returns an error and never consults the bitmap — but it is wrong, and worth a separate drive-by.
* With `pmix_base_collect_data` set to false there is no fence at all, so this fix does not apply to that (non-default) combination; on-demand retrieval there is a different path.
* `bml_r2` silently drops a BTL wholesale on any `add_procs` error and skips its progress registration, which is what converts one failed endpoint into a deaf rank. Making that failure louder would have saved a lot of debugging here.

