### PR TITLE
Give MPI_Lookup_name a range when the caller does not

### DIFF
--- a/docs/man-openmpi/man3/MPI_Lookup_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Lookup_name.3.rst
@@ -42,39 +42,44 @@ The following keys for *info* are recognized:
    Key                   Type      Description
    ---                   ----      -----------
 
-   ompi_lookup_order     char *    Resolution order for name lookup.
+   range                 char *    Scope in which to search for the
+                                   service name.  See the NAME SCOPE
+                                   section below.
 
-The *ompi_lookup_order* info key can specify one of four valid string
-values (see the NAME SCOPE section below for more information on name
-scopes):
+The *range* info key accepts one of two string values:
 
-*local*: Only search the local scope for name resolution.
+*nspace*: Restrict the operation to processes in the same MPI job (PMIx
+   namespace) as the calling process.
 
-*global*: Only search the global scope for name resolution.
+*session*: Apply the operation across all processes in the same session.
 
-*local,global*: Search the local scope for name resolution. If
-   not found, try searching the global scope for name resolution. This
-   behavior is the default if the *ompi_lookup_order* info key is not
-   specified.
+If the *info* argument is ``MPI_INFO_NULL``, or is a valid info object
+that does not contain a *range* key, *session* scope is used. Because
+:ref:`MPI_Publish_name`, :ref:`MPI_Lookup_name`, and
+:ref:`MPI_Unpublish_name` all share this default, a name published with
+``MPI_INFO_NULL`` is found by a lookup with ``MPI_INFO_NULL``.
 
-*global,local*: Search the global scope for name resolution. If
-   not found, try searching the local scope for name resolution.
-
-If no info key is provided, the search will first check to see if a
-global server has been specified and is available. If so, then the
-search will default to global scope first, followed by local. Otherwise,
-the search will default to local.
+Any other value for *range* results in an error.
 
 
 NAME SCOPE
 ----------
 
-Open MPI supports two name scopes: *global* and *local*. Local scope
-values are placed in a data store located on the mpirun of the calling
-process' job, while global scope values reside on a central server.
-Calls to :ref:`MPI_Unpublish_name` must correctly specify the scope to be used
-in finding the value to be removed. The function will return an error if
-the specified service name is not found on the indicated location.
+Open MPI supports two name scopes, selected by the *range* info key:
+*nspace* and *session*.
+
+*nspace* scope restricts the (service_name, port_name) pair to processes
+in the publisher's own MPI job, i.e., processes sharing the publisher's
+PMIx namespace.
+
+*session* scope makes the pair visible to every process in the same PMIx
+session. This includes jobs started by separate ``mpirun`` invocations
+that share a persistent DVM or scheduler allocation, as well as jobs
+created via :ref:`MPI_Comm_spawn`. *session* is the default scope.
+
+The same scope must be used to publish, look up, and unpublish a given
+service name. :ref:`MPI_Unpublish_name` returns an error if the service
+name is not found in the indicated scope.
 
 For a more detailed description of scoping rules, please see the
 :ref:`MPI_Publish_name` man page.

--- a/docs/man-openmpi/man3/MPI_Publish_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Publish_name.3.rst
@@ -41,75 +41,70 @@ The following keys for *info* are recognized:
    Key                   Type      Description
    ---                   ----      -----------
 
-   ompi_global_scope     bool      If set to true, publish the name in
-                                   the global scope.  Publish in the local
-                                   scope otherwise.  See the NAME SCOPE
-                                   section for more details.
+   range                 char *    Scope in which to publish the service
+                                   name.  See the NAME SCOPE section
+                                   below.
 
-   ompi_unique           bool      If set to true, return an error if the
-                                   specified service_name already exists.
-                                   Default to overwriting any pre-existing
-                                   value.
+   persistence           char *    How long the published service name is
+                                   retained.  See below.
 
