### PR TITLE
mpirun: also set PRTE_MCA_personality alongside schizo_proxy

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -134,6 +134,9 @@ int main(int argc, char *argv[])
      * child environment because it is easier and we're not going to
      * be around long enough for it to matter (since we exec prterun
      * asap */
+    setenv("PRTE_MCA_schizo_proxy", "ompi", 1);
+    /* schizo_proxy is deprecated in favor of personality.
+     * Set both for compatibility with older and newer PRRTE versions. */
     setenv("PRTE_MCA_personality", "ompi", 1);
     setenv("OMPI_VERSION", OMPI_VERSION, 1);
     char *base_tool_name = opal_basename(argv[0]);


### PR DESCRIPTION
`schizo_proxy` was renamed to `personality` in PRRTE. Using Open MPI
with an external PRRTE/PMIx new enough to know the rename prints this
on every launch:

  ```
  --------------------------------------------------------------------------
  A deprecated MCA variable value was specified in the environment or
  on the command line.  Deprecated MCA variables should be avoided;
  they may disappear in future releases.

  Deprecated variable: schizo_proxy
  New variable:        personality
  --------------------------------------------------------------------------
  ```

Set `PRTE_MCA_personality` alongside the existing
`PRTE_MCA_schizo_proxy`. An older prterun only recognizes
`schizo_proxy` and ignores the unknown `personality` var; a newer one
recognizes both.

A matching OpenPMIx patch
(openpmix/openpmix@101a8fc03a9010db6f2e69efffb46f7071b2d0b6) treats
an identical value on both names as intentional and silences the
warning. The patch has been merged upstream but is not yet in an
official release, so the warning will continue until a PMIx release
contains it. This change is therefore harmless until then and becomes
effective once that PMIx patch is available.

Credits: AccelCom @ Barcelona Supercomputing Center