### PR TITLE
coll/nbc return correct error code from progress during start of round

### DIFF
--- a/ompi/mca/coll/libnbc/nbc.c
+++ b/ompi/mca/coll/libnbc/nbc.c
@@ -599,7 +599,7 @@ static inline int NBC_Start_round(NBC_Handle *handle) {
   if (handle->row_offset) {
     res = NBC_Progress(handle);
     if ((NBC_OK != res) && (NBC_CONTINUE != res)) {
-      return OMPI_ERROR;
+      return res;
     }
   }
 


### PR DESCRIPTION
When a fault tolerance error causes NBC_Progress to return an error code, it will return the specific fault tolerance error code. NBC_Start_round is ignoring this and returning OMPI_ERROR instead of the correct code, which causes MPI functions to return MPI_ERR_OTHER instead of the correct fault tolerance error code.

This causes intermittent failures of Fenix's CI testing: https://github.com/sandialabs/Fenix/issues/136