-*bool* info keys are actually strings but are evaluated as follows: if
-the string value is a number, it is converted to an integer and cast to
-a boolean (meaning that zero integers are false and non-zero values are
-true). If the string value is (case-insensitive) "yes" or "true", the
-boolean is true. If the string value is (case-insensitive) "no" or
-"false", the boolean is false. All other string values are unrecognized,
-and therefore false.
+The *range* info key accepts one of two string values:
 
-If no info key is provided, the function will first check to see if a
-global server has been specified and is available. If so, then the
-publish function will default to global scope first, followed by local.
-Otherwise, the data will default to publish with local scope.
+*nspace*: Restrict the operation to processes in the same MPI job (PMIx
+   namespace) as the calling process.
+
+*session*: Apply the operation across all processes in the same session.
+
+If the *info* argument is ``MPI_INFO_NULL``, or is a valid info object
+that does not contain a *range* key, *session* scope is used. Because
+:ref:`MPI_Publish_name`, :ref:`MPI_Lookup_name`, and
+:ref:`MPI_Unpublish_name` all share this default, a name published with
+``MPI_INFO_NULL`` is found by a lookup with ``MPI_INFO_NULL``.
+
+Any other value for *range* results in an error.
+
+The *persistence* info key accepts one of four string values:
+
+*indef*: Retain the service name until it is explicitly unpublished.
+
+*proc*: Retain the service name until the publishing process terminates.
+
+*app*: Retain the service name until the publishing application
+   terminates.
+
+*session*: Retain the service name until the session terminates. This is
+   the default if the *persistence* key is not given.
+
+Any other value for *persistence* results in an error.
 
 
 NAME SCOPE
 ----------
 
-Open MPI supports two name scopes: *global* and *local*. Local scope
-will place the specified service/port pair in a data store located on
-the mpirun of the calling process' job. Thus, data published with local
-scope will only be accessible to processes in jobs spawned by that
-mpirun - e.g., processes in the calling process' job, or in jobs spawned
-via :ref:`MPI_Comm_spawn`.
+Open MPI supports two name scopes, selected by the *range* info key:
+*nspace* and *session*.
 
-Global scope places the specified service/port pair in a data store
-located on a central server that is accessible to all jobs running in
-the cluster or environment. Thus, data published with global scope can
-be accessed by multiple mpiruns and used for :ref:`MPI_Comm_Connect` and
-:ref:`MPI_Comm_accept` between jobs.
+*nspace* scope restricts the (service_name, port_name) pair to processes
+in the publisher's own MPI job, i.e., processes sharing the publisher's
+PMIx namespace.
 
-Note that global scope operations require both the presence of the
-central server and that the calling process be able to communicate to
-that server. :ref:`MPI_Publish_name` will return an error if global scope is
-specified and a global server is either not specified or cannot be
-found.
+*session* scope makes the pair visible to every process in the same PMIx
+session. This includes jobs started by separate ``mpirun`` invocations
+that share a persistent DVM or scheduler allocation, as well as jobs
+created via :ref:`MPI_Comm_spawn`. *session* is the default scope.
 
-Open MPI provides a server called *ompi-server* to support global scope
-operations. Please refer to its manual page for a more detailed
-description of data store/lookup operations.
+The same scope must be used to publish, look up, and unpublish a given
+service name. :ref:`MPI_Unpublish_name` returns an error if the service
+name is not found in the indicated scope.
 
