### PR TITLE
v5.0.x: prepare v5.0.11rc1 release

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -17,7 +17,7 @@
 
 major=5
 minor=0
-release=10
+release=11
 
 # MPI Standard Compliance Level
 mpi_standard_version=3
@@ -41,7 +41,7 @@ flex_min_version=2.5.4
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc1
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"
@@ -62,7 +62,7 @@ tarball_version=gitclone
 
 # The date when this release was created
 
-date="20 January 2026"
+date="August 2026"
 
 # The shared library version of each of Open MPI's public libraries.
 # These versions are maintained in accordance with the "Library
@@ -94,14 +94,14 @@ date="20 January 2026"
 # Version numbers are described in the Libtool current:revision:age
 # format.
 
-libmpi_so_version=80:7:40
-libmpi_mpifh_so_version=80:1:40
+libmpi_so_version=80:8:40
+libmpi_mpifh_so_version=80:2:40
 libmpi_usempi_tkr_so_version=80:1:40
 libmpi_usempi_ignore_tkr_so_version=80:1:40
 libmpi_usempif08_so_version=80:3:40
-libopen_pal_so_version=80:5:0
+libopen_pal_so_version=80:6:0
 libmpi_java_so_version=80:1:40
-liboshmem_so_version=80:4:40
+liboshmem_so_version=80:5:40
 libompitrace_so_version=80:0:40
 
 # "Common" components install standalone libraries that are run-time
@@ -114,8 +114,8 @@ libmca_ompi_common_ompio_so_version=80:1:0
 libmca_ompi_common_monitoring_so_version=80:0:0
 
 # OPAL layer
-libmca_opal_common_cuda_so_version=80:0:0
-libmca_opal_common_ofi_so_version=80:4:0
-libmca_opal_common_sm_so_version=80:1:0
+libmca_opal_common_cuda_so_version=80:1:0
+libmca_opal_common_ofi_so_version=80:5:0
+libmca_opal_common_sm_so_version=80:2:0
 libmca_opal_common_ucx_so_version=80:1:0
 libmca_opal_common_ugni_so_version=80:0:0

--- a/docs/release-notes/changelog/v5.0.x.rst
+++ b/docs/release-notes/changelog/v5.0.x.rst
@@ -4,6 +4,70 @@ Open MPI v5.0.x series
 This file contains all the NEWS updates for the Open MPI v5.0.x
 series, in reverse chronological order.
 
+Open MPI Version v5.0.11
+------------------------------
+:Date: August 2026
+
+- Internal PMIx and PRRTe versions:
+  - PMIx (v5.0.11). Repo: ``https://github.com/openpmix/openpmix``. Commit hash: ``3795947f0fa625f406f1d085d1e70a8413b3febc``.
+  - PRRTE (v3.0.14). Repo: ``https://github.com/openpmix/prrte``. Commit hash: ``a99bf3a006ddc8609e85da8f8eef13ba6d27aaba``.
+
+- Partitioned Communication (MPI_Psend/MPI_Precv) Enhancements
+  - Support MPI_PROC_NULL in partitioned communication
+  - Fixed MPI_Parrived for null and inactive requests (fixes #14003)
+  - part/persist: cancel the setup handshake when freeing a request
+  - Added a partcomm fix for mismatched types
+  - spc: add missing per-function counters for partitioned communication
+  - Fixed brace initialization (fixes #13757)
+  - Dropped erroneous always-inline attribute from mca_part_persist_start (fixes #13721)
+
+- PML/OB1 and Request Correctness/Reliability
+  - Fixed critical race in wait_sync on weakly-ordered architectures (opal/threads)
+  - Added memory/release barriers to sendreq and recvreq lock/unlock paths, unlocked completion paths, and recv_req_matched on weakly-ordered architectures
+  - Drained pckt_pending from mca_pml_ob1_progress to avoid orphaned FINs
+  - Cleared req_match_received during mrecv/imrecv reinit; drained stale send ranges on sendreq reuse
+  - Added acquire/release barriers for sync struct handoff between request and test/wait
+  - pml/cm: pack data from application buffer in successive MPI_Start calls
+  - Fixed buffered sends for OB1 as well
+  - Fixed MPI_Testall spuriously returning MPI_ERR_IN_STATUS
+  - Fixed remnants of req_complete being a bool
+
+- Collectives, Accelerator, and Fault Tolerance
+  - coll/ucc: fixed UCC teardown ordering and resource leak during MPI_Finalize
+  - coll/hcoll: fixed hcoll context leak on MPI_Finalize
+  - coll/cuda: stage full input for MPI_IN_PLACE in reduce_scatter_block
+  - coll/accelerator: use dev_id and transfer type; also check for ROCm component
+  - accelerator/cuda: defer VMM/mpool probes until mem_type is known
+  - btl/ofi: fault tolerance fixes; try to identify/report failed procs when not identifiable from failed op's context
+  - btl,mtl/ofi: set device only flag
+  - Return MPI_ERR_PROC_FAILED on I(m)probe when appropriate
+  - Reworked communicator teardown ordering in MPI_Finalize; replaced EXTRA_RETAIN mechanism with proper sub-communicator ownership; released c_keyhash instead of destructing it
+
+- OSHMEM Enhancements
+  - OSHMEM/SCOLL/UCC: Advertise ep_map field so teams are cacheable
+  - OSHMEM/MCA/SSHMEM/BASE: Changed default base address to NULL
+
+- Fortran
+  - Fortran REAL16: improved detection and wiring across OMPI/OPAL
+  - Fixed problems with neighbor collectives
+
+- Bug Fixes and Minor Enhancements
+  - Fixed pdata leak on the MPI_Lookup_name error path; gave MPI_Lookup_name a range when the caller does not
+  - opal: removed malloc attribute from realloc wrapper
+  - Checked opal_asprintf() return in mca_base_var_build_env(); set str to NULL after free
+  - Made yield_when_idle a modifyable MPI_T_cvar
+  - btl/sm: bounded peer-supplied descriptor copy in endpoint destructor
+  - op/aarch64, op/base: plugged misc memory leaks
+  - external data pack: switched to using size_t
+  - OMPI/RTE: Modified job name printing to use thread local storage
+  - Pointed the ftagree alg to the correct MCA param
+  - Reserved dist graph tags outside the libnbc tag range
+  - Updated the datatype tests to call opal_finalize
+  - configury: fixed --with-knem=PATH; allowed knem to be disabled
+  - contrib/platform/mellanox: dropped deprecated mpirun-prefix-by-default
+  - Documentation: documented the name-publishing info keys that actually exist; fixed shmem_wait argument descriptions; fixed typo in mpi_minimum_memory_alignment info key; fixed spelling and grammar throughout RST docs; added a limited llms.txt for the v5.0.x series
+  - CI/build system: updated PR-check actions; bumped actions/checkout to v6; removed V=1 from community Jenkins make invocations; enabled verbose output in community Jenkins build/test
+
 Open MPI Version v5.0.10rc2
 ------------------------------
 :Date: 11 February 2026


### PR DESCRIPTION
- Update VERSION file to v5.0.11rc1
- Update changelog v5.0.10 to v5.0.11rc1 including:
  * PMIx v5.0.11 and PRRTE v3.0.14 updates
  * Partitioned communication (MPI_Psend/MPI_Precv) fixes
  * PML/OB1 memory-barrier and request-correctness fixes on weakly-ordered architectures
  * coll/ucc and coll/hcoll MPI_Finalize leak/teardown fixes
  * OSHMEM SCOLL/UCC and SSHMEM enhancements
  * Fortran REAL16 detection and neighbor collectives fixes
  * Various documentation and build system fixes