### PR TITLE
ABI: A few enhancements to mpi.h

### DIFF
--- a/ompi/mpi/c/abi.h.in
+++ b/ompi/mpi/c/abi.h.in
@@ -28,6 +28,10 @@ extern "C" {
 #undef MPI_ABI_SUBVERSION
 #define MPI_ABI_SUBVERSION 0
 
+typedef intptr_t @MPI_AINT@;
+typedef int64_t  @MPI_OFFSET@;
+typedef int64_t  @MPI_COUNT@;
+
 typedef struct MPI_ABI_Comm * MPI_Comm;
 typedef struct MPI_ABI_Datatype * MPI_Datatype;
 typedef struct MPI_ABI_Errhandler * MPI_Errhandler;
@@ -39,30 +43,6 @@ typedef struct MPI_ABI_Op * MPI_Op;
 typedef struct MPI_ABI_Request * MPI_Request;
 typedef struct MPI_ABI_Session * MPI_Session;
 typedef struct MPI_ABI_Win * MPI_Win;
-
-/* MPI_Aint is defined to be intptr_t (or equivalent to it, if compiler support is absent).
- * The only acceptable alternative to intptr_t is the C89 type equivalent to it. */
-#if !defined(MPI_ABI_Aint)
-#define MPI_ABI_Aint intptr_t
-#endif
-typedef MPI_ABI_Aint @MPI_AINT@;
-#undef  MPI_ABI_Aint
-
-/* MPI_Offset will be 64b on all relevant systems.
- * We allow for MPI implementations supporting for 128b filesystems. */
-#if !defined(MPI_ABI_Offset)
-#define MPI_ABI_Offset int64_t
-#endif
-typedef MPI_ABI_Offset @MPI_OFFSET@;
-#undef  MPI_ABI_Offset
-
-/* MPI_Count must be large enough to hold the larger of MPI_Aint and MPI_Offset.
- * Platforms where MPI_Aint is larger than MPI_Offset are extremely rare. */
-#if !defined(MPI_ABI_Count)
-#define MPI_ABI_Count MPI_Offset
-#endif
-typedef MPI_ABI_Count @MPI_COUNT@;
-#undef  MPI_ABI_Count
 
 typedef struct {
   int MPI_SOURCE;

--- a/ompi/mpi/c/abi.h.in
+++ b/ompi/mpi/c/abi.h.in
@@ -11,7 +11,6 @@
 #ifndef MPI_H_ABI
 #define MPI_H_ABI
 
-#include <stddef.h>
 #include <stdint.h>
 
 #if defined(__cplusplus)


### PR DESCRIPTION
* If `stdint.h` is assumed to be available, then MPI_Aint/Offset/Count can be defined from the integral types there without requiring any C preprocessor crutches.

* The MPI ABI header can be implemented without `stddef.h`.

PS: The removal of `stddef.h` may break the build and/or tests. Let's see how it goes.
