### PR TITLE
[v6.0.x] Fix a typo and change async modex default

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -9,6 +9,7 @@
  * Copyright (c) 2023-2026 Jeffrey M. Squyres.  All rights reserved.
  * Copyright (c) 2024      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -646,11 +647,16 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                if( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, NULL, 0,
-                                                        fence_release,
-                                                        (void*)&active))) {
-                    ret = opal_pmix_convert_status(rc);
-                    return ompi_instance_print_error ("PMIx_Fence_nb() failed", ret);
+                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                if (PMIX_SUCCESS != rc) {
+                    active = false;
+                    if (PMIX_OPERATION_SUCCEEDED == rc) {
+                        // can return operation_succeeded if atomically completed
+                        ret = MPI_SUCCESS;
+                    } else {
+                        ret = opal_pmix_convert_status(rc);
+                        return ompi_instance_print_error ("PMIx_Fence_nb() failed", ret);
+                    }
                 }
             }
         } else {
@@ -662,12 +668,19 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
             OPAL_POST_OBJECT(&active);
             PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
             rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
-            if( PMIX_SUCCESS != rc) {
-                ret = opal_pmix_convert_status(rc);
-                return ompi_instance_print_error ("PMIx_Fence() failed", ret);
+            if (PMIX_SUCCESS != rc) {
+                active = false;
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
+                    // can return operation_succeeded if atomically completed
+                    ret = MPI_SUCCESS;
+                } else {
+                    ret = opal_pmix_convert_status(rc);
+                    return ompi_instance_print_error ("PMIx_Fence() failed", ret);
+                }
+            } else {
+                /* cannot just wait on thread as we need to call opal_progress */
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
             }
-            /* cannot just wait on thread as we need to call opal_progress */
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
         }
     }
 
@@ -844,7 +857,9 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
          * we have to wait here for it to complete. However, there
          * is no reason to do two barriers! */
         if (background_fence) {
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+            if (active) {
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+            }
         } else if (!ompi_async_mpi_init) {
             /* wait for everyone to reach this point - this is a hard
              * barrier requirement at this time, though we hope to relax
@@ -853,12 +868,19 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
             active = true;
             OPAL_POST_OBJECT(&active);
             PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-            if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, info, 1,
-                                                    fence_release, (void*)&active))) {
-                ret = opal_pmix_convert_status(rc);
-                return ompi_instance_print_error ("PMIx_Fence_nb() failed", ret);
+            rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
+            if (PMIX_SUCCESS != rc) {
+                active = false;
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
+                    // can return operation_succeeded if atomically completed
+                    ret = MPI_SUCCESS;
+                } else {
+                    ret = opal_pmix_convert_status(rc);
+                    return ompi_instance_print_error ("PMIx_Fence() failed", ret);
+                }
+            } else {
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
             }
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
         }
     }
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -647,7 +647,7 @@ static int ompi_mpi_instance_init_common (int argc, char **argv)
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
                 if (PMIX_SUCCESS != rc) {
                     active = false;
                     if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/ompi/runtime/ompi_mpi_finalize.c
+++ b/ompi/runtime/ompi_mpi_finalize.c
@@ -24,6 +24,7 @@
  *                         reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -300,14 +301,25 @@ int ompi_mpi_finalize(void)
          * communications/actions to complete.  See
          * https://github.com/open-mpi/ompi/issues/1576 for the
          * original bug report. */
-        if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_cbfunc, (void*)&active))) {
-            ret = opal_pmix_convert_status(rc);
-            OMPI_ERROR_LOG(ret);
+        rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_cbfunc, (void*)&active);
+        if (PMIX_SUCCESS != rc) {
             /* Reset the active flag to false, to avoid waiting for
              * completion when the fence was failed. */
             active = false;
+            // can return operation_succeeded if atomically completed
+            if (PMIX_OPERATION_SUCCEEDED == rc) {
+                ret = MPI_SUCCESS;
+            } else {
+                ret = opal_pmix_convert_status(rc);
+                OMPI_ERROR_LOG(ret);
+            }
+        } else {
+            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+            /* NOTE: we lose the fence return status here. This can be
+             * a problem as the fence CAN fail. Might consider retrieving
+             * the returned status so you can respond if it doesn't 
+             * successfully complete? */
         }
