### PR TITLE
Hide some internal functions and 13 variables from public ABI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,15 @@ and [`docs/contributing.rst`](docs/contributing.rst):
   single DSO. See the "Symbol Visibility" section of
   [`docs/developers/source-code.rst`](docs/developers/source-code.rst)
   and [`ompi/mpi/README_ABI.md`](ompi/mpi/README_ABI.md).
+
+  > **When hiding internal implementation functions with public ABI wrappers:**
+  > If an internal function (e.g., `ompi_abi_*`) has a corresponding public ABI
+  > function (e.g., `MPI_Abi_*`) and is only called through that wrapper, the
+  > internal function can be marked `OMPI_HIDDEN`. Update any direct callers
+  > (e.g., tests) to use the public wrapper. Note: Public wrappers may have
+  > additional requirements (e.g., MPI initialization or error handling) not
+  > present in the internal implementation.
+
 - **New files need the standard copyright/license header.** Copy the
   multi-institution BSD header block — including the `$COPYRIGHT$` and
   `$HEADER$` tokens — from a neighboring file. If you substantially

--- a/ompi/mpi/bindings/ompi_bindings/c.py
+++ b/ompi/mpi/bindings/ompi_bindings/c.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024      Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2024-2026 Triad National Security, LLC. All rights reserved.
 # Copyright (c) 2023      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
@@ -508,9 +508,9 @@ class ABIConverterBuilder:
 
     def generate_errhandler_args_convert_fn_intern_to_abi(self, header_only=False):
         if header_only == True:
-            self.dump(f'void ompi_convert_errhandler_args_intern_to_abi(void *object, int object_type, int *err_code);')
+            self.dump(f'OMPI_HIDDEN void ompi_convert_errhandler_args_intern_to_abi(void *object, int object_type, int *err_code);')
             return
-        self.dump(f'void ompi_convert_errhandler_args_intern_to_abi(void *object, int object_type, int *err_code)')
+        self.dump(f'OMPI_HIDDEN void ompi_convert_errhandler_args_intern_to_abi(void *object, int object_type, int *err_code)')
         self.dump('{')
         lines = []
         lines.append('ompi_communicator_t **comm;')

--- a/ompi/mpi/c/attr_fn_abi.c
+++ b/ompi/mpi/c/attr_fn_abi.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2025      Triad National Security, LLC. All rights
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -31,32 +31,32 @@
  * variables used for certain predefined attributes,
  * e.g. MPI_IO, MPI_HOST
  */
-int ompi_abi_mpi_proc_null_val = MPI_PROC_NULL_ABI_INTERNAL;
-int ompi_abi_mpi_any_source_val = MPI_ANY_SOURCE_ABI_INTERNAL;
-int ompi_abi_mpi_lastusedcode = 0;
+OMPI_HIDDEN int ompi_abi_mpi_proc_null_val = MPI_PROC_NULL_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_any_source_val = MPI_ANY_SOURCE_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_lastusedcode = 0;
 
 /*
  * variables used for certain predefined attributes
  * for windows
  */
-int ompi_abi_mpi_win_flavor_create = MPI_WIN_FLAVOR_CREATE_ABI_INTERNAL;
-int ompi_abi_mpi_win_flavor_allocate = MPI_WIN_FLAVOR_ALLOCATE_ABI_INTERNAL;
-int ompi_abi_mpi_win_flavor_shared = MPI_WIN_FLAVOR_SHARED_ABI_INTERNAL;
-int ompi_abi_mpi_win_flavor_dynamic = MPI_WIN_FLAVOR_DYNAMIC_ABI_INTERNAL;
-int ompi_abi_mpi_win_model_unified = MPI_WIN_UNIFIED_ABI_INTERNAL;
-int ompi_abi_mpi_win_model_separate = MPI_WIN_SEPARATE_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_flavor_create = MPI_WIN_FLAVOR_CREATE_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_flavor_allocate = MPI_WIN_FLAVOR_ALLOCATE_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_flavor_shared = MPI_WIN_FLAVOR_SHARED_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_flavor_dynamic = MPI_WIN_FLAVOR_DYNAMIC_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_model_unified = MPI_WIN_UNIFIED_ABI_INTERNAL;
+OMPI_HIDDEN int ompi_abi_mpi_win_model_separate = MPI_WIN_SEPARATE_ABI_INTERNAL;
 
 /*
  * predefined callbacks for win, comm, type attributes
  */
