### PR TITLE
[v6.0.x] opal/mca/base: fix var group lookup in component repository …

### DIFF
--- a/opal/mca/base/mca_base_component_repository.c
+++ b/opal/mca/base/mca_base_component_repository.c
@@ -296,7 +296,7 @@ static void mca_base_component_repository_release_internal(mca_base_component_re
 {
     int group_id;
 
-    group_id = mca_base_var_group_find(NULL, ri->ri_type, ri->ri_name);
+    group_id = mca_base_var_group_find("*", ri->ri_type, ri->ri_name);
     if (0 <= group_id) {
         /* ensure all variables are deregistered before we dlclose the component */
         mca_base_var_group_deregister(group_id);

--- a/opal/mca/base/mca_base_var_group.c
+++ b/opal/mca/base/mca_base_var_group.c
@@ -29,6 +29,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
@@ -412,6 +413,7 @@ int mca_base_var_group_deregister(int group_index)
 int mca_base_var_group_find(const char *project_name, const char *framework_name,
                             const char *component_name)
 {
+    assert(NULL != project_name);
     return group_find(project_name, framework_name, component_name, false);
 }
 


### PR DESCRIPTION
backport https://github.com/open-mpi/ompi/pull/13897 to v6.0.x