### PR TITLE
portals4: use PtlHandleIsEqual() to compare handles

### DIFF
--- a/opal/mca/btl/portals4/btl_portals4.c
+++ b/opal/mca/btl/portals4/btl_portals4.c
@@ -712,7 +712,7 @@ void mca_btl_portals4_free_module(mca_btl_portals4_module_t *portals4_btl)
         portals4_btl->recv_idx = (ptl_pt_index_t) ~0UL;
     }
 
-    if (PTL_EQ_NONE != portals4_btl->recv_eq_h) {
+    if (!PtlHandleIsEqual(portals4_btl->recv_eq_h, PTL_EQ_NONE)) {
         ret = PtlEQFree(portals4_btl->recv_eq_h);
         if (PTL_OK != ret)
             OPAL_OUTPUT_VERBOSE(


### PR DESCRIPTION
The Portals4 standard requires the use of PtlHandleIsEqual() instead of the (in)equality operator, because a handle may be a compound data type that cannot be directly compared.