-int ABI_C_MPI_TYPE_NULL_DELETE_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
+OMPI_HIDDEN int ABI_C_MPI_TYPE_NULL_DELETE_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
                                     void* attribute_val_out,
                                     void* extra_state )
 {
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_TYPE_NULL_COPY_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
+OMPI_HIDDEN int ABI_C_MPI_TYPE_NULL_COPY_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
                                   void* extra_state,
                                   void* attribute_val_in,
                                   void* attribute_val_out,
@@ -66,7 +66,7 @@ int ABI_C_MPI_TYPE_NULL_COPY_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_ke
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_TYPE_DUP_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
+OMPI_HIDDEN int ABI_C_MPI_TYPE_DUP_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
                             void* extra_state,
                             void* attribute_val_in, void* attribute_val_out,
                             int* flag )
@@ -76,14 +76,14 @@ int ABI_C_MPI_TYPE_DUP_FN( MPI_Datatype_ABI_INTERNAL datatype, int type_keyval,
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_WIN_NULL_DELETE_FN( MPI_Win_ABI_INTERNAL window, int win_keyval,
+OMPI_HIDDEN int ABI_C_MPI_WIN_NULL_DELETE_FN( MPI_Win_ABI_INTERNAL window, int win_keyval,
                                    void* attribute_val_out,
                                    void* extra_state )
 {
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_WIN_NULL_COPY_FN( MPI_Win_ABI_INTERNAL window, int win_keyval,
+OMPI_HIDDEN int ABI_C_MPI_WIN_NULL_COPY_FN( MPI_Win_ABI_INTERNAL window, int win_keyval,
                                  void* extra_state,
                                  void* attribute_val_in,
                                  void* attribute_val_out, int* flag )
@@ -92,7 +92,7 @@ int ABI_C_MPI_WIN_NULL_COPY_FN( MPI_Win_ABI_INTERNAL window, int win_keyval,
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_WIN_DUP_FN( MPI_Win_ABI_INTERNAL window, int win_keyval, void* extra_state,
+OMPI_HIDDEN int ABI_C_MPI_WIN_DUP_FN( MPI_Win_ABI_INTERNAL window, int win_keyval, void* extra_state,
                            void* attribute_val_in, void* attribute_val_out,
                            int* flag )
 {
@@ -101,14 +101,14 @@ int ABI_C_MPI_WIN_DUP_FN( MPI_Win_ABI_INTERNAL window, int win_keyval, void* ext
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_COMM_NULL_DELETE_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval,
+OMPI_HIDDEN int ABI_C_MPI_COMM_NULL_DELETE_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval,
                                     void* attribute_val_out,
                                     void* extra_state )
 {
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_COMM_NULL_COPY_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval,
+OMPI_HIDDEN int ABI_C_MPI_COMM_NULL_COPY_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval,
                                   void* extra_state,
                                   void* attribute_val_in,
                                   void* attribute_val_out, int* flag )
@@ -117,7 +117,7 @@ int ABI_C_MPI_COMM_NULL_COPY_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval,
     return MPI_SUCCESS;
 }
 
-int ABI_C_MPI_COMM_DUP_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval, void* extra_state,
+OMPI_HIDDEN int ABI_C_MPI_COMM_DUP_FN( MPI_Comm_ABI_INTERNAL comm, int comm_keyval, void* extra_state,
                      void* attribute_val_in, void* attribute_val_out,
                      int* flag )
 {

--- a/ompi/mpi/c/bindings.h
+++ b/ompi/mpi/c/bindings.h
@@ -12,6 +12,8 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,14 +120,14 @@ BEGIN_C_DECLS
     } while (0)
 
 
-int ompi_sendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, 
+OMPI_HIDDEN int ompi_sendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag,
                   void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
-int ompi_isendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, 
+OMPI_HIDDEN int ompi_isendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag,
                    void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request * request);
-int ompi_abi_get_fortran_info(ompi_info_t **info);
-int ompi_abi_set_fortran_info(ompi_info_t *info);
-int ompi_abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false, int *is_set);
-int ompi_abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
+OMPI_HIDDEN int ompi_abi_get_fortran_info(ompi_info_t **info);
+OMPI_HIDDEN int ompi_abi_set_fortran_info(ompi_info_t *info);
+OMPI_HIDDEN int ompi_abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false, int *is_set);
+OMPI_HIDDEN int ompi_abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
 
 END_C_DECLS
 

--- a/ompi/mpi/c/isendrecv_replace.c.in
+++ b/ompi/mpi/c/isendrecv_replace.c.in
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Triad National Security, LLC. All rights
+ * Copyright (c) 2021-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
@@ -68,12 +68,12 @@ static void ompi_isendrecv_context_destructor(ompi_isendrecv_replace_context_t *
     OBJ_DESTRUCT(&context->convertor);
 }
 
-OBJ_CLASS_INSTANCE(ompi_isendrecv_replace_context_t, 
+OMPI_HIDDEN OBJ_CLASS_INSTANCE(ompi_isendrecv_replace_context_t,
                    opal_object_t, 
                    ompi_isendrecv_context_constructor,
                    ompi_isendrecv_context_destructor);
 #else
-OBJ_CLASS_DECLARATION(ompi_isendrecv_replace_context_t);
+OMPI_HIDDEN OBJ_CLASS_DECLARATION(ompi_isendrecv_replace_context_t);
 #endif /* OMPI_BUILD_MPI_PROFILING */
 
 static int ompi_isendrecv_replace_complete_func (ompi_comm_request_t *request)

--- a/ompi/mpi/c/ompi_abi_fortran.c
+++ b/ompi/mpi/c/ompi_abi_fortran.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023, 2026 Jeffrey M. Squyres.  All rights reserved.
- * Copyright (c) 2024-2025 Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -70,7 +70,7 @@ static int ompi_abi_fortran_finalize(void)
     return OMPI_SUCCESS;
 }
         
-int ompi_abi_get_fortran_info(ompi_info_t **info)
+OMPI_HIDDEN int ompi_abi_get_fortran_info(ompi_info_t **info)
 {
     ompi_info_t *newinfo = NULL;
     int ret = MPI_SUCCESS;
@@ -185,7 +185,7 @@ err_cleanup:
     return ret;
 }
 
-int ompi_abi_set_fortran_info(ompi_info_t *info)
+OMPI_HIDDEN int ompi_abi_set_fortran_info(ompi_info_t *info)
 {
     int ret = MPI_SUCCESS;
     static bool already_called = false;   
@@ -225,7 +225,7 @@ int ompi_abi_set_fortran_info(ompi_info_t *info)
 
 }
 
-int ompi_abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false, int *is_set)
+OMPI_HIDDEN int ompi_abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false, int *is_set)
 {
     int ret = MPI_SUCCESS;
 
@@ -451,7 +451,7 @@ int ompi_abi_get_fortran_booleans(int logical_size, void *logical_true, void *lo
     return ret;
 }
 
-int ompi_abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false)
+OMPI_HIDDEN int ompi_abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false)
 {
     int ret=MPI_SUCCESS;
     static bool already_called = false;

--- a/ompi/mpi/c/ompi_isendrecv.c
+++ b/ompi/mpi/c/ompi_isendrecv.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
- * Copyright (c) 2021-2024 Triad National Security, LLC. All rights
+ * Copyright (c) 2021-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -45,7 +45,7 @@ struct ompi_isendrecv_context_t {
 };
 
 typedef struct ompi_isendrecv_context_t ompi_isendrecv_context_t;
-OBJ_CLASS_INSTANCE(ompi_isendrecv_context_t, opal_object_t, NULL, NULL);
+OMPI_HIDDEN OBJ_CLASS_INSTANCE(ompi_isendrecv_context_t, opal_object_t, NULL, NULL);
 
 static int ompi_isendrecv_complete_func (ompi_comm_request_t *request)
 {
@@ -77,7 +77,7 @@ static int ompi_isendrecv_complete_func (ompi_comm_request_t *request)
     return OMPI_SUCCESS;
 }
 
-int ompi_isendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request * request)
+OMPI_HIDDEN int ompi_isendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request * request)
 {
     ompi_isendrecv_context_t *context = NULL;
     ompi_comm_request_t *crequest;

--- a/ompi/mpi/c/ompi_sendrecv.c
+++ b/ompi/mpi/c/ompi_sendrecv.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
- * Copyright (c) 2024      Triad National Security, LLC. All rights
+ * Copyright (c) 2024-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -36,7 +36,7 @@
 #include "ompi/memchecker.h"
 #include "ompi/runtime/ompi_spc.h"
 
-int ompi_sendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status)
+OMPI_HIDDEN int ompi_sendrecv(const void * sendbuf, size_t sendcount, MPI_Datatype sendtype, int dest, int sendtag, void * recvbuf, size_t recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status)
 {
     ompi_request_t* req = MPI_REQUEST_NULL;
     int rc = MPI_SUCCESS;

--- a/ompi/mpi/tool/mpit-internal.h
+++ b/ompi/mpi/tool/mpit-internal.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2011      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2025      Triad National Security, LLC. All rights
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
@@ -43,8 +43,8 @@ typedef struct ompi_mpit_cvar_handle_t {
     void           *bound_object;
 } ompi_mpit_cvar_handle_t;
 
-void ompi_mpit_lock (void);
-void ompi_mpit_unlock (void);
+OMPI_HIDDEN void ompi_mpit_lock (void);
+OMPI_HIDDEN void ompi_mpit_unlock (void);
 
 OMPI_DECLSPEC extern volatile uint32_t ompi_mpit_init_count;
 
@@ -57,15 +57,17 @@ OMPI_DECLSPEC extern volatile uint32_t ompi_mpit_init_count;
    why the two must never be conflated). */
 OMPI_DECLSPEC extern int ompi_mpit_thread_level;
 
