### PR TITLE
ompi/runtime: fix singleton output cleanup

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -937,8 +937,11 @@ static bool check_file(const char *root, const char *path)
      *  - non-zero files starting with "output-"
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
-        fullpath = opal_os_path(false, &fullpath, root, path, NULL);
-        stat(fullpath, &st);
+        fullpath = opal_os_path(false, root, path, NULL);
+        if (NULL == fullpath || 0 != stat(fullpath, &st)) {
+            free(fullpath);
+            return false;
+        }
         free(fullpath);
         if (0 == st.st_size) {
             return true;

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -938,10 +938,7 @@ static bool check_file(const char *root, const char *path)
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
         fullpath = opal_os_path(false, root, path, NULL);
-        if (NULL == fullpath || 0 != stat(fullpath, &st)) {
-            free(fullpath);
-            return false;
-        }
+        stat(fullpath, &st);
         free(fullpath);
         if (0 == st.st_size) {
             return true;

--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -938,7 +938,10 @@ static bool check_file(const char *root, const char *path)
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
         fullpath = opal_os_path(false, root, path, NULL);
-        stat(fullpath, &st);
+        if (NULL == fullpath || 0 != stat(fullpath, &st)) {
+            free(fullpath);
+            return false;
+        }
         free(fullpath);
         if (0 == st.st_size) {
             return true;

--- a/ompi/test/general/mpi_init.c
+++ b/ompi/test/general/mpi_init.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
+ * Copyright (c) 2026      Yongqiang Tian.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,9 +19,16 @@
 
 #include "ompi_config.h"
 
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
 #include "support.h"
 
 #include "mpi.h"
+#include "opal/util/os_path.h"
+#include "opal/util/proc.h"
 
 int main(int argc, char *argv[])
 {
@@ -39,8 +47,33 @@ int main(int argc, char *argv[])
     MPI_Comm_size(MPI_COMM_SELF, &self_size);
     test_verify("MPI_COMM_SELF size is 1", 1 == self_size);
 
+    char *empty_output = NULL;
+    test_verify("singleton process session directory is available",
+                NULL != opal_process_info.proc_session_dir);
+    if (NULL != opal_process_info.proc_session_dir) {
+        empty_output = opal_os_path(false, opal_process_info.proc_session_dir,
+                                    "output-empty-regression", NULL);
+    }
+    test_verify("singleton session output path is available", NULL != empty_output);
+
+    FILE *stream = NULL;
+    if (NULL != empty_output) {
+        stream = fopen(empty_output, "w");
+    }
+    test_verify("empty singleton output file can be created", NULL != stream);
+    if (NULL != stream) {
+        fclose(stream);
+    }
+
     rc = MPI_Finalize();
     test_verify("MPI_Finalize returns MPI_SUCCESS", MPI_SUCCESS == rc);
+
+    if (NULL != empty_output) {
+        errno = 0;
+        test_verify("MPI_Finalize removes empty singleton output",
+                    -1 == access(empty_output, F_OK) && ENOENT == errno);
+        free(empty_output);
+    }
 
     return test_finalize();
 }


### PR DESCRIPTION
## Summary

- remove the unintended `&fullpath` path element from the singleton session cleanup call to `opal_os_path()`
- retain the entry if its path cannot be constructed or `stat()` fails, instead of reading an uninitialized `struct stat`
- extend the singleton `MPI_Init` / `MPI_Finalize` test to verify that finalization removes an empty `output-*` file

`check_file()` passed a `char **` as the first unnamed argument to the NULL-terminated variadic `opal_os_path()` API. The active `sentinel` attribute checks the terminating NULL but cannot diagnose the type of that unnamed element. As a result, singleton finalization queried an unintended path, retained an empty output file, and left its session-directory tree behind.

The callback now treats path-construction or `stat()` failure conservatively: when it cannot establish that an output file is empty, it retains the entry.

Fixes #14338.

## Testing

- clean out-of-tree developer build with `--disable-mpi-fortran`
- direct `ompi/test/general/mpi_init`: 9/9 checks passed
- `make check` in `ompi/test/general`: 17/17 tests passed
- regression-oracle check: temporarily restoring the old call made the new test fail in 3/3 runs; restoring the fix made it pass again
