### PR TITLE
osc/rdma: correct shared-state atomics for local peers and alternate btls

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,16 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- Fixed wrong answers from one-sided (RMA) operations on a window
+  allocated with ``MPI_Win_allocate`` when the target is a process on the
+  same node but the operation is carried out by the underlying transport
+  rather than with CPU atomics.  In that case ``osc/rdma`` described the
+  target's memory with an address taken from the calling process's own
+  mapping of the shared segment, while pairing it with the memory
+  registration of a different process, so the transport could read or
+  write the wrong location.  ``MPI_Win_shared_query`` on such a window
+  continues to report an address that is valid in the calling process.
+
 - One-sided (RMA) windows on networks without hardware atomics --
   ``btl/tcp``, for example -- are dramatically faster when more than one
   MPI process shares a node.  The ``osc/rdma`` component now applies its

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,16 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- One-sided (RMA) windows on networks without hardware atomics --
+  ``btl/tcp``, for example -- are dramatically faster when more than one
+  MPI process shares a node.  The ``osc/rdma`` component now applies its
+  shared state optimization whenever the underlying transport guarantees
+  that CPU atomics and transport atomics are atomic with respect to each
+  other, which includes the emulated atomics used on such networks.
+  Previously the optimization was disabled for these transports, so
+  every window-state atomic issued by a process was routed to another
+  process on the same node and executed as a network round trip.
+
 - Nonblocking file I/O no longer loses data when the operating system's
   asynchronous I/O queue fills, which on macOS it readily does: the
   ``posix`` ``fbtl`` component sized its batch of concurrent ``aio_write``

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -610,7 +610,7 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
     if (module->single_node) {
         use_cpu_atomics = true;
     } else if (module->use_accelerated_btl) {
-        use_cpu_atomics = !!(module->accelerated_btl->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
+        use_cpu_atomics = !!(module->accelerated_btl->btl_atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     } else {
         /* using the shared state optimization that is enabled by
          * being able to use cpu atomics was never enabled for

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -548,6 +548,8 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) my_peer;
 
         ex_peer->super.base = (intptr_t) *base;
+        ex_peer->super.local_base = (intptr_t) *base;
+        my_peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
 
         if (!module->same_size) {
             ex_peer->size = size;
@@ -853,23 +855,30 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
                 ex_peer->size = temp[i].size;
             }
 
-            if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor || peer_rank == my_rank) {
-                /* base is local and cpu atomics are available */
-                if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
-                    ex_peer->super.base = (uintptr_t) module->segment_base + offset;
-                } else {
-                    ex_peer->super.base = (uintptr_t) *base;
-                }
-
-                peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
-                if (use_cpu_atomics) {
-                    peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
-                } else if (module->use_memory_registration) {
-                    ex_peer->super.base_handle = (mca_btl_base_registration_handle_t *) peer_region->btl_handle_data;
-                }
+            /* the memory of a peer on this node lives in the shared segment, so
+             * we can always compute an address for it that is valid in this
+             * process, whether or not we can use cpu atomics on that peer */
+            if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
+                ex_peer->super.local_base = (osc_rdma_base_t) ((uintptr_t) module->segment_base + offset);
+                peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
                 offset += temp[i].size;
                 offset += OPAL_ALIGN_PAD_AMOUNT(offset, memory_alignment);
+            } else if (peer_rank == my_rank) {
+                ex_peer->super.local_base = (osc_rdma_base_t) (uintptr_t) *base;
+                peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
+            }
+
+            if (use_cpu_atomics && (MPI_WIN_FLAVOR_ALLOCATE == module->flavor || peer_rank == my_rank)) {
+                /* base is local and cpu atomics are available */
+                ex_peer->super.base = ex_peer->super.local_base;
+
+                peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
+                peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
             } else {
+                /* the peer will be reached through the btl, so base and
+                 * base_handle have to describe the same mapping.  even for a
+                 * peer on this node we must use the address the registration
+                 * was made with rather than our own mapping of the segment. */
                 ex_peer->super.base = peer_region->base;
 
                 if (module->use_memory_registration) {
@@ -1664,8 +1673,8 @@ int ompi_osc_rdma_shared_query(
                 continue;
             }
             ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
-            if (ompi_osc_rdma_peer_local_base(peer)) {
-                if (module->same_size && ex_peer->super.base) {
+            if (ompi_osc_rdma_peer_shared_mem(peer)) {
+                if (module->same_size && ex_peer->super.local_base) {
                     break;
                 } else if (ex_peer->size > 0) {
                     break;
@@ -1678,21 +1687,24 @@ int ompi_osc_rdma_shared_query(
         peer = ompi_osc_module_get_peer (module, rank);
     }
 
-    if (NULL == peer || !ompi_osc_rdma_peer_local_base(peer)) {
+    if (NULL == peer || !ompi_osc_rdma_peer_shared_mem(peer)) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
+    /* report local_base rather than base: base is the address the peer is
+     * reached at through the btl, which is only also a valid address in this
+     * process when cpu atomics are in use */
     if (module->same_size && module->same_disp_unit) {
         *size = module->size;
         *disp_unit = module->disp_unit;
         ompi_osc_rdma_peer_basic_t *ex_peer = (ompi_osc_rdma_peer_basic_t *) peer;
-        *((void**) baseptr) = (void *) (intptr_t)ex_peer->base;
+        *((void**) baseptr) = (void *) (intptr_t)ex_peer->local_base;
         rc = OMPI_SUCCESS;
     } else {
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
-        if (ex_peer->super.base != 0) {
+        if (ex_peer->super.local_base != 0) {
             /* we know the base of the peer */
-            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.base;
+            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.local_base;
             *size = ex_peer->size;
             *disp_unit = ex_peer->disp_unit;
             rc = OMPI_SUCCESS;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -609,18 +609,16 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
     if (module->single_node) {
         use_cpu_atomics = true;
-    } else if (module->use_accelerated_btl) {
-        use_cpu_atomics = !!(module->accelerated_btl->btl_atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     } else {
-        /* using the shared state optimization that is enabled by
-         * being able to use cpu atomics was never enabled for
-         * alternate btls, due to a previous bug in the enablement
-         * logic when alternate btls were first supported.  It is
-         * likely that this optimization could work with sufficient
-         * testing, but for now, always disable to not introduce new
-         * correctness risks.
-         */
-        use_cpu_atomics = false;
+        /* the shared state optimization requires that atomics issued through
+         * the btl be atomic with respect to atomics issued by the cpu, since
+         * a peer on this node will update the state directly while a peer on
+         * another node reaches it through the btl.  module->atomic_flags
+         * reports that guarantee for both the accelerated and the alternate
+         * btl case: for alternate btls the atomics are emulated as active
+         * messages that the target's cpu applies with opal_atomic_*(), so
+         * they are cpu atomics on the same memory by construction. */
+        use_cpu_atomics = !!(module->atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     }
 
     if (1 == local_size) {

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -145,6 +145,8 @@ enum {
     OMPI_OSC_RDMA_PEER_DEMAND_LOCKED        = 0x80,
     /** we can use CPU atomics on that peer */
     OMPI_OSC_RDMA_PEER_CPU_ATOMICS          = 0x100,
+    /** peer's window memory is directly accessible through local_base */
+    OMPI_OSC_RDMA_PEER_SHARED_MEM           = 0x200,
 };
 
 /**
@@ -230,6 +232,21 @@ static inline bool ompi_osc_rdma_peer_local_base (ompi_osc_rdma_peer_t *peer)
 static inline bool ompi_osc_rdma_peer_cpu_atomics (ompi_osc_rdma_peer_t *peer)
 {
     return ompi_osc_rdma_peer_local_base(peer) && !!(peer->flags & OMPI_OSC_RDMA_PEER_CPU_ATOMICS);
+}
+
+/**
+ * @brief check if the peer's window memory is mapped into this process
+ *
+ * @param[in] peer            peer object to check
+ *
+ * Unlike ompi_osc_rdma_peer_local_base(), this only says that the memory can
+ * be reached with direct loads and stores through the peer's local_base
+ * field.  It does not imply that RMA operations on the peer are performed
+ * that way, which additionally requires that cpu atomics be usable.
+ */
+static inline bool ompi_osc_rdma_peer_shared_mem (ompi_osc_rdma_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_RDMA_PEER_SHARED_MEM);
 }
 
 /**

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -772,11 +772,20 @@ static void am_rdma_retry_operation(am_rdma_operation_t *operation)
                                      &operation->hdr, &operation);
             break;
         case MCA_BTL_BASE_AM_ATOMIC:
-            /* atomic operation was completed */
+        case MCA_BTL_BASE_AM_CAS:
+            /* the atomic operation itself was already applied to the target
+             * when the request was first processed; all that remains is to
+             * deliver the saved result back to the initiator. */
             ret = am_rdma_respond(operation->btl, operation->endpoint,
                                   &operation->descriptor, &operation->atomic_response,
                                   &operation->hdr);
             break;
+        default:
+            /* an unhandled type here would silently drop the response and
+             * hang the initiator, so fail loudly instead. */
+            BTL_ERROR(("unexpected active-message RDMA operation type %d",
+                       operation->hdr.type));
+            abort();
         }
     } else {
         ret = am_rdma_respond(operation->btl, operation->endpoint,


### PR DESCRIPTION
### Summary

Four related fixes to the shared-state path in `osc/rdma`. Together they correct
which peers may use CPU atomics on a window's state, and make the active-message
fallback usable when they may not.

### The defects

**1. `btl/base`: a queued compare-and-swap AM RDMA operation never answers.**
`am_rdma_process_atomic()` responds to an operation it applies immediately, but
when the operation is queued for lack of a descriptor the response is dropped.
The initiator then waits forever on a completion that is never sent.

**2. `osc/rdma`: the global-atomicity flag is read from the wrong field.**
`allocate_state_shared()` tests

```c
module->accelerated_btl->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB
```

`MCA_BTL_ATOMIC_SUPPORTS_GLOB` is `0x20000000`, a bit in `btl_atomic_flags`.
The highest bit assigned in `btl_flags` is `MCA_BTL_FLAGS_RDMA_REMOTE_COMPLETION`
at `0x800000`, so this test can never be true for any BTL. Every window
therefore took the non-shared state layout even on BTLs that do guarantee
CPU/BTL atomicity, which routes on-node peers' window-state atomics through the
BTL to the local leader instead of doing them in shared memory.

**3. `osc/rdma`: the shared-state optimization is disabled outright for
alternate btls.** The `else` branch hardcodes `use_cpu_atomics = false` with a
comment explaining that it was never enabled because of the bug in (2), and that
it is likely correct but untested. It is correct: for an alternate BTL the
atomics are emulated as active messages that the *target's own CPU* applies with
`opal_atomic_*()` against the same `opal_shmem` segment local peers map, so they
are CPU atomics on the same memory by construction. The AM-RMA layer already
advertises `MCA_BTL_ATOMIC_SUPPORTS_GLOB` itself.

Both cases now read the guarantee from `module->atomic_flags`, which reports it
correctly for the accelerated and the alternate BTL alike.

**4. `osc/rdma`: a peer's `base` and `base_handle` can describe different
mappings.** Allowing `MPI_WIN_SHARED_QUERY` on regular windows (815fe8e5a1) made
`peer->base` unconditionally hold *this* process's mapping of the shared
segment, so the query had an address to report. But `base` is also what
`osc_rdma_get_remote_segment()` hands to the BTL, paired with `base_handle`, the
registration made by the local leader. When CPU atomics are not in use the two
no longer describe the same mapping and an operation on a same-node peer can
read or write the wrong location.

This keeps `base` as the address the peer is reached at through the BTL and
records the process-local address in the previously unused `local_base` field,
marked by a new `OMPI_OSC_RDMA_PEER_SHARED_MEM` flag. `MPI_WIN_SHARED_QUERY`
reports `local_base`, which is what it wants either way. The distinction is
deliberately kept out of `ompi_osc_rdma_peer_local_base()`, whose callers use it
to decide whether to bypass the BTL entirely and so must keep implying that CPU
atomics are usable.