-        OMPI_LAZY_WAIT_FOR_COMPLETION(active);
     }
 
     ompi_mpi_instance_finalize (&ompi_mpi_instance_default);

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -543,7 +543,7 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
                 if (PMIX_SUCCESS != rc) {
                     active = false;
                     if (PMIX_OPERATION_SUCCEEDED == rc) {

--- a/ompi/runtime/ompi_mpi_init.c
+++ b/ompi/runtime/ompi_mpi_init.c
@@ -26,7 +26,7 @@
  * Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.
  *                         All Rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021-2022 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2025      Advanced Micro Devices, Inc. All rights reserved.
@@ -543,12 +543,17 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
                 active = true;
                 OPAL_POST_OBJECT(&active);
                 PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
-                if( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, NULL, 0,
-                                                        fence_release,
-                                                        (void*)&active))) {
-                    ret = opal_pmix_convert_status(rc);
-                    error = "PMIx_Fence_nb() failed";
-                    goto error;
+                rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active);
+                if (PMIX_SUCCESS != rc) {
+                    active = false;
+                    if (PMIX_OPERATION_SUCCEEDED == rc) {
+                        // can return operation_succeeded if atomically completed
+                        ret = MPI_SUCCESS;
+                    } else {
+                        ret = opal_pmix_convert_status(rc);
+                        error = "PMIx_Fence_nb() failed";
+                        goto error;
+                    }
                 }
             }
         } else {
@@ -561,12 +566,19 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
             PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &opal_pmix_collect_all_data, PMIX_BOOL);
             rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
             if( PMIX_SUCCESS != rc) {
-                ret = opal_pmix_convert_status(rc);
-                error = "PMIx_Fence() failed";
-                goto error;
+                active = false;
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
+                    // can return operation_succeeded if atomically completed
+                    ret = MPI_SUCCESS;
+                } else {
+                    ret = opal_pmix_convert_status(rc);
+                    error = "PMIx_Fence_nb() failed";
+                    goto error;
+                }
+            } else {
+                /* cannot just wait on thread as we need to call opal_progress */
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
             }
-            /* cannot just wait on thread as we need to call opal_progress */
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
         }
     }
 