+OMPI_HIDDEN extern opal_mutex_t ompi_mpit_big_lock;
+
 /* Set when a first MPI_T_init_thread() failed partway through framework
    registration, which is not unwindable; MPI_T can never be brought up
    in this process again, and MPI_T_finalize() must not run the component
    closes (see both files for the details). */
-extern bool ompi_mpit_init_failed;
+OMPI_HIDDEN extern bool ompi_mpit_init_failed;
 
-int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype);
-int ompit_opal_to_mpit_error (int rc);
-bool ompit_obj_invalid(void *obj_handle);
+OMPI_HIDDEN int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype);
+OMPI_HIDDEN int ompit_opal_to_mpit_error (int rc);
+OMPI_HIDDEN bool ompit_obj_invalid(void *obj_handle);
 
 /* --- MPI_T events support (see specs/mpi-t-events/spec.md sec. 6) --------- */
 
@@ -94,24 +96,24 @@ typedef struct ompi_mpit_event_cb_ctx_t {
     void              *user_data;
 } ompi_mpit_event_cb_ctx_t;
 
-ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new(ompit_generic_fn_t fn, void *user_data);
-void ompit_event_ctx_release(void *user_data);
+OMPI_HIDDEN ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new(ompit_generic_fn_t fn, void *user_data);
+OMPI_HIDDEN void ompit_event_ctx_release(void *user_data);
 
 /* Trampolines with the OPAL callback signatures; each forwards to the user's
    MPI_T callback after casting the opaque handles.  Calling an MPI_T callback
    through an OPAL function-pointer type would be undefined behaviour, so these
    bridge the (function-pointer) type mismatch. */
