### PR TITLE
[v6.0.x] oshmem/memheap: validate symmetric memory layouts

### DIFF
--- a/oshmem/mca/memheap/base/base.h
+++ b/oshmem/mca/memheap/base/base.h
@@ -67,6 +67,8 @@ int mca_memheap_base_alloc_init(mca_memheap_map_t *, size_t, long, char *);
 void mca_memheap_base_alloc_exit(mca_memheap_map_t *);
 int mca_memheap_base_static_init(mca_memheap_map_t *);
 void mca_memheap_base_static_exit(mca_memheap_map_t *);
+int mca_memheap_base_static_segment_offset(const map_segment_t *segment,
+                                           uint64_t *offset);
 int mca_memheap_base_reg(mca_memheap_map_t *);
 int mca_memheap_base_dereg(mca_memheap_map_t *);
 int memheap_oob_init(mca_memheap_map_t *);

--- a/oshmem/mca/memheap/base/memheap_base_mkey.c
+++ b/oshmem/mca/memheap/base/memheap_base_mkey.c
@@ -30,6 +30,9 @@
 #include "opal/util/timings.h"
 #include "opal/mca/pmix/pmix-internal.h"
 
+#include <limits.h>
+#include <stdint.h>
+
 /* Turn ON/OFF debug output from build (default 0) */
 #ifndef MEMHEAP_BASE_DEBUG
 #define MEMHEAP_BASE_DEBUG    0
@@ -41,6 +44,19 @@
 
 #define MEMHEAP_MKEY_MAXSIZE   4096
 #define MEMHEAP_RECV_REQS_MAX  16
+
+#define MEMHEAP_LAYOUT_VERSION 1U
+#define MEMHEAP_LAYOUT_TERMINATOR_VALUE 0x4d484c31U
+
+static uint8_t memheap_layout_terminator[] = {
+    0x4d, 0x48, 0x4c, 0x31};
+
+typedef struct {
+    uint32_t type;
+    uint64_t size;
+    int64_t hints;
+    uint64_t static_offset;
+} memheap_layout_descriptor_t;
 
 typedef struct oob_comm_request {
     opal_list_item_t super;
@@ -86,14 +102,417 @@ int mca_memheap_seg_cmp(const void *k, const void *v)
     return 0;
 }
 
