### PR TITLE
[v4.1.x] pml/cm, pml/ob1: pack buffered sends on every MPI_Start

### DIFF
--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -373,7 +373,7 @@ do {                                                                    \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
             opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
-                                             sendreq->req_send.req_base.req_datatype,   \
+                                             &sendreq->req_send.req_base.req_datatype->super,   \
                                              max_data,                  \
                                              sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \

--- a/ompi/mca/pml/cm/pml_cm_sendreq.h
+++ b/ompi/mca/pml/cm/pml_cm_sendreq.h
@@ -372,6 +372,10 @@ do {                                                                    \
             iov.iov_base = (IOVBASE_TYPE*)sendreq->req_buff;            \
             max_data = iov.iov_len = sendreq->req_count;                \
             iov_count = 1;                                              \
+            opal_convertor_prepare_for_send( &sendreq->req_send.req_base.req_convertor, \
+                                             sendreq->req_send.req_base.req_datatype,   \
+                                             max_data,                  \
+                                             sendreq->req_addr);        \
             opal_convertor_pack( &sendreq->req_send.req_base.req_convertor, \
                                  &iov,                                  \
                                  &iov_count,                            \

--- a/ompi/mca/pml/ob1/pml_ob1_start.c
+++ b/ompi/mca/pml/ob1/pml_ob1_start.c
@@ -87,13 +87,16 @@ int mca_pml_ob1_start(size_t count, ompi_request_t** requests)
                     sendreq = (mca_pml_ob1_send_request_t *) request;
                     requests[i] = request;
                 } else if (sendreq->req_send.req_bytes_packed != 0) {
-                    size_t offset = 0;
                     /**
                      * Reset the convertor in case we're dealing with the original
-                     * request, which when completed do not reset the convertor.
+                     * request, which when completed do not reset the convertor but
+                     * leaves it pointing to the buffered send location, with the
+                     * packed datatype and count.
                      */
-                    opal_convertor_set_position (&sendreq->req_send.req_base.req_convertor,
-                                                 &offset);
+                    opal_convertor_prepare_for_send(&sendreq->req_send.req_base.req_convertor,
+                                                    &sendreq->req_send.req_base.req_datatype->super,
+                                                    sendreq->req_send.req_base.req_count,
+                                                    sendreq->req_send.req_base.req_addr);
                 }
 
                 /* reset the completion flag */


### PR DESCRIPTION
Backport of two buffered-send fixes to v4.1.x.

PML/CM packs the user buffer into its bounce buffer at MPI_Bsend_init time but not on each MPI_Start, so a restarted persistent buffered send retransmits the payload of the previous start. The MPI_Bsend_init_overtake test exercises exactly that sequence, and on v4.1.x every message after
the first carries stale data.

  3226c6c8f6 / b124df402a  pml/cm: pack data from application buffer in successive MPI_Start calls
  429c7b7e61 / 78bfdae69c  Fix buffered sends for OB1 as well.

Cherry-picked from the v5.0.x versions rather than the main originals. The main version of the first commit does apply to v4.1.x, but produces slightly different content; the v5.0.x version is the one verified here. Order matters: the OB1 commit also touches pml_cm_sendreq.h and will not apply to a pristine v4.1.x tree on its own.

Verified on v4.1.x with a two-rank reduction of that test, which needs no fabric and no scale: before the change 19 of 20 messages carry a stale payload, after it all 20 are correct. pml/ob1 over shared memory passes both before and after, so the OB1 commit is here for parity with v5.0.x rather than because this test needs it.

Scope: this is only to get the MTT runs on this branch clean.