### PR TITLE
accelerator/cuda: fix memory pool and memory context handling

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -356,7 +356,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         if (OPAL_UNLIKELY(NULL == ctx)) {
             cuCtxSetCurrent(mem_ctx);
         }
-        return 1;
     }
 
     is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -261,15 +261,17 @@ static int accelerator_cuda_check_mpool(CUdeviceptr dbuf, CUmemorytype *mem_type
     }
 
     /* check if device has access */
-    for (int i = 0; i < device_count; i++) {
-        location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-        location.id   = i;
-        result = cuMemPoolGetAccess(&flags, mpool, &location);
-        if ((CUDA_SUCCESS == result) &&
-            (CU_MEM_ACCESS_FLAGS_PROT_READWRITE == flags)) {
-            *mem_type = CU_MEMORYTYPE_DEVICE;
-            *dev_id  = i;
-            return 1;
+    if (mpool) {
+        for (int i = 0; i < device_count; i++) {
+            location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+            location.id   = i;
+            result = cuMemPoolGetAccess(&flags, mpool, &location);
+            if ((CUDA_SUCCESS == result) &&
+                (CU_MEM_ACCESS_FLAGS_PROT_READWRITE == flags)) {
+                *mem_type = CU_MEMORYTYPE_DEVICE;
+                *dev_id  = i;
+                return 1;
+            }
         }
     }
 

--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -355,8 +355,22 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
 
     if (CU_MEMORYTYPE_DEVICE == mem_type && NULL != mem_ctx) {
         result = cuCtxGetCurrent(&ctx);
+        if (CUDA_SUCCESS != result) {
+            opal_output(0,
+                        "CUDA: error calling cuCtxGetCurrent: "
+                        "result=%d, ptr=%p",
+                        result, addr);
+            return OPAL_ERROR;
+        }
         if (OPAL_UNLIKELY(NULL == ctx)) {
-            cuCtxSetCurrent(mem_ctx);
+            result = cuCtxSetCurrent(mem_ctx);
+            if (CUDA_SUCCESS != result) {
+                opal_output(0,
+                            "CUDA: error calling cuCtxSetCurrent: "
+                            "result=%d, ptr=%p",
+                            result, addr);
+                return OPAL_ERROR;
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses two issues I encountered recently:

1) When we detect a context for the memory we're probing in check_addr we would just return without setting the output device ID and *after* setting the memory context. This is most likely a typo.
2) We did not check whether the memory pool was valid before passing it to `cuMemPoolGetAccess`, which leads to a flood of warnings from cuda-gdb. Adding a check silences these.