@@ -616,7 +628,9 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
          * we have to wait here for it to complete. However, there
          * is no reason to do two barriers! */
         if (background_fence) {
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+            if (active) {
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
+            }
         } else if (!ompi_async_mpi_init) {
             /* wait for everyone to reach this point - this is a hard
              * barrier requirement at this time, though we hope to relax
@@ -625,13 +639,20 @@ int ompi_mpi_init(int argc, char **argv, int requested, int *provided,
             active = true;
             OPAL_POST_OBJECT(&active);
             PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-            if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, info, 1,
-                                                    fence_release, (void*)&active))) {
-                ret = opal_pmix_convert_status(rc);
-                error = "PMIx_Fence_nb() failed";
-                goto error;
+            rc = PMIx_Fence_nb(NULL, 0, info, 1, fence_release, (void*)&active);
+            if (PMIX_SUCCESS != rc) {
+                active = false;
+                if (PMIX_OPERATION_SUCCEEDED == rc) {
+                    // can return operation_succeeded if atomically completed
+                    ret = MPI_SUCCESS;
+                } else {
+                    ret = opal_pmix_convert_status(rc);
+                    error = "PMIx_Fence_nb() failed";
+                    goto error;
+                }
+            } else {
+                OMPI_LAZY_WAIT_FOR_COMPLETION(active);
             }
-            OMPI_LAZY_WAIT_FOR_COMPLETION(active);
         }
     }
 

--- a/opal/mca/pmix/base/pmix_base_frame.c
+++ b/opal/mca/pmix/base/pmix_base_frame.c
@@ -5,6 +5,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +36,7 @@
 
 bool opal_pmix_collect_all_data = true;
 int opal_pmix_verbose_output = -1;
-bool opal_pmix_base_async_modex = false;
+bool opal_pmix_base_async_modex = true;
 opal_pmix_base_t opal_pmix_base = {.timeout = 0,
                                    .initialized = 0,
                                    .lock = {.mutex = OPAL_MUTEX_STATIC_INIT,
@@ -44,7 +45,7 @@ opal_pmix_base_t opal_pmix_base = {.timeout = 0,
 
 static int opal_pmix_base_frame_register(mca_base_register_flag_t flags)
 {
-    opal_pmix_base_async_modex = false;
+    opal_pmix_base_async_modex = true;
     (void) mca_base_var_register("opal", "pmix", "base", "async_modex",
                                  "Use asynchronous modex mode", MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                                  OPAL_INFO_LVL_9, MCA_BASE_VAR_SCOPE_READONLY,


### PR DESCRIPTION
Backport of #14316 to `v6.0.x`.

This backport carries **two** commits, because #14316 does not apply to `v6.0.x` on its own. In merge order:

1. **#13628** — "Fix usage of PMIx_Fence_nb to conform with PMIx Standard" (commit c3f1a510a6, merged 2026-02-10). **This PR was labeled `Target: v6.0.x` but was never actually backported.** It reworks every `PMIx_Fence_nb()` call site to handle `PMIX_OPERATION_SUCCEEDED` — the case where the fence completes atomically and the callback is therefore never invoked — and to clear `active` on the error paths. `v6.0.x` still carries the older shape:

   ```c
   if( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, NULL, 0, fence_release, (void*)&active))) {
   ```

   Since #14316 edits exactly those lines, cherry-picking it alone conflicts in `ompi/instance/instance.c` and `ompi/runtime/ompi_mpi_init.c`. Picking #13628 first resolves that: #14316 then applies with no conflicts at all (the resulting diff is byte-identical to the commit on `main`).

2. **#14316** — "Fix a typo and change async modex default" (the PR actually being backported here).

The only conflict encountered in the whole sequence was a copyright-header line in `ompi/instance/instance.c` while picking #13628 (two 2026 lines added independently on the two branches); both lines were kept. No code conflicts.

**Additionally, this PR likely needs #14322 merged as well — see below.**

Note that #13628 also touches `ompi/runtime/ompi_mpi_finalize.c`, which is why this backport's diff is larger than #14316's alone.

### This PR likely also needs #14322 to be merged

**#14322** backports #14321 ("Fix the asynchronous modex endpoint wire-up race") to `v6.0.x`. It is not a *build* dependency of this PR — the two apply independently, and I verified all three commits coexist cleanly in either order — but it is very likely a *correctness* dependency, and merging this PR without it is not recommended.

The reason: #14316 flips `pmix_base_async_modex` to true by default, and #14321 is what makes that code path safe. Before #14321, enabling the asynchronous modex meant endpoint wire-up ran while the background fence was still in flight, so a peer that had not yet committed its modex data read as a peer that posted nothing and its endpoint was silently never wired up. That showed up as hangs (or "unable to reach" aborts) in five CI jobs on #14316 itself, and it affects every transport that resolves peers during `add_procs`, not just shared memory.

So on `v6.0.x`, merging this PR alone would turn on by default a code path that the release branch does not yet have the fix for. Recommended order: merge #14322 first (or at least both before `v6.0.x` ships).

---

The fence code in ompi_mpi_init correctly loaded a pmix_info_t, and then promptly forgot to include it in the PMIx_Fence_nb call, thereby losing the collect_data flag setting.

Change the default async_modex flag from false to true. There is no known reason to conduct a synchronous modex. We could just remove it altogether, but at least switching the default flag value is a reasonable first step.
