### PR TITLE
[v6.0.x] mpirun: also set PRTE_MCA_personality alongside schizo_proxy

### DIFF
--- a/ompi/tools/mpirun/main.c
+++ b/ompi/tools/mpirun/main.c
@@ -135,6 +135,9 @@ int main(int argc, char *argv[])
      * be around long enough for it to matter (since we exec prterun
      * asap */
     setenv("PRTE_MCA_schizo_proxy", "ompi", 1);
+    /* schizo_proxy is deprecated in favor of personality.
+     * Set both for compatibility with older and newer PRRTE versions. */
+    setenv("PRTE_MCA_personality", "ompi", 1);
     setenv("OMPI_VERSION", OMPI_VERSION, 1);
     char *base_tool_name = opal_basename(argv[0]);
     setenv("OMPI_TOOL_NAME", base_tool_name, 1);


### PR DESCRIPTION
schizo_proxy is deprecated in PRRTE in favor of personality, and a PRRTE new enough to know the rename warns on every launch that uses it. Setting personality alongside it keeps mpirun working silently against both an older prterun (which only recognizes schizo_proxy) and a newer one -- a matching OpenPMIx patch is upstream, pending an official release, and silences the warning too.

Credits: AccelCom @ Barcelona Supercomputing Center


(cherry picked from commit 9870598af78533e944f43aba650e5711389a1bc8)