### PR TITLE
opal: remove malloc attribute from realloc wrapper

### DIFF
--- a/opal/util/malloc.h
+++ b/opal/util/malloc.h
@@ -112,7 +112,7 @@ OPAL_DECLSPEC void *opal_calloc(size_t nmembers, size_t size, const char *file, 
  * configure (or by default if you're building in a SVN checkout).
  */
 OPAL_DECLSPEC void *opal_realloc(void *ptr, size_t size, const char *file, int line)
-    __opal_attribute_malloc__ __opal_attribute_warn_unused_result__;
+    __opal_attribute_warn_unused_result__;
 
 /**
  * \internal


### PR DESCRIPTION
Fixes #14343.

`opal_realloc` is realloc-like: returned storage can preserve pointers copied
from the previous allocation to existing objects. It therefore does not satisfy
the no-alias property expressed by GCC's plain `malloc` function attribute.

[GCC's documentation](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute)
explicitly distinguishes realloc-like functions from functions that satisfy
the plain `malloc` attribute.

As demonstrated in #14343, GCC 11 and GCC 16 at `-O2` and `-O3` can apply an
invalid alias optimization when the realloc wrapper carries this attribute.
Removing the attribute restores the expected result in the matched reproducer.

This PR removes `__opal_attribute_malloc__` from the `opal_realloc`
declaration while retaining `__opal_attribute_warn_unused_result__`.

Validation on x86-64 Ubuntu with GCC 11.4:

- `./autogen.pl`
- `../configure --enable-mem-debug --disable-dlopen`
- `make -j6`
- native `opal_malloc`: 15/15 tests passed
- native `opal_pointer_array`: 27/27 tests passed