+static int pack_values(pmix_data_buffer_t *msg, void *value, int32_t count,
+                       pmix_data_type_t type)
+{
+    pmix_status_t rc;
+
+    if (NULL == msg || NULL == value || count < 0) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    rc = PMIx_Data_pack(NULL, msg, value, count, type);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return (int) rc;
+    }
+
+    return OSHMEM_SUCCESS;
+}
+
+static int get_layout_descriptor(int seg,
+                                 memheap_layout_descriptor_t *descriptor)
+{
+    const map_segment_t *segment;
+    int rc;
+
+    if (NULL == descriptor || NULL == memheap_map
+        || NULL == memheap_map->mem_segs || seg < 0
+        || seg >= memheap_map->n_segments) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    segment = &memheap_map->mem_segs[seg];
+    if ((uintmax_t) segment->seg_size > UINT64_MAX
+        || (uintmax_t) segment->type >= (uintmax_t) MAP_SEGMENT_UNKNOWN) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    if (sizeof(long) > sizeof(int64_t)
+        && (segment->alloc_hints < (long) INT64_MIN
+            || segment->alloc_hints > (long) INT64_MAX)) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    descriptor->type = (uint32_t) segment->type;
+    descriptor->size = (uint64_t) segment->seg_size;
+    descriptor->hints = (int64_t) segment->alloc_hints;
+    descriptor->static_offset = 0;
+
+    if (MAP_SEGMENT_STATIC == segment->type) {
+        rc = mca_memheap_base_static_segment_offset(
+            segment, &descriptor->static_offset);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    return OSHMEM_SUCCESS;
+}
+
+static int pack_memheap_layout(pmix_data_buffer_t *msg)
+{
+    memheap_layout_descriptor_t descriptor;
+    uint32_t version = MEMHEAP_LAYOUT_VERSION;
+    uint32_t segment_count;
+    int rc;
+    int seg;
+
+    if (NULL == msg || NULL == memheap_map || memheap_map->n_segments < 0
+        || (uintmax_t) memheap_map->n_segments > UINT32_MAX) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    segment_count = (uint32_t) memheap_map->n_segments;
+    rc = pack_values(msg, &version, 1, PMIX_UINT32);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+    rc = pack_values(msg, &segment_count, 1, PMIX_UINT32);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+
+    for (seg = 0; seg < memheap_map->n_segments; ++seg) {
+        rc = get_layout_descriptor(seg, &descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = pack_values(msg, &descriptor.type, 1, PMIX_UINT32);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = pack_values(msg, &descriptor.size, 1, PMIX_UINT64);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = pack_values(msg, &descriptor.hints, 1, PMIX_INT64);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = pack_values(msg, &descriptor.static_offset, 1, PMIX_UINT64);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    /*
+     * End the variable-length descriptor stream with fixed bytes. This lets
+     * the receiver detect a truncated flex-encoded final descriptor before
+     * interpreting any following bytes as remote keys.
+     */
+    rc = pack_values(msg, memheap_layout_terminator,
+                     (int32_t) sizeof(memheap_layout_terminator), PMIX_BYTE);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
+
+    return OSHMEM_SUCCESS;
+}
+
+static int select_peer_payload(pmix_data_buffer_t *message,
+                               size_t total_size, int offset, int size)
+{
+    size_t peer_offset;
+    size_t peer_size;
+
+    if (NULL == message || NULL == message->base_ptr || offset < 0
+        || size < 0) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    peer_offset = (size_t) offset;
+    peer_size = (size_t) size;
+    if (total_size > message->bytes_allocated || peer_size > total_size
+        || peer_offset > total_size - peer_size) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    message->unpack_ptr = message->base_ptr + peer_offset;
+    /*
+     * Bundled PMIx checks pack_ptr, rather than bytes_used, when deciding
+     * whether an unpack would cross the end of a buffer.
+     */
+    message->pack_ptr = message->base_ptr + peer_offset + peer_size;
+    message->bytes_used = peer_offset + peer_size;
+    return OSHMEM_SUCCESS;
+}
+
+static void report_layout_header_problem(int local_pe, int remote_pe,
+                                         const char *field,
+                                         uint64_t local_value,
+                                         uint64_t remote_value,
+                                         pmix_status_t decode_rc)
+{
+    if (0 != local_pe) {
+        return;
+    }
+
+    if (PMIX_SUCCESS == decode_rc) {
+        oshmem_output(oshmem_memheap_base_framework.framework_output,
+                      "Error %s:%d - %s()", __SPML_FILE__, __LINE__,
+                      __func__,
+                      "OSHMEM memheap layout mismatch: local PE %d, "
+                      "remote PE %d, field %s, local %llu, remote %llu; "
+                      "remote keys cannot be associated safely",
+                      local_pe, remote_pe, field,
+                      (unsigned long long) local_value,
+                      (unsigned long long) remote_value);
+    } else {
+        oshmem_output(oshmem_memheap_base_framework.framework_output,
+                      "Error %s:%d - %s()", __SPML_FILE__, __LINE__,
+                      __func__,
+                      "OSHMEM memheap layout mismatch: local PE %d, "
+                      "remote PE %d, field %s decode failure (%d), "
+                      "local %llu, remote %llu; remote keys cannot be "
+                      "associated safely",
+                      local_pe, remote_pe, field, (int) decode_rc,
+                      (unsigned long long) local_value,
+                      (unsigned long long) remote_value);
+    }
+}
+
+static void report_layout_descriptor_problem(
+    int local_pe, int remote_pe, uint32_t segment, const char *field,
+    const memheap_layout_descriptor_t *local,
+    const memheap_layout_descriptor_t *remote, pmix_status_t decode_rc)
+{
+    if (0 != local_pe) {
+        return;
+    }
+
+    if (PMIX_SUCCESS == decode_rc) {
+        oshmem_output(oshmem_memheap_base_framework.framework_output,
+                      "Error %s:%d - %s()", __SPML_FILE__, __LINE__,
+                      __func__,
+                      "OSHMEM memheap layout mismatch: local PE %d, "
+                      "remote PE %d, segment %u, field %s, local "
+                      "{type=%u,size=%llu,hints=%lld,static_offset=%llu}, "
+                      "remote {type=%u,size=%llu,hints=%lld,"
+                      "static_offset=%llu}; remote keys cannot be "
+                      "associated safely",
+                      local_pe, remote_pe, segment, field, local->type,
+                      (unsigned long long) local->size,
+                      (long long) local->hints,
+                      (unsigned long long) local->static_offset,
+                      remote->type, (unsigned long long) remote->size,
+                      (long long) remote->hints,
+                      (unsigned long long) remote->static_offset);
+    } else {
+        oshmem_output(oshmem_memheap_base_framework.framework_output,
+                      "Error %s:%d - %s()", __SPML_FILE__, __LINE__,
+                      __func__,
+                      "OSHMEM memheap layout mismatch: local PE %d, "
+                      "remote PE %d, segment %u, field descriptor[%u].%s "
+                      "decode failure (%d), local "
+                      "{type=%u,size=%llu,hints=%lld,static_offset=%llu}, "
+                      "remote {type=%u,size=%llu,hints=%lld,"
+                      "static_offset=%llu}; remote keys cannot be "
+                      "associated safely",
+                      local_pe, remote_pe, segment, segment, field,
+                      (int) decode_rc, local->type,
+                      (unsigned long long) local->size,
+                      (long long) local->hints,
+                      (unsigned long long) local->static_offset,
+                      remote->type, (unsigned long long) remote->size,
+                      (long long) remote->hints,
+                      (unsigned long long) remote->static_offset);
+    }
+}
+
+static int unpack_descriptor_field(
+    pmix_data_buffer_t *message, void *value, pmix_data_type_t type,
+    int remote_pe, int local_pe, uint32_t segment, const char *field,
+    const memheap_layout_descriptor_t *local,
+    const memheap_layout_descriptor_t *remote)
+{
+    int32_t count = 1;
+    pmix_status_t rc;
+
+    rc = PMIx_Data_unpack(NULL, message, value, &count, type);
+    if (PMIX_SUCCESS != rc || 1 != count) {
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIX_ERR_BAD_PARAM;
+        }
+        report_layout_descriptor_problem(local_pe, remote_pe, segment, field,
+                                         local, remote, rc);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    return OSHMEM_SUCCESS;
+}
+
+static int unpack_and_validate_layout(pmix_data_buffer_t *message,
+                                      int remote_pe, int local_pe)
+{
+    memheap_layout_descriptor_t local_descriptor;
+    memheap_layout_descriptor_t remote_descriptor;
+    uint32_t local_count;
+    uint32_t remote_count = 0;
+    uint8_t remote_terminator[sizeof(memheap_layout_terminator)] = {0};
+    uint64_t remote_terminator_value = 0;
+    uint32_t remote_version = 0;
+    uint32_t segment;
+    const char *mismatch;
+    int32_t count;
+    pmix_status_t pmix_rc;
+    int rc;
+
+    if (NULL == message || NULL == memheap_map || remote_pe < 0
+        || local_pe < 0 || memheap_map->n_segments < 0
+        || memheap_map->n_segments > INT_MAX
+        || (uintmax_t) memheap_map->n_segments > UINT32_MAX) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    local_count = (uint32_t) memheap_map->n_segments;
+    count = 1;
+    pmix_rc = PMIx_Data_unpack(NULL, message, &remote_version, &count,
+                              PMIX_UINT32);
+    if (PMIX_SUCCESS != pmix_rc || 1 != count) {
+        if (PMIX_SUCCESS == pmix_rc) {
+            pmix_rc = PMIX_ERR_BAD_PARAM;
+        }
+        report_layout_header_problem(local_pe, remote_pe, "version",
+                                     MEMHEAP_LAYOUT_VERSION, remote_version,
+                                     pmix_rc);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    if (MEMHEAP_LAYOUT_VERSION != remote_version) {
+        report_layout_header_problem(local_pe, remote_pe, "version",
+                                     MEMHEAP_LAYOUT_VERSION, remote_version,
+                                     PMIX_SUCCESS);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    count = 1;
+    pmix_rc = PMIx_Data_unpack(NULL, message, &remote_count, &count,
+                              PMIX_UINT32);
+    if (PMIX_SUCCESS != pmix_rc || 1 != count) {
+        if (PMIX_SUCCESS == pmix_rc) {
+            pmix_rc = PMIX_ERR_BAD_PARAM;
+        }
+        report_layout_header_problem(local_pe, remote_pe, "count",
+                                     local_count, remote_count, pmix_rc);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    if (remote_count > INT_MAX || local_count != remote_count) {
+        report_layout_header_problem(local_pe, remote_pe, "count",
+                                     local_count, remote_count, PMIX_SUCCESS);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    for (segment = 0; segment < remote_count; ++segment) {
+        rc = get_layout_descriptor((int) segment, &local_descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            MEMHEAP_ERROR("failed to construct local layout descriptor %u",
+                          segment);
+            return rc;
+        }
+        memset(&remote_descriptor, 0, sizeof(remote_descriptor));
+
+        rc = unpack_descriptor_field(
+            message, &remote_descriptor.type, PMIX_UINT32, remote_pe,
+            local_pe, segment, "type", &local_descriptor,
+            &remote_descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = unpack_descriptor_field(
+            message, &remote_descriptor.size, PMIX_UINT64, remote_pe,
+            local_pe, segment, "size", &local_descriptor,
+            &remote_descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = unpack_descriptor_field(
+            message, &remote_descriptor.hints, PMIX_INT64, remote_pe,
+            local_pe, segment, "hints", &local_descriptor,
+            &remote_descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = unpack_descriptor_field(
+            message, &remote_descriptor.static_offset, PMIX_UINT64,
+            remote_pe, local_pe, segment, "static_offset",
+            &local_descriptor, &remote_descriptor);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+
+        mismatch = NULL;
+        if (remote_descriptor.type >= (uint32_t) MAP_SEGMENT_UNKNOWN
+            || local_descriptor.type != remote_descriptor.type) {
+            mismatch = "type";
+        } else if (local_descriptor.size != remote_descriptor.size) {
+            mismatch = "size";
+        } else if (local_descriptor.hints != remote_descriptor.hints) {
+            mismatch = "hints";
+        } else if (local_descriptor.static_offset
+                   != remote_descriptor.static_offset) {
+            mismatch = "static_offset";
+        }
+        if (NULL != mismatch) {
+            report_layout_descriptor_problem(
+                local_pe, remote_pe, segment, mismatch, &local_descriptor,
+                &remote_descriptor, PMIX_SUCCESS);
+            return OSHMEM_ERR_BAD_PARAM;
+        }
+    }
+
+    count = (int32_t) sizeof(remote_terminator);
+    pmix_rc = PMIx_Data_unpack(NULL, message, remote_terminator, &count,
+                              PMIX_BYTE);
+    if (PMIX_SUCCESS != pmix_rc) {
+        report_layout_header_problem(
+            local_pe, remote_pe, "terminator",
+            MEMHEAP_LAYOUT_TERMINATOR_VALUE, 0, pmix_rc);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    for (segment = 0; segment < sizeof(remote_terminator); ++segment) {
+        remote_terminator_value = (remote_terminator_value << 8)
+                                  | remote_terminator[segment];
+    }
+    if (count != (int32_t) sizeof(remote_terminator)
+        || 0 != memcmp(remote_terminator, memheap_layout_terminator,
+                       sizeof(remote_terminator))) {
+        report_layout_header_problem(
+            local_pe, remote_pe, "terminator",
+            MEMHEAP_LAYOUT_TERMINATOR_VALUE, remote_terminator_value,
+            PMIX_SUCCESS);
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    return OSHMEM_SUCCESS;
+}
+
 static int pack_local_mkeys(pmix_data_buffer_t *msg, int pe, int seg)
 {
     int i, n;
+    int rc;
     sshmem_mkey_t *mkey;
+    uint32_t packed_value;
 
     /* go over all transports and pack mkeys */
     n = memheap_map->num_transports;
-    PMIx_Data_pack(NULL, msg, &n, 1, PMIX_UINT32);
+    if (n < 0 || (uintmax_t) n > UINT32_MAX) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    packed_value = (uint32_t) n;
+    rc = pack_values(msg, &packed_value, 1, PMIX_UINT32);
+    if (OSHMEM_SUCCESS != rc) {
+        return rc;
+    }
     MEMHEAP_VERBOSE(5, "found %d transports to %d", n, pe);
     for (i = 0; i < n; i++) {
         mkey = mca_memheap_base_get_mkey(mca_memheap_seg2base_va(seg), i);
@@ -102,14 +521,31 @@ static int pack_local_mkeys(pmix_data_buffer_t *msg, int pe, int seg)
                           seg, i);
             return OSHMEM_ERROR;
         }
-        PMIx_Data_pack(NULL, msg, &i, 1, PMIX_UINT32);
-        PMIx_Data_pack(NULL, msg, &mkey->va_base, 1, PMIX_UINT64);
+        packed_value = (uint32_t) i;
+        rc = pack_values(msg, &packed_value, 1, PMIX_UINT32);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
+        rc = pack_values(msg, &mkey->va_base, 1, PMIX_UINT64);
+        if (OSHMEM_SUCCESS != rc) {
+            return rc;
+        }
         if (0 == mkey->va_base) {
-            PMIx_Data_pack(NULL, msg, &mkey->u.key, 1, PMIX_UINT64);
+            rc = pack_values(msg, &mkey->u.key, 1, PMIX_UINT64);
+            if (OSHMEM_SUCCESS != rc) {
+                return rc;
+            }
         } else {
-            PMIx_Data_pack(NULL, msg, &mkey->len, 1, PMIX_UINT16);
+            rc = pack_values(msg, &mkey->len, 1, PMIX_UINT16);
+            if (OSHMEM_SUCCESS != rc) {
+                return rc;
+            }
             if (0 < mkey->len) {
-                PMIx_Data_pack(NULL, msg, mkey->u.data, mkey->len, PMIX_BYTE);
+                rc = pack_values(msg, mkey->u.data, mkey->len,
+                                 PMIX_BYTE);
+                if (OSHMEM_SUCCESS != rc) {
+                    return rc;
+                }
             }
         }
         MEMHEAP_VERBOSE(5,
@@ -524,22 +960,26 @@ void mca_memheap_modex_recv_all(void)
     void *send_buffer = NULL;
     char *rcv_buffer = NULL;
     size_t size;
+    int send_size;
     int *rcv_size = NULL;
     int *rcv_n_transports = NULL;
     int *rcv_offsets = NULL;
     int rc = OSHMEM_SUCCESS;
-    size_t buffer_size;
+    size_t buffer_size = 0;
 
     OPAL_TIMING_ENV_INIT(recv_all);
 
-    if (!mca_memheap_base_key_exchange) {
-        oshmem_shmem_barrier();
-        return;
-    }
-    OPAL_TIMING_ENV_NEXT(recv_all, "barrier");
+    OPAL_TIMING_ENV_NEXT(recv_all, "start");
     nprocs = oshmem_num_procs();
     my_pe = oshmem_my_proc_id();
     OPAL_TIMING_ENV_NEXT(recv_all, "proc position");
+
+    if (nprocs <= 0 || my_pe < 0 || my_pe >= nprocs
+        || (size_t) nprocs > SIZE_MAX / sizeof(int)) {
+        rc = OSHMEM_ERR_BAD_PARAM;
+        goto exit_fatal;
+    }
+
     /* buffer allocation for num_transports
      * message sizes and offsets */
 
@@ -558,8 +998,8 @@ void mca_memheap_modex_recv_all(void)
     }
 
     rcv_n_transports = (int *)malloc(nprocs * sizeof(int));
-    if (NULL == rcv_offsets) {
-        MEMHEAP_ERROR("failed to get rcv_offsets buffer");
+    if (NULL == rcv_n_transports) {
+        MEMHEAP_ERROR("failed to get rcv_n_transports buffer");
         rc = OSHMEM_ERR_OUT_OF_RESOURCE;
         goto exit_fatal;
     }
@@ -573,18 +1013,31 @@ void mca_memheap_modex_recv_all(void)
         goto exit_fatal;
     }
 
-    for (j = 0; j < memheap_map->n_segments; j++) {
-        pack_local_mkeys(msg, 0, j);
+    rc = pack_memheap_layout(msg);
+    if (OSHMEM_SUCCESS != rc) {
+        MEMHEAP_ERROR("failed to pack local memheap layout");
+        goto exit_fatal;
     }
-
-    /* we assume here that int32_t returned by opal_dss.unload
-     * is equal to size of int we use for MPI_Allgather, MPI_Allgatherv */
-
-    assert(sizeof(int32_t) == sizeof(int));
+    if (mca_memheap_base_key_exchange) {
+        for (j = 0; j < memheap_map->n_segments; j++) {
+            rc = pack_local_mkeys(msg, my_pe, j);
+            if (OSHMEM_SUCCESS != rc) {
+                MEMHEAP_ERROR("failed to pack local keys for segment %d", j);
+                goto exit_fatal;
+            }
+        }
+    }
 
     /* Do allgather */
     PMIX_DATA_BUFFER_UNLOAD(msg, send_buffer, size);
-    MEMHEAP_VERBOSE(1, "local keys packed into %d bytes, %" PRIsize_t " segments", size, memheap_map->n_segments);
+    if (0 == size || size > INT_MAX) {
+        MEMHEAP_ERROR("invalid local key payload size: %" PRIsize_t, size);
+        rc = OSHMEM_ERR_BAD_PARAM;
+        goto exit_fatal;
+    }
+    send_size = (int) size;
+    MEMHEAP_VERBOSE(1, "local memheap payload packed into %d bytes, %d segments",
+                    send_size, memheap_map->n_segments);
 
     OPAL_TIMING_ENV_NEXT(recv_all, "serialize data");
 
@@ -601,7 +1054,7 @@ void mca_memheap_modex_recv_all(void)
     OPAL_TIMING_ENV_NEXT(recv_all, "allgather: transport cnt");
 
 
-    rc = oshmem_shmem_allgather(&size, rcv_size, sizeof(int));
+    rc = oshmem_shmem_allgather(&send_size, rcv_size, sizeof(int));
     if (MPI_SUCCESS != rc) {
         MEMHEAP_ERROR("allgather failed");
         goto exit_fatal;
@@ -611,12 +1064,33 @@ void mca_memheap_modex_recv_all(void)
 
     /* calculating offsets (displacements) for allgatherv */
 
-    rcv_offsets[0] = 0;
-    for (i = 1; i < nprocs; i++) {
-        rcv_offsets[i] = rcv_offsets[i - 1] + rcv_size[i - 1];
+    for (i = 0; i < nprocs; ++i) {
+        if (rcv_n_transports[i] < 0 || rcv_size[i] < 0
+            || buffer_size > INT_MAX) {
+            MEMHEAP_ERROR("invalid receive metadata from PE %d", i);
+            rc = OSHMEM_ERR_BAD_PARAM;
+            goto exit_fatal;
+        }
+        rcv_offsets[i] = (int) buffer_size;
+        if ((size_t) rcv_size[i] > SIZE_MAX - buffer_size) {
+            MEMHEAP_ERROR("receive payload size overflows at PE %d", i);
+            rc = OSHMEM_ERR_BAD_PARAM;
+            goto exit_fatal;
+        }
+        buffer_size += (size_t) rcv_size[i];
+        if (buffer_size > INT_MAX) {
+            MEMHEAP_ERROR("receive displacement exceeds INT_MAX at PE %d",
+                          i);
+            rc = OSHMEM_ERR_BAD_PARAM;
+            goto exit_fatal;
+        }
     }
 
-    buffer_size = rcv_offsets[nprocs - 1] + rcv_size[nprocs - 1];
+    if (0 == buffer_size) {
+        MEMHEAP_ERROR("empty collective key payload");
+        rc = OSHMEM_ERR_BAD_PARAM;
+        goto exit_fatal;
+    }
 
     rcv_buffer = malloc (buffer_size);
     if (NULL == rcv_buffer) {
@@ -627,9 +1101,11 @@ void mca_memheap_modex_recv_all(void)
 
     OPAL_TIMING_ENV_NEXT(recv_all, "alloc data buf");
 
-    rc = oshmem_shmem_allgatherv(send_buffer, rcv_buffer, size, rcv_size, rcv_offsets);
+    rc = oshmem_shmem_allgatherv(send_buffer, rcv_buffer, send_size,
+                                 rcv_size, rcv_offsets);
     if (MPI_SUCCESS != rc) {
         free (rcv_buffer);
+        rcv_buffer = NULL;
         MEMHEAP_ERROR("allgatherv failed");
         goto exit_fatal;
     }
@@ -637,41 +1113,88 @@ void mca_memheap_modex_recv_all(void)
     OPAL_TIMING_ENV_NEXT(recv_all, "Perform mkey exchange");
 
     PMIX_DATA_BUFFER_LOAD(msg, rcv_buffer, buffer_size);
+    rcv_buffer = NULL;
 
-    /* deserialize mkeys */
+    /*
+     * Pass 1 validates every peer, including self. It intentionally holds no
+     * lock and performs no remote-key allocation, unpack, or mutation.
+     */
+    for (i = 0; i < nprocs; i++) {
+        rc = select_peer_payload(msg, buffer_size, rcv_offsets[i],
+                                 rcv_size[i]);
+        if (OSHMEM_SUCCESS != rc) {
+            goto exit_fatal;
+        }
+        rc = unpack_and_validate_layout(msg, i, my_pe);
+        if (OSHMEM_SUCCESS != rc) {
+            goto exit_fatal;
+        }
+    }
+
+    /*
+     * Lazy key lookup still uses the validated receiver-local segment
+     * ordinal. Preserve the disabled eager-exchange barrier, but return only
+     * after every peer's canonical layout has passed validation.
+     */
+    if (!mca_memheap_base_key_exchange) {
+        oshmem_shmem_barrier();
+        goto exit_fatal;
+    }
+
+    /*
+     * Pass 2 reselects and revalidates each remote slice to position its
+     * cursor at the existing key records before installing them.
+     */
     OPAL_THREAD_LOCK(&memheap_oob.lck);
     for (i = 0; i < nprocs; i++) {
         if (i == my_pe) {
             continue;
         }
 
-        msg->unpack_ptr = (void *)((intptr_t) msg->base_ptr + rcv_offsets[i]);
-
+        rc = select_peer_payload(msg, buffer_size, rcv_offsets[i],
+                                 rcv_size[i]);
+        if (OSHMEM_SUCCESS != rc) {
+            break;
+        }
+        rc = unpack_and_validate_layout(msg, i, my_pe);
+        if (OSHMEM_SUCCESS != rc) {
+            break;
+        }
         for (j = 0; j < memheap_map->n_segments; j++) {
-            map_segment_t *s;
+            map_segment_t *segment;
 
-            s = &memheap_map->mem_segs[j];
-            if (NULL != s->mkeys_cache[i]) {
+            segment = &memheap_map->mem_segs[j];
+            if (NULL != segment->mkeys_cache[i]) {
                 MEMHEAP_VERBOSE(10, "PE%d: segment%d already exists, mkey will be replaced", i, j);
             } else {
-                s->mkeys_cache[i] = (sshmem_mkey_t *) calloc(rcv_n_transports[i],
-                        sizeof(sshmem_mkey_t));
-                if (NULL == s->mkeys_cache[i]) {
+                segment->mkeys_cache[i] = (sshmem_mkey_t *)
+                    calloc(rcv_n_transports[i], sizeof(sshmem_mkey_t));
+                if (NULL == segment->mkeys_cache[i]) {
                     MEMHEAP_ERROR("PE%d: segment%d: Failed to allocate mkeys cache entry", i, j);
-                    oshmem_shmem_abort(-1);
+                    rc = OSHMEM_ERR_OUT_OF_RESOURCE;
+                    break;
                 }
             }
-            memheap_oob.mkeys = s->mkeys_cache[i];
+            memheap_oob.mkeys = segment->mkeys_cache[i];
             memheap_oob.segno = j;
             unpack_remote_mkeys(oshmem_ctx_default, msg, i);
+        }
+        if (OSHMEM_SUCCESS != rc) {
+            break;
         }
     }
 
     OPAL_TIMING_ENV_NEXT(recv_all, "Unpack data");
 
     OPAL_THREAD_UNLOCK(&memheap_oob.lck);
+    if (OSHMEM_SUCCESS != rc) {
+        goto exit_fatal;
+    }
 
 exit_fatal:
+    if (rcv_buffer) {
+        free(rcv_buffer);
+    }
     if (rcv_size) {
         free(rcv_size);
     }

--- a/oshmem/mca/memheap/base/memheap_base_static.c
+++ b/oshmem/mca/memheap/base/memheap_base_static.c
@@ -19,112 +19,407 @@
 #include "oshmem/util/oshmem_util.h"
 #include "opal/util/minmax.h"
 
+#if defined(__linux__)
+#include <link.h>
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 #include <pthread.h>
 
-static int _check_perms(const char *perm);
-static int _check_non_static_segment(const map_segment_t *mem_segs,
-                                     int n_segment,
-                                     const void *start, const void *end);
-static int _check_address(void *start, void **end);
-static int _check_pathname(uint64_t inode, const char *pathname);
+#if defined(__linux__)
+typedef struct {
+    uintptr_t start;
+    uintptr_t end;
+} writable_load_range_t;
+
+typedef struct {
+    uintptr_t load_bias;
+    writable_load_range_t *ranges;
+    size_t count;
+    size_t capacity;
+    bool found_main;
+    int status;
+} executable_layout_t;
+
+static executable_layout_t executable_layout;
+
+static int add_uintptr(uintptr_t left, uintptr_t right, uintptr_t *result)
+{
+    if (NULL == result || left > UINTPTR_MAX - right) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    *result = left + right;
+    return OSHMEM_SUCCESS;
+}
+
+static int append_writable_range(executable_layout_t *layout, uintptr_t start,
+                                 uintptr_t end)
+{
+    writable_load_range_t *ranges;
+    size_t new_capacity;
+
+    if (NULL == layout || start >= end) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    if (layout->count == layout->capacity) {
+        if (0 == layout->capacity) {
+            new_capacity = 4;
+        } else {
+            if (layout->capacity > SIZE_MAX / 2) {
+                return OSHMEM_ERR_BAD_PARAM;
+            }
+            new_capacity = layout->capacity * 2;
+        }
+        if (new_capacity > SIZE_MAX / sizeof(*ranges)) {
+            return OSHMEM_ERR_BAD_PARAM;
+        }
+
+        ranges = realloc(layout->ranges, new_capacity * sizeof(*ranges));
+        if (NULL == ranges) {
+            return OSHMEM_ERR_OUT_OF_RESOURCE;
+        }
+        layout->ranges = ranges;
+        layout->capacity = new_capacity;
+    }
+
+    layout->ranges[layout->count].start = start;
+    layout->ranges[layout->count].end = end;
+    ++layout->count;
+    return OSHMEM_SUCCESS;
+}
+
+static int find_main_executable(struct dl_phdr_info *info, size_t size,
+                                void *data)
+{
+    executable_layout_t *layout = data;
+    size_t i;
+
+    (void) size;
+    if (NULL != info->dlpi_name && '\0' != info->dlpi_name[0]) {
+        return 0;
+    }
+
+    layout->found_main = true;
+    layout->load_bias = (uintptr_t) info->dlpi_addr;
+    for (i = 0; i < info->dlpi_phnum; ++i) {
+        const ElfW(Phdr) *phdr = &info->dlpi_phdr[i];
+        uintptr_t start;
+        uintptr_t end;
+        int rc;
+
+        if (PT_LOAD != phdr->p_type || 0 == (phdr->p_flags & PF_W)
+            || 0 == phdr->p_memsz) {
+            continue;
+        }
+        if ((uintmax_t) phdr->p_vaddr > (uintmax_t) UINTPTR_MAX
+            || (uintmax_t) phdr->p_memsz > (uintmax_t) UINTPTR_MAX) {
+            layout->status = OSHMEM_ERR_BAD_PARAM;
+            return 1;
+        }
+
+        rc = add_uintptr(layout->load_bias, (uintptr_t) phdr->p_vaddr,
+                         &start);
+        if (OSHMEM_SUCCESS == rc) {
+            rc = add_uintptr(start, (uintptr_t) phdr->p_memsz, &end);
+        }
+        if (OSHMEM_SUCCESS == rc && start >= end) {
+            rc = OSHMEM_ERR_BAD_PARAM;
+        }
+        if (OSHMEM_SUCCESS == rc) {
+            rc = append_writable_range(layout, start, end);
+        }
+        if (OSHMEM_SUCCESS != rc) {
+            layout->status = rc;
+            return 1;
+        }
+    }
+
+    return 1;
+}
+
+static int compare_writable_ranges(const void *left, const void *right)
+{
+    const writable_load_range_t *left_range = left;
+    const writable_load_range_t *right_range = right;
+
+    if (left_range->start < right_range->start) {
+        return -1;
+    }
+    if (left_range->start > right_range->start) {
+        return 1;
+    }
+    if (left_range->end < right_range->end) {
+        return -1;
+    }
+    if (left_range->end > right_range->end) {
+        return 1;
+    }
+    return 0;
+}
+
+static void coalesce_writable_ranges(executable_layout_t *layout)
+{
+    size_t input;
+    size_t output = 0;
+
+    if (layout->count > 1) {
+        qsort(layout->ranges, layout->count, sizeof(*layout->ranges),
+              compare_writable_ranges);
+    }
+
+    for (input = 0; input < layout->count; ++input) {
+        if (0 == output
+            || layout->ranges[output - 1].end < layout->ranges[input].start) {
+            layout->ranges[output++] = layout->ranges[input];
+            continue;
+        }
+        layout->ranges[output - 1].end =
+            opal_max(layout->ranges[output - 1].end,
+                     layout->ranges[input].end);
+    }
+    layout->count = output;
+}
+
+static int discover_executable_layout(void)
+{
+    int iterate_status;
+
+    free(executable_layout.ranges);
+    memset(&executable_layout, 0, sizeof(executable_layout));
+    executable_layout.status = OSHMEM_SUCCESS;
+
+    iterate_status = dl_iterate_phdr(find_main_executable,
+                                     &executable_layout);
+    if (OSHMEM_SUCCESS != executable_layout.status) {
+        MEMHEAP_ERROR("failed to discover writable executable ELF ranges: %d",
+                      executable_layout.status);
+        return executable_layout.status;
+    }
+    if (!executable_layout.found_main || 0 == iterate_status) {
+        MEMHEAP_ERROR("failed to locate the main executable ELF image");
+        return OSHMEM_ERR_NOT_FOUND;
+    }
+
+    coalesce_writable_ranges(&executable_layout);
+    return OSHMEM_SUCCESS;
+}
+
+static int append_static_segment(mca_memheap_map_t *map, int original_count,
+                                 uintptr_t start, uintptr_t end)
+{
+    map_segment_t *segment;
+    uintptr_t segment_size;
+
+    if (NULL == map || start >= end) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    segment_size = end - start;
+    if ((uintmax_t) segment_size > (uintmax_t) SIZE_MAX) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+
+    if (map->n_segments > original_count) {
+        segment = &map->mem_segs[map->n_segments - 1];
+        if (MAP_SEGMENT_STATIC == segment->type
+            && (uintptr_t) segment->super.va_end == start) {
+            MEMHEAP_VERBOSE(5, "Coalescing static segment");
+            segment->super.va_end = (void *) end;
+            segment->seg_size =
+                (uintptr_t) segment->super.va_end
+                - (uintptr_t) segment->super.va_base;
+            return OSHMEM_SUCCESS;
+        }
+    }
+
+    if (map->n_segments < 0 || map->capacity < map->n_segments
+        || (map->n_segments == map->capacity
+            && map->capacity > INT_MAX / 2)) {
+        return OSHMEM_ERR_OUT_OF_RESOURCE;
+    }
+    segment = mca_memheap_base_allocate_segment(map);
+    if (NULL == segment) {
+        return OSHMEM_ERR_OUT_OF_RESOURCE;
+    }
+
+    memset(segment, 0, sizeof(*segment));
+    MAP_SEGMENT_RESET_FLAGS(segment);
+    segment->seg_id = MAP_SEGMENT_SHM_INVALID;
+    segment->super.va_base = (void *) start;
+    segment->super.va_end = (void *) end;
+    segment->seg_size = (size_t) segment_size;
+    segment->type = MAP_SEGMENT_STATIC;
+    ++map->n_segments;
+    MEMHEAP_VERBOSE(5, "add static intersection: %p-%p",
+                    segment->super.va_base, segment->super.va_end);
+    return OSHMEM_SUCCESS;
+}
+
+static int add_static_interval(mca_memheap_map_t *map, int original_count,
+                               uintptr_t start, uintptr_t end)
+{
+    int i;
+
+    if (start >= end) {
+        return OSHMEM_SUCCESS;
+    }
+
+    for (i = 0; i < original_count; ++i) {
+        uintptr_t excluded_start;
+        uintptr_t excluded_end;
+        int rc;
+
+        if (MAP_SEGMENT_STATIC == map->mem_segs[i].type) {
+            continue;
+        }
+        excluded_start = (uintptr_t) map->mem_segs[i].super.va_base;
+        excluded_end = (uintptr_t) map->mem_segs[i].super.va_end;
+        if (excluded_start >= excluded_end) {
+            return OSHMEM_ERR_BAD_PARAM;
+        }
+        if (excluded_end <= start || excluded_start >= end) {
+            continue;
+        }
+
+        if (start < excluded_start) {
+            rc = add_static_interval(map, original_count, start,
+                                     opal_min(end, excluded_start));
+            if (OSHMEM_SUCCESS != rc) {
+                return rc;
+            }
+        }
+        if (excluded_end < end) {
+            return add_static_interval(map, original_count,
+                                       opal_max(start, excluded_end), end);
+        }
+        return OSHMEM_SUCCESS;
+    }
+
+    return append_static_segment(map, original_count, start, end);
+}
+#endif /* defined(__linux__) */
 
 int mca_memheap_base_static_init(mca_memheap_map_t *map)
 {
-    /* read and parse segments from /proc/self/maps */
-    int ret = OSHMEM_SUCCESS;
-    int n_segments = map->n_segments;
+#if defined(__linux__)
+    int rc;
+    int original_count;
+    int i;
     uint64_t total_mem = 0;
-    void* start;
-    void* end;
-    char perms[8];
-    uint64_t offset;
-    char dev[8];
-    uint64_t inode;
-    char pathname[OPAL_PATH_MAX];
-    FILE *fp;
-    char line[1024];
-    map_segment_t *s;
+    FILE *maps = NULL;
+    char line[4096];
 
     assert(map);
     assert(HEAP_SEG_INDEX < map->n_segments);
+    original_count = map->n_segments;
 
-    /* FIXME!!! Linux specific code */
-    fp = fopen("/proc/self/maps", "r");
-    if (NULL == fp) {
-        MEMHEAP_ERROR("Failed to open /proc/self/maps");
-        return OSHMEM_ERROR;
+    rc = discover_executable_layout();
+    if (OSHMEM_SUCCESS != rc) {
+        goto out;
     }
 
-    while (NULL != fgets(line, sizeof(line), fp)) {
-        if (3 > sscanf(line,
-               "%llx-%llx %s %llx %s %llx %s",
-               (unsigned long long *) &start,
-               (unsigned long long *) &end,
-               perms,
-               (unsigned long long *) &offset,
-               dev,
-               (unsigned long long *) &inode,
-               pathname)) {
-            MEMHEAP_ERROR("Failed to sscanf /proc/self/maps output %s", line);
-            ret = OSHMEM_ERROR;
+    maps = fopen("/proc/self/maps", "r");
+    if (NULL == maps) {
+        MEMHEAP_ERROR("Failed to open /proc/self/maps");
+        rc = OSHMEM_ERROR;
+        goto out;
+    }
+
+    while (NULL != fgets(line, sizeof(line), maps)) {
+        unsigned long long parsed_start;
+        unsigned long long parsed_end;
+        uintptr_t map_start;
+        uintptr_t map_end;
+        char perms[5];
+        size_t range_index;
+        int fields;
+
+        if (NULL == strchr(line, '\n') && !feof(maps)) {
+            MEMHEAP_ERROR("truncated /proc/self/maps entry");
+            rc = OSHMEM_ERR_BAD_PARAM;
             goto out;
         }
-
-        if (OSHMEM_ERROR == _check_non_static_segment(
-                                                   map->mem_segs, n_segments,
-                                                   start, end)) {
-            continue;
-        }
-
-        if (OSHMEM_ERROR == _check_address(start, &end))
-            continue;
-
-        if (OSHMEM_ERROR == _check_pathname(inode, pathname))
-            continue;
-
-        if (OSHMEM_ERROR == _check_perms(perms))
-            continue;
-
-        MEMHEAP_VERBOSE(5, "add: %s", line);
-
-        if ((map->n_segments > 0) &&
-            (start == map->mem_segs[map->n_segments - 1].super.va_end)) {
-            s = &map->mem_segs[map->n_segments - 1];
-            MEMHEAP_VERBOSE(5, "Coalescing segment");
-            s->super.va_end = end;
-            s->seg_size = ((uintptr_t)s->super.va_end - (uintptr_t)s->super.va_base);
-            continue;
-        }
-
-        s = mca_memheap_base_allocate_segment(map);
-        if (NULL == s) {
-            MEMHEAP_ERROR("failed to allocate segment");
-            ret = OSHMEM_ERR_OUT_OF_RESOURCE;
+        fields = sscanf(line, "%llx-%llx %4s", &parsed_start, &parsed_end,
+                        perms);
+        if (3 != fields || parsed_start >= parsed_end
+            || (uintmax_t) parsed_start > (uintmax_t) UINTPTR_MAX
+            || (uintmax_t) parsed_end > (uintmax_t) UINTPTR_MAX) {
+            MEMHEAP_ERROR("invalid /proc/self/maps entry: %s", line);
+            rc = OSHMEM_ERR_BAD_PARAM;
             goto out;
         }
+        if (4 != strlen(perms) || 'w' != perms[1] || 'p' != perms[3]) {
+            continue;
+        }
 
-        memset(s, 0, sizeof(*s));
-        MAP_SEGMENT_RESET_FLAGS(s);
-        s->seg_id        = MAP_SEGMENT_SHM_INVALID;
-        s->super.va_base = start;
-        s->super.va_end  = end;
-        s->seg_size      = ((uintptr_t)s->super.va_end - (uintptr_t)s->super.va_base);
-        s->type          = MAP_SEGMENT_STATIC;
-        map->n_segments++;
+        map_start = (uintptr_t) parsed_start;
+        map_end = (uintptr_t) parsed_end;
+        for (range_index = 0; range_index < executable_layout.count;
+             ++range_index) {
+            uintptr_t intersection_start =
+                opal_max(map_start,
+                         executable_layout.ranges[range_index].start);
+            uintptr_t intersection_end =
+                opal_min(map_end, executable_layout.ranges[range_index].end);
 
-        total_mem += ((uintptr_t)s->super.va_end - (uintptr_t)s->super.va_base);
+            if (intersection_start < intersection_end) {
+                rc = add_static_interval(map, original_count,
+                                         intersection_start,
+                                         intersection_end);
+                if (OSHMEM_SUCCESS != rc) {
+                    MEMHEAP_ERROR("failed to add static executable interval: %d",
+                                  rc);
+                    goto out;
+                }
+            }
+        }
+    }
+    if (ferror(maps)) {
+        MEMHEAP_ERROR("Failed to read /proc/self/maps");
+        rc = OSHMEM_ERROR;
+        goto out;
+    }
+
+    for (i = original_count; i < map->n_segments; ++i) {
+        uint64_t segment_size = (uint64_t) map->mem_segs[i].seg_size;
+
+        if (segment_size > UINT64_MAX - total_mem) {
+            MEMHEAP_ERROR("static executable memory size overflow");
+            rc = OSHMEM_ERR_BAD_PARAM;
+            goto out;
+        }
+        total_mem += segment_size;
     }
 
     MEMHEAP_VERBOSE(1,
                     "Memheap static memory: %llu byte(s), %d segments",
-                    total_mem, map->n_segments);
+                    (unsigned long long) total_mem, map->n_segments);
+    rc = OSHMEM_SUCCESS;
 
 out:
-    fclose(fp);
-    return ret;
+    if (NULL != maps) {
+        fclose(maps);
+    }
+    free(executable_layout.ranges);
+    executable_layout.ranges = NULL;
+    executable_layout.count = 0;
+    executable_layout.capacity = 0;
+    if (OSHMEM_SUCCESS != rc) {
+        executable_layout.found_main = false;
+        map->n_segments = original_count;
+    }
+    return rc;
+#else
+    assert(map);
+    MEMHEAP_ERROR("main-executable writable ELF layout discovery is unsupported on this platform");
+    return OSHMEM_ERR_NOT_SUPPORTED;
+#endif
 }
 
 void mca_memheap_base_static_exit(mca_memheap_map_t *map)
@@ -132,139 +427,31 @@ void mca_memheap_base_static_exit(mca_memheap_map_t *map)
     assert(map);
 }
 
-static int _check_perms(const char *perms)
+int mca_memheap_base_static_segment_offset(const map_segment_t *segment,
+                                           uint64_t *offset)
 {
-    if (!strcmp(perms, "rw-p") || !strcmp(perms, "rwxp"))
-        return OSHMEM_SUCCESS;
+#if defined(__linux__)
+    uintptr_t base;
+    uintmax_t relative;
 
-    return OSHMEM_ERROR;
-}
-
-static int _check_non_static_segment(const map_segment_t *mem_segs,
-                                     int n_segment,
-                                     const void *start, const void *end)
-{
-    int i;
-
-    for (i = 0; i < n_segment; i++) {
-        if ((start <= mem_segs[i].super.va_base) &&
-            (mem_segs[i].super.va_base < end)) {
-            MEMHEAP_VERBOSE(100,
-                            "non static segment: %p-%p already exists as %p-%p",
-                            start, end, mem_segs[i].super.va_base,
-                            mem_segs[i].super.va_end);
-            return OSHMEM_ERROR;
-        }
+    if (NULL == segment || NULL == offset
+        || MAP_SEGMENT_STATIC != segment->type
+        || !executable_layout.found_main) {
+        return OSHMEM_ERR_BAD_PARAM;
     }
-
+    base = (uintptr_t) segment->super.va_base;
+    if (base < executable_layout.load_bias) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    relative = (uintmax_t) (base - executable_layout.load_bias);
+    if (relative > UINT64_MAX) {
+        return OSHMEM_ERR_BAD_PARAM;
+    }
+    *offset = (uint64_t) relative;
     return OSHMEM_SUCCESS;
-}
-
-static int _check_address(void *start, void **end)
-{
-    /* FIXME Linux specific code */
-#ifdef __linux__
-    extern unsigned _end;
-    uintptr_t data_end = (uintptr_t)&_end;
-
-    /**
-     * SGI shmem only supports globals&static in main program.
-     * It does not support them in shared objects or in dlopen()
-     * (Clarified on PGAS 2011 tutorial).
-     *
-     * So ignored any maps that start higher then process _end.
-     */
-    if ((uintptr_t)start > data_end) {
-        MEMHEAP_VERBOSE(100,
-                        "skip segment: data _end < segment start (%p < %p)",
-                        data_end, start);
-        return OSHMEM_ERROR;
-    }
-
-    if ((uintptr_t)*end > data_end) {
-        MEMHEAP_VERBOSE(100,
-                        "adjust segment: data _end < segment end (%p < %p",
-                        data_end, *end);
-         *end = (void*)data_end;
-    }
+#else
+    (void) segment;
+    (void) offset;
+    return OSHMEM_ERR_NOT_SUPPORTED;
 #endif
-    return OSHMEM_SUCCESS;
 }
-
-static int _check_pathname(uint64_t inode, const char *pathname)
-{
-    static const char *proc_self_exe = "/proc/self/exe";
-    static int warned = 0;
-    char exe_path[OPAL_PATH_MAX];
-    char module_path[OPAL_PATH_MAX];
-    char *path;
-
-    if (0 == inode) {
-        /* segment is not mapped to file, allow sharing it */
-        return OSHMEM_SUCCESS;
-    }
-
-    path = realpath(proc_self_exe, exe_path);
-    if (NULL == path) {
-        if (0 == warned) {
-            MEMHEAP_VERBOSE(100, "failed to read link %s: %m", proc_self_exe);
-            MEMHEAP_VERBOSE(100, "all segments will be registered");
-            warned = 1;
-        }
-
-        return OSHMEM_SUCCESS;
-    }
-
-    /* for file-mapped segments allow segments from start process only */
-    path = realpath(pathname, module_path);
-    if (NULL == path) {
-        return OSHMEM_ERROR;
-    }
-
-    if (!strncmp(exe_path, module_path, sizeof(exe_path))) {
-        return OSHMEM_SUCCESS;
-    }
-
-    return OSHMEM_ERROR;
-
-    /* Probably we need more accurate path check
-     * To press check coverity issue following code is disabled
-     */
-#if 0
-    char *p;
-    if ('\0' == seg->pathname[0])
-    return OSHMEM_SUCCESS;
-
-    if (0 == strncmp(seg->pathname, "/lib", 4))
-    return OSHMEM_ERROR;
-
-    if (0 == strncmp(seg->pathname, "/usr/lib", 8))
-    return OSHMEM_ERROR;
-
-    if (0 == strncmp(seg->pathname, "/dev", 4))
-    return OSHMEM_ERROR;
-
-    if (0 == strcmp(seg->pathname, "[stack]"))
-    return OSHMEM_ERROR;
-
-    if (0 == strcmp(seg->pathname, "[vdso]"))
-    return OSHMEM_ERROR;
-
-    if (0 == strcmp(seg->pathname, "[vsyscall]"))
-    return OSHMEM_ERROR;
-
-    p = rindex(seg->pathname, '/');
-    if (p) {
-        if (0 == strncmp(p+1, "libshmem.so", 11))
-        return OSHMEM_ERROR;
-
-        if (0 == strncmp(p+1, "lib" OMPI_LIBMPI_NAME ".so", 9))
-        return OSHMEM_ERROR;
-
-        if (0 == strncmp(p+1, "libmca_common_sm.so", 19))
-        return OSHMEM_ERROR;
-    }
-#endif
-    return OSHMEM_SUCCESS;
-}
-


### PR DESCRIPTION
OpenSHMEM currently discovers static symmetric storage by scanning writable mappings in `/proc/self/maps`. Anonymous runtime mappings can therefore enter the memheap table, even though those mappings may differ between PEs. The receiver then indexes remote keys with its local segment order, which can lead to an out-of-bounds access or an incorrect key/segment pairing. This is related to #13621.

This PR:

- limits static segments to the writable `PT_LOAD` ranges of `/proc/self/exe`, intersected with the process's current mappings; and
- exchanges and validates a canonical segment-layout descriptor before allocating peer key state or unpacking keys, aborting initialization with a clear diagnostic on a mismatch.

Validation:

- fresh `v6.0.x` builds before and after the commits, using bundled PMIx/PRRTE with OpenSHMEM and UCX enabled;
- both full `make -j64` builds completed successfully, including compilation of `memheap_base_static.c` and `memheap_base_mkey.c`.