-As an example of the impact of these scoping rules, consider the case
-where a job has been started with mpirun - call this job "job1". A
-process in job1 creates and publishes a service/port pair using a local
-scope. Open MPI will store this data in the data store within mpirun.
-
-A process in job1 (perhaps the same as did the publish, or perhaps some
-other process in the job) subsequently calls :ref:`MPI_Comm_spawn` to start
-another job (call it "job2") under this mpirun. Since the two jobs share
-a common mpirun, both jobs have access to local scope data. Hence, a
-process in job2 can perform an :ref:`MPI_Lookup_name` with a local scope to
-retrieve the information.
-
-However, assume another user starts a job using mpirun - call this job
-"job3". Because the service/port data published by job1 specified local
-scope, processes in job3 cannot access that data. In contrast, if the
-data had been published using global scope, then any process in job3
-could access the data, provided that mpirun was given knowledge of how
-to contact the central server and the process could establish
-communication with it.
+As an example of the impact of these scoping rules, consider a job
+started with ``mpirun`` -- call it "job1". A process in job1 publishes a
+service/port pair using *nspace* scope. A process in a job that job1
+subsequently starts via :ref:`MPI_Comm_spawn` -- call it "job2" -- is in
+a different namespace, and so cannot retrieve that pair. Had job1
+published with *session* scope (the default), processes in job2 could
+retrieve it, as could processes in any other job sharing the same
+session.
 
 
 ERRORS

--- a/docs/man-openmpi/man3/MPI_Unpublish_name.3.rst
+++ b/docs/man-openmpi/man3/MPI_Unpublish_name.3.rst
@@ -44,34 +44,44 @@ The following keys for *info* are recognized:
    Key                   Type      Description
    ---                   ----      -----------
 
-   ompi_global_scope     bool      If set to true, unpublish the name from
-                                   the global scope.  Unpublish from the local
-                                   scope otherwise.  See the NAME SCOPE
-                                   section for more details.
+   range                 char *    Scope from which to remove the service
+                                   name.  See the NAME SCOPE section
+                                   below.
 
-*bool* info keys are actually strings but are evaluated as follows: if
-the string value is a number, it is converted to an integer and cast to
-a boolean (meaning that zero integers are false and non-zero values are
-true). If the string value is (case-insensitive) "yes" or "true", the
-boolean is true. If the string value is (case-insensitive) "no" or
-"false", the boolean is false. All other string values are unrecognized,
-and therefore false.
+The *range* info key accepts one of two string values:
 
-If no info key is provided, the function will first check to see if a
-global server has been specified and is available. If so, then the
-unpublish function will default to global scope first, followed by
-local. Otherwise, the data will default to unpublish with local scope.
+*nspace*: Restrict the operation to processes in the same MPI job (PMIx
+   namespace) as the calling process.
+
+*session*: Apply the operation across all processes in the same session.
+
+If the *info* argument is ``MPI_INFO_NULL``, or is a valid info object
+that does not contain a *range* key, *session* scope is used. Because
+:ref:`MPI_Publish_name`, :ref:`MPI_Lookup_name`, and
+:ref:`MPI_Unpublish_name` all share this default, a name published with
+``MPI_INFO_NULL`` is found by a lookup with ``MPI_INFO_NULL``.
+
+Any other value for *range* results in an error.
 
 
 NAME SCOPE
 ----------
 
-Open MPI supports two name scopes: *global* and *local*. Local scope
-values are placed in a data store located on the mpirun of the calling
-process' job, while global scope values reside on a central server.
-Calls to :ref:`MPI_Unpublish_name` must correctly specify the scope to be used
-in finding the value to be removed. The function will return an error if
-the specified service name is not found on the indicated location.
+Open MPI supports two name scopes, selected by the *range* info key:
+*nspace* and *session*.
+
+*nspace* scope restricts the (service_name, port_name) pair to processes
+in the publisher's own MPI job, i.e., processes sharing the publisher's
+PMIx namespace.
+
+*session* scope makes the pair visible to every process in the same PMIx
+session. This includes jobs started by separate ``mpirun`` invocations
+that share a persistent DVM or scheduler allocation, as well as jobs
+created via :ref:`MPI_Comm_spawn`. *session* is the default scope.
+
+The same scope must be used to publish, look up, and unpublish a given
+service name. :ref:`MPI_Unpublish_name` returns an error if the service
+name is not found in the indicated scope.
 
 For a more detailed description of scoping rules, please see the
 :ref:`MPI_Publish_name` man page.

