### PR TITLE
btl/tcp: do not pair a peer with an address we hold ourselves

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,17 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- Fixed ``btl/tcp`` failing to connect, or hanging, on nodes that have an
+  interface whose IP address is not unique across the job -- a container
+  bridge such as ``docker0``, which is commonly ``172.17.0.1`` on every
+  node, is the usual cause.  Such an address was preferred when pairing
+  local and remote interfaces, because being identical it appeared to be
+  the best possible match, and it is in fact unusable: a connection to it
+  never leaves the node, and a connection from it is answered to the
+  peer's own copy of the address.  Both the address and the local
+  interface that holds it are now excluded when the peer is on another
+  node.
+
 - Fixed wrong answers from one-sided (RMA) operations on a window
   allocated with ``MPI_Win_allocate`` when the target is a process on the
   same node but the operation is carried out by the underlying transport

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -172,6 +172,12 @@ struct mca_btl_tcp_module_t {
                                            sending address for this
                                            BTL */
     uint32_t tcp_ifmask;                /**< BTL interface netmask */
+    bool tcp_shared_addr;               /**< This interface's address was also
+                                             seen on another node, so it cannot
+                                             be the source of a connection to
+                                             one.  Latched the first time a peer
+                                             advertises the address; see
+                                             mca_btl_tcp_addr_local_index() */
 
     opal_mutex_t tcp_endpoints_mutex;
     opal_list_t tcp_endpoints;

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -40,6 +40,7 @@
 
 #include "opal/class/opal_hash_table.h"
 #include "opal/mca/btl/base/btl_base_error.h"
+#include "opal/mca/hwloc/hwloc-internal.h"
 #include "opal/mca/pmix/pmix-internal.h"
 #include "opal/mca/reachable/base/base.h"
 #include "opal/util/arch.h"
@@ -111,6 +112,61 @@ static inline int mca_btl_tcp_proc_is_proc_left(opal_process_name_t a, opal_proc
 #define MCA_BTL_TCP_PROC_LOCAL_VERTEX(index)  (index)
 #define MCA_BTL_TCP_PROC_REMOTE_VERTEX(index) (index + mca_btl_tcp_component.tcp_num_btls)
 
+/*
+ * Index of the local interface configured with this address, or -1 if we do
+ * not have it.
+ *
+ * An address that exists on this node is useless for reaching a process that
+ * is somewhere else, and it is useless in both directions.  It cannot be the
+ * destination: connect() to it succeeds locally and lands on whatever happens
+ * to be listening on this host, so the peer we meant to reach never sees the
+ * connection.  It cannot be the source either, because
+ * mca_btl_tcp_endpoint_start_connect() binds the local interface's address to
+ * the socket, and the peer then replies to its own copy of that address.  This
+ * is reachable whenever an interface carries an address that is not unique
+ * across the job, and a container bridge is the usual way that happens,
+ * docker0 being 172.17.0.1 on every node.
+ *
+ * The index is into mca_btl_tcp_component.local_ifs, and it is therefore also
+ * the index into tcp_btls: mca_btl_tcp_create() appends one entry to that list
+ * per module it registers, in the same iteration, so the two are one-to-one and
+ * in order.  The vertex loop below already relies on that correspondence.
+ *
+ * The comparison has to be on the address itself.  Matching by network is not
+ * enough and would match every legitimate peer, because on a cluster whose
+ * nodes share a subnet a peer's real addresses are on our network too.
+ */
+static int mca_btl_tcp_addr_local_index(const mca_btl_tcp_addr_t *addr)
+{
+    opal_if_t *local_if;
+    int index = 0;
+
+    /* Note: the address family test cannot be spelled as a "continue", because
+     * every iteration has to reach the increment below. */
+    OPAL_LIST_FOREACH (local_if, &mca_btl_tcp_component.local_ifs, opal_if_t) {
+        if (addr->addr_family == local_if->af_family) {
+            if (AF_INET == addr->addr_family) {
+                struct sockaddr_in *sin = (struct sockaddr_in *) &local_if->if_addr;
+                if (0 == memcmp(&sin->sin_addr, &addr->addr_union.addr_inet,
+                                sizeof(struct in_addr))) {
+                    return index;
+                }
+            }
+#if OPAL_ENABLE_IPV6
+            else if (AF_INET6 == addr->addr_family) {
+                struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) &local_if->if_addr;
+                if (0 == memcmp(&sin6->sin6_addr, &addr->addr_union.addr_inet6,
+                                sizeof(struct in6_addr))) {
+                    return index;
+                }
+            }
+#endif
+        }
+        index++;
+    }
+    return -1;
+}
+
 /* This function builds a graph to match local and remote interfaces
  * together. It also populates the remote proc object.
  *
@@ -120,6 +176,9 @@ static inline int mca_btl_tcp_proc_is_proc_left(opal_process_name_t a, opal_proc
  *                                interfaces to be on the left side of the graph.
  *                                If false, we set remote process interfaces to
  *                                be on the left side of the graph.
+ * @param peer_is_local (IN)      True when the remote proc runs on this node.
+ *                                Read from the caller's opal_proc_t, because
+ *                                btl_proc->proc_opal is not linked yet.
  * @param graph_out (OUT)         Constructed and populated bipartite interface
  *                                graph with vertices as interfaces and negative
  *                                reachability weights as costs for the edges.
@@ -141,7 +200,7 @@ static inline int mca_btl_tcp_proc_is_proc_left(opal_process_name_t a, opal_proc
  */
 static int mca_btl_tcp_proc_create_interface_graph(mca_btl_tcp_proc_t *btl_proc,
                                                    mca_btl_tcp_modex_addr_t *remote_addrs,
-                                                   int local_proc_is_left,
+                                                   int local_proc_is_left, bool peer_is_local,
                                                    opal_bp_graph_t **graph_out)
 {
     opal_bp_graph_t *graph = NULL;
@@ -215,6 +274,49 @@ static int mca_btl_tcp_proc_create_interface_graph(mca_btl_tcp_proc_t *btl_proc,
     if (NULL == results) {
         rc = OPAL_ERROR;
         goto err_graph;
+    }
+
+    /* An address configured on this node cannot connect us to a peer that is
+     * somewhere else, in either direction, so retire both the remote address
+     * and the local interface that holds it.  Such an address is identical to
+     * one of ours, so it trivially shares a network and carries about the
+     * highest weight available -- exactly the pair the solver prefers, and the
+     * one that cannot work.  Zeroing the weight is how this file already spells
+     * "no connection", so the edge loop below skips these pairs along with
+     * every other unreachable one.
+     *
+     * A peer that really does run on this node is exempt from both rules,
+     * because for it our addresses are the right ones.
+     *
+     * The remote rule clears a column and depends only on the remote address,
+     * so it is settled once per address rather than once per (local, remote)
+     * pair.  The local rule clears a row and is remembered on the module:
+     * being unusable as a source is a property of the interface, not of one
+     * pairing, and a peer that does not advertise the address cannot teach us
+     * anything about it. */
+    if (!peer_is_local) {
+        for (y = 0; y < results->num_remote; y++) {
+            int local_index = mca_btl_tcp_addr_local_index(&btl_proc->proc_addrs[y]);
+            if (0 > local_index) {
+                continue;
+            }
+            assert(local_index < results->num_local);
+            BTL_VERBOSE(("remote address %d is also configured on this node: neither it "
+                         "nor our interface %d that holds it can reach a peer elsewhere",
+                         y, local_index));
+            mca_btl_tcp_component.tcp_btls[local_index]->tcp_shared_addr = true;
+            for (x = 0; x < results->num_local; x++) {
+                results->weights[x][y] = 0;
+            }
+        }
+
+        for (x = 0; x < results->num_local; x++) {
+            if (mca_btl_tcp_component.tcp_btls[x]->tcp_shared_addr) {
+                for (y = 0; y < results->num_remote; y++) {
+                    results->weights[x][y] = 0;
+                }
+            }
+        }
     }
 
     /* Add vertices for each local node. These will store the btl index */
@@ -328,7 +430,7 @@ out:
 
 static int mca_btl_tcp_proc_handle_modex_addresses(mca_btl_tcp_proc_t *btl_proc,
                                                    mca_btl_tcp_modex_addr_t *remote_addrs,
-                                                   int local_proc_is_left)
+                                                   int local_proc_is_left, bool peer_is_local)
 {
     opal_bp_graph_t *graph = NULL;
     int rc = OPAL_SUCCESS;
@@ -336,7 +438,7 @@ static int mca_btl_tcp_proc_handle_modex_addresses(mca_btl_tcp_proc_t *btl_proc,
     int *matched_edges = NULL;
 
     rc = mca_btl_tcp_proc_create_interface_graph(btl_proc, remote_addrs, local_proc_is_left,
-                                                 &graph);
+                                                 peer_is_local, &graph);
     if (rc) {
         goto cleanup;
     }
@@ -428,7 +530,10 @@ mca_btl_tcp_proc_t *mca_btl_tcp_proc_create(opal_proc_t *proc)
      */
     local_proc_is_left = mca_btl_tcp_proc_is_proc_left(proc->proc_name,
                                                        opal_proc_local_get()->proc_name);
-    rc = mca_btl_tcp_proc_handle_modex_addresses(btl_proc, remote_addrs, local_proc_is_left);
+    /* Note: btl_proc->proc_opal is not linked until the cleanup block below, so
+     * the locality of the peer has to be read from the proc we were handed. */
+    rc = mca_btl_tcp_proc_handle_modex_addresses(btl_proc, remote_addrs, local_proc_is_left,
+                                                OPAL_PROC_ON_LOCAL_NODE(proc->proc_flags));
 
     if (OPAL_SUCCESS != rc) {
         goto cleanup;


### PR DESCRIPTION
### Summary

`btl/tcp` can pair an endpoint with an address that this node holds itself. Any address duplicated across nodes does it, and a container bridge is the ordinary way that happens: `docker0` is `172.17.0.1` on every node.

The pairing is not merely possible, it is preferred: local and remote interfaces are matched by a bipartite assignment over reachability weights, and two interfaces holding the *same* address trivially share a network, so that pair gets about the highest weight available and the solver picks it.

Such an address is unusable in **both** directions:

- **As the destination.** `connect()` to it succeeds locally and lands on whatever happens to be listening on this host, so the peer we meant to reach never sees the connection.
- **As the source.** `mca_btl_tcp_endpoint_start_connect()` binds the local interface's address to the socket — deliberately, so the peer can pair BTL modules — and the peer then replies to its own copy of that address, so the reply never comes back.

How the destination case fails depends on what is listening here, and the two outcomes are not equally bad:

- Nothing listening. `connect()` fails, `mca_btl_tcp_endpoint_close()` completes the pending frags with `OPAL_ERR_UNREACH` and reports the error non-fatally, so the PML re-routes to another BTL module. Recoverable, but it costs a full connect timeout and a burst of `BTL_ERROR` output per affected pair.
- An unrelated local process listening. `connect()` succeeds and the connect ACK carries an identity that does not match the endpoint. This is the case that hangs: the exchange stalls in the handshake rather than reaching `MCA_BTL_TCP_FAILED`, so no frag is ever completed and there is nothing for the upper layer to re-route.

There is no correctness risk in either case: the identity check in `mca_btl_tcp_endpoint_recv_connect_ack()` prevents the process from ever exchanging data with the wrong peer.

### The fix

`mca_btl_tcp_proc_create_interface_graph()` retires both pairings, unless the peer really does run on this node. In the reachability weight matrix, the duplicated remote address clears a **column** and the local interface that holds it clears a **row**. Zeroing a weight is how this file already spells "no connection", so the edge loop skips these pairs along with every other unreachable one and the solver never sees them.

The row rule is remembered on the module (`tcp_shared_addr`) rather than recomputed per peer: being unusable as a source is a property of the interface, not of one pairing, and a peer that does not advertise the address cannot teach us anything about it.

Note `opal_ifaddrtokindex()` is not usable for this — it matches by network, not by address, so on a cluster whose nodes share a subnet it reports a match for every peer address. The check compares addresses directly. A peer that genuinely runs on this node is exempt from both rules, because for it our addresses are the right ones; the locality is read from the `opal_proc_t` handed to `mca_btl_tcp_proc_create()` and threaded down, since `btl_proc->proc_opal` is not linked until after the modex addresses have been handled and is still NULL at that point.

If this leaves a peer with no usable pairing at all, the graph ends up with no edges and the existing "Unable to find reachable pairing" error reports it, which is a better outcome than a job that hangs.