-void ompit_event_cb_trampoline(mca_base_event_instance_t *inst,
+OMPI_HIDDEN void ompit_event_cb_trampoline(mca_base_event_instance_t *inst,
                                mca_base_event_registration_t *reg,
                                mca_base_event_cb_safety_t cb_safety, void *user_data);
-void ompit_event_dropped_trampoline(opal_count_t count, mca_base_event_registration_t *reg,
+OMPI_HIDDEN void ompit_event_dropped_trampoline(opal_count_t count, mca_base_event_registration_t *reg,
                                     int source_index, mca_base_event_cb_safety_t cb_safety,
                                     void *user_data);
-void ompit_event_free_trampoline(mca_base_event_registration_t *reg,
+OMPI_HIDDEN void ompit_event_free_trampoline(mca_base_event_registration_t *reg,
                                  mca_base_event_cb_safety_t cb_safety, void *user_data);
 
 /* Install the OPAL debug raise-check hook (a no-op unless OPAL_ENABLE_DEBUG). */
-void ompit_install_event_debug_hook(void);
+OMPI_HIDDEN void ompit_install_event_debug_hook(void);
 
 static inline int mpit_is_initialized (void)
 {

--- a/ompi/mpi/tool/mpit_common.c
+++ b/ompi/mpi/tool/mpit_common.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2020      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
- * Copyright (c) 2025      Triad National Security, LLC. All rights
+ * Copyright (c) 2025-2026 Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2026      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
@@ -25,7 +25,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
+OMPI_HIDDEN opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
 
 /* ompi_mpit_init_count and ompi_mpit_thread_level are read by the lower
    libopen_mpi layer (the instance and world-model init paths), which
@@ -33,7 +33,7 @@ opal_mutex_t ompi_mpit_big_lock = OPAL_MUTEX_STATIC_INIT;
    therefore defined alongside the other process-wide thread flags in
    ompi/runtime/ompi_mpi_init.c. */
 
-bool ompi_mpit_init_failed = false;
+OMPI_HIDDEN bool ompi_mpit_init_failed = false;
 
 #if OPAL_ENABLE_DEBUG
 /* Per-thread depth of MPI_T big-lock sections this thread holds (debug only),
@@ -42,7 +42,7 @@ bool ompi_mpit_init_failed = false;
 static opal_thread_local int ompi_mpit_locked_depth = 0;
 #endif
 
-void ompi_mpit_lock (void)
+OMPI_HIDDEN void ompi_mpit_lock (void)
 {
     opal_mutex_lock (&ompi_mpit_big_lock);
 #if OPAL_ENABLE_DEBUG
@@ -50,7 +50,7 @@ void ompi_mpit_lock (void)
 #endif
 }
 
-void ompi_mpit_unlock (void)
+OMPI_HIDDEN void ompi_mpit_unlock (void)
 {
 #if OPAL_ENABLE_DEBUG
     --ompi_mpit_locked_depth;
@@ -60,7 +60,7 @@ void ompi_mpit_unlock (void)
 
 /* --- MPI_T events: callback contexts, trampolines, debug hook ------------ */
 
-ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new (ompit_generic_fn_t fn, void *user_data)
+OMPI_HIDDEN ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new (ompit_generic_fn_t fn, void *user_data)
 {
     ompi_mpit_event_cb_ctx_t *ctx = malloc (sizeof (*ctx));
     if (NULL != ctx) {
@@ -70,12 +70,12 @@ ompi_mpit_event_cb_ctx_t *ompit_event_cb_ctx_new (ompit_generic_fn_t fn, void *u
     return ctx;
 }
 
-void ompit_event_ctx_release (void *user_data)
+OMPI_HIDDEN void ompit_event_ctx_release (void *user_data)
 {
     free (user_data);
 }
 
-void ompit_event_cb_trampoline (mca_base_event_instance_t *inst,
+OMPI_HIDDEN void ompit_event_cb_trampoline (mca_base_event_instance_t *inst,
                                 mca_base_event_registration_t *reg,
                                 mca_base_event_cb_safety_t cb_safety, void *user_data)
 {
@@ -86,7 +86,7 @@ void ompit_event_cb_trampoline (mca_base_event_instance_t *inst,
         (MPI_T_cb_safety) cb_safety, ctx->user_data);
 }
 
-void ompit_event_dropped_trampoline (opal_count_t count, mca_base_event_registration_t *reg,
+OMPI_HIDDEN void ompit_event_dropped_trampoline (opal_count_t count, mca_base_event_registration_t *reg,
                                      int source_index, mca_base_event_cb_safety_t cb_safety,
                                      void *user_data)
 {
@@ -97,7 +97,7 @@ void ompit_event_dropped_trampoline (opal_count_t count, mca_base_event_registra
         ctx->user_data);
 }
 
-void ompit_event_free_trampoline (mca_base_event_registration_t *reg,
+OMPI_HIDDEN void ompit_event_free_trampoline (mca_base_event_registration_t *reg,
                                   mca_base_event_cb_safety_t cb_safety, void *user_data)
 {
     ompi_mpit_event_cb_ctx_t *ctx = (ompi_mpit_event_cb_ctx_t *) user_data;
@@ -118,7 +118,7 @@ static void ompit_event_assert_no_big_lock (void)
 }
 #endif
 
-void ompit_install_event_debug_hook (void)
+OMPI_HIDDEN void ompit_install_event_debug_hook (void)
 {
 #if OPAL_ENABLE_DEBUG
     mca_base_event_debug_raise_check_fn = ompit_event_assert_no_big_lock;
@@ -152,7 +152,7 @@ static MPI_Datatype mca_to_mpi_datatypes[MCA_BASE_VAR_TYPE_MAX] = {
     [MCA_BASE_VAR_TYPE_UINT64_T] = MPI_UINT64_T,
 };
 
-int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype)
+OMPI_HIDDEN int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype)
 {
     if (!datatype) {
         return OMPI_SUCCESS;
@@ -164,7 +164,7 @@ int ompit_var_type_to_datatype (mca_base_var_type_t type, MPI_Datatype *datatype
     return OMPI_SUCCESS;
 }
 
-int ompit_opal_to_mpit_error (int rc)
+OMPI_HIDDEN int ompit_opal_to_mpit_error (int rc)
 {
     if (rc >= 0) {
         /* Already an MPI error (always >= 0) */
@@ -186,7 +186,7 @@ int ompit_opal_to_mpit_error (int rc)
  * Check whether a MPI object is valid or not.
  * If invalid return true, otherwise false.
  */
-bool ompit_obj_invalid(void *obj_handle)
+OMPI_HIDDEN bool ompit_obj_invalid(void *obj_handle)
 {
     bool ret = true; /* by default return obj is invalid */
     opal_object_t *opal_obj = NULL;

--- a/ompi/test/general/abi_fortran.c
+++ b/ompi/test/general/abi_fortran.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2026      Jeff Squyres.  All rights reserved.
+ * Copyright (c) 2026      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -31,6 +33,12 @@
 
 int main(int argc, char *argv[])
 {
+    /* Initialize MPI for the ABI functions that require it */
+    MPI_Init(&argc, &argv);
+
+    /* Set error handler to return (not abort) so we can test error cases */
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
     /* 16-byte scratch buffers: large enough for the widest logical
      * (opal_int128_t) any build could store, so a get/set for a valid size
      * never overruns regardless of Fortran support or platform logical
@@ -62,13 +70,13 @@ int main(int argc, char *argv[])
         const int not_pow2[] = { 0, 3, 5, 6, 7, 9, 12, 15, 100 };
         for (i = 0; i < sizeof(not_pow2) / sizeof(not_pow2[0]); i++) {
             int is_set = -1;
-            int rc = ompi_abi_get_fortran_booleans(not_pow2[i], logical_true,
+            int rc = MPI_Abi_get_fortran_booleans(not_pow2[i], logical_true,
                                                     logical_false, &is_set);
             if (MPI_ERR_ARG == rc) {
                 test_success();
             } else {
                 snprintf(msg, sizeof(msg),
-                         "get_fortran_booleans(%d) expected MPI_ERR_ARG, got %d",
+                         "MPI_Abi_get_fortran_booleans(%d) expected MPI_ERR_ARG, got %d",
                          not_pow2[i], rc);
                 test_failure(msg);
             }
@@ -85,13 +93,13 @@ int main(int argc, char *argv[])
         const int pow2_ok[] = { 1, 2, 4, 8, 16 };
         for (i = 0; i < sizeof(pow2_ok) / sizeof(pow2_ok[0]); i++) {
             int is_set = -1;
-            int rc = ompi_abi_get_fortran_booleans(pow2_ok[i], logical_true,
+            int rc = MPI_Abi_get_fortran_booleans(pow2_ok[i], logical_true,
                                                     logical_false, &is_set);
             if (MPI_ERR_ARG != rc) {
                 test_success();
             } else {
                 snprintf(msg, sizeof(msg),
-                         "get_fortran_booleans(%d) unexpectedly returned MPI_ERR_ARG",
+                         "MPI_Abi_get_fortran_booleans(%d) unexpectedly returned MPI_ERR_ARG",
                          pow2_ok[i]);
                 test_failure(msg);
             }
@@ -115,49 +123,50 @@ int main(int argc, char *argv[])
          * rejects every registration attempt (the get path returns the
          * compiler-derived values and never consults a user
          * registration). */
-        int rc = ompi_abi_set_fortran_booleans(4, logical_true, logical_false);
+        int rc = MPI_Abi_set_fortran_booleans(4, logical_true, logical_false);
         if (MPI_ERR_ABI == rc) {
             test_success();
         } else {
             snprintf(msg, sizeof(msg),
-                     "set_fortran_booleans(4) with Fortran support expected "
+                     "MPI_Abi_set_fortran_booleans(4) with Fortran support expected "
                      "MPI_ERR_ABI, got %d", rc);
             test_failure(msg);
         }
 #else
         /* A non-power-of-two size is rejected and must not trip the latch. */
-        int rc = ompi_abi_set_fortran_booleans(3, logical_true, logical_false);
+        int rc = MPI_Abi_set_fortran_booleans(3, logical_true, logical_false);
         if (MPI_ERR_ARG == rc) {
             test_success();
         } else {
             snprintf(msg, sizeof(msg),
-                     "set_fortran_booleans(3) expected MPI_ERR_ARG, got %d", rc);
+                     "MPI_Abi_set_fortran_booleans(3) expected MPI_ERR_ARG, got %d", rc);
             test_failure(msg);
         }
 
         /* The first valid call configures the logicals and succeeds. */
-        rc = ompi_abi_set_fortran_booleans(4, logical_true, logical_false);
+        rc = MPI_Abi_set_fortran_booleans(4, logical_true, logical_false);
         if (MPI_SUCCESS == rc) {
             test_success();
         } else {
             snprintf(msg, sizeof(msg),
-                     "first valid set_fortran_booleans(4) expected MPI_SUCCESS, got %d",
+                     "first valid MPI_Abi_set_fortran_booleans(4) expected MPI_SUCCESS, got %d",
                      rc);
             test_failure(msg);
         }
 
         /* A second call, after a successful one, must return MPI_ERR_ABI. */
-        rc = ompi_abi_set_fortran_booleans(4, logical_true, logical_false);
+        rc = MPI_Abi_set_fortran_booleans(4, logical_true, logical_false);
         if (MPI_ERR_ABI == rc) {
             test_success();
         } else {
             snprintf(msg, sizeof(msg),
-                     "second set_fortran_booleans() expected MPI_ERR_ABI, got %d",
+                     "second MPI_Abi_set_fortran_booleans() expected MPI_ERR_ABI, got %d",
                      rc);
             test_failure(msg);
         }
 #endif
     }
 
+    MPI_Finalize();
     return test_finalize();
 }


### PR DESCRIPTION
Add OMPI_HIDDEN attribute to internal symbols in libmpi.so and libmpi_abi.so to prevent them from being exported in the public API.

Hidden functions (27):
- 9 ABI C callback functions (ABI_C_MPI_*_FN)
- 12 MPI_T functions (ompit_*, including ompi_mpit_lock/unlock)
- 4 Fortran ABI functions (ompi_abi_get/set_fortran_*)
- 2 Sendrecv functions (ompi_sendrecv, ompi_isendrecv)

Hidden variables (13):
- 9 ABI variables (ompi_abi_mpi_*)
- 2 MPI_T variables (ompi_mpit_big_lock, ompi_mpit_init_failed)
- 2 Class instances (ompi_isendrecv_context_t_class, ompi_isendrecv_replace_context_t_class)

Files modified:
- ompi/mpi/c/attr_fn_abi.c
- ompi/mpi/c/abi.h
- ompi/mpi/c/bindings.h
- ompi/mpi/c/ompi_abi_fortran.c
- ompi/mpi/c/ompi_isendrecv.c
- ompi/mpi/c/ompi_sendrecv.c
- ompi/mpi/tool/mpit_common.c
- ompi/mpi/tool/mpit-internal.h
- ompi/test/general/abi_fortran.c
- ompi/mpi/bindings/ompi_bindings/c.py
- ompi/mpi/c/isendrecv_replace.c.in

Also updated AGENTS.md with a note about changing visibility of internal symbols which tests might be using.

Related to #14336