--- a/ompi/mpi/c/lookup_name.c.in
+++ b/ompi/mpi/c/lookup_name.c.in
@@ -101,6 +101,7 @@ PROTOTYPE ERROR_CLASS lookup_name(STRING service_name, INFO info, STRING_OUT por
             ret = MPI_ERR_NAME;
         }
 
+        PMIX_PDATA_DESTRUCT(&pdat);
         return OMPI_ERRHANDLER_NOHANDLE_INVOKE(ret, FUNC_NAME);
     }
 

--- a/ompi/mpi/c/lookup_name.c.in
+++ b/ompi/mpi/c/lookup_name.c.in
@@ -42,7 +42,7 @@ PROTOTYPE ERROR_CLASS lookup_name(STRING service_name, INFO info, STRING_OUT por
     pmix_status_t rc;
     pmix_pdata_t pdat;
     pmix_info_t pinfo;
-    pmix_data_range_t rng;
+    pmix_data_range_t rng = PMIX_RANGE_SESSION;
 
     if ( MPI_PARAM_CHECK ) {
         OMPI_ERR_INIT_FINALIZE(FUNC_NAME);


### PR DESCRIPTION
### The bug

`MPI_Lookup_name` declares its range uninitialized and only ever assigns it
inside `if (MPI_INFO_NULL != info)`, and then only when that info actually carries
a `"range"` key:

```c
pmix_data_range_t rng;                  /* never initialized */

if (MPI_INFO_NULL != info) {
    ompi_info_get(info, "range", &info_str, &flag);
    if (flag) {
        rng = ...;                      /* set ONLY here */
    }
}
PMIX_INFO_LOAD(&pinfo, PMIX_RANGE, &rng, PMIX_DATA_RANGE);   /* used unconditionally */
```

So a caller passing `MPI_INFO_NULL` - i.e. anyone who does not care about the
range - hands PMIx whatever happened to be on the stack.

The range a requester supplies constrains *which publishers its lookup is willing
to see*, so a garbage value matches none of them: every stored item is passed
over, the lookup returns "not found", and we translate that to `MPI_ERR_NAME`. A
name the calling process itself published moments earlier cannot be found.

Because it depends on what previously occupied that stack slot, it presents as an
intermittent, environment-dependent `MPI_ERR_NAME` rather than as anything the
caller did wrong.

`publish_name.c.in` and `unpublish_name.c.in` both initialize the same variable to
`PMIX_RANGE_SESSION`; `lookup_name.c.in` is the only one of the three that does
not - which is exactly why publish succeeds and the matching lookup fails.

### How it was found

mpi4py's `test_dynproc.TestDPM.testNamePublishing` (each rank publishes and then
looks up *its own* name, with `MPI_INFO_NULL`) started failing in PRRTE's mpi4py
CI:

```
  File "test/test_dynproc.py", line 56, in testNamePublishing
    found = MPI.Lookup_name(service)
mpi4py.MPI.Exception: MPI_ERR_NAME: invalid name argument
```

Tracing the range through the stack showed it arriving at PRRTE's data server as
`4` (`PMIX_RANGE_SESSION`) for the publish but as `107`/`109`/`111` for the lookup -
correct *type*, garbage *value*, varying run to run. One hop earlier it was already
garbage when PMIx handed it to the host server, so neither PRRTE nor PMIx was
involved; a minimal PMIx client doing the same publish/lookup with an explicit
range works correctly.

### The fix

Initialize `rng` to `PMIX_RANGE_SESSION` - the PMIx default for a lookup, and what
the two sibling files already use.

### Testing

With this one-line change, `mpiexec -n 2 python test/main.py -v
test_dynproc.TestDPM.testNamePublishing` passes on both ranks (it fails on both
without it), built against external PMIx and PRRTE master.
