### PR TITLE
[v5.0.x] opal/show_help: serialize the help file lexer

### DIFF
--- a/opal/util/show_help.c
+++ b/opal/util/show_help.c
@@ -32,6 +32,7 @@
 
 #include "opal/constants.h"
 #include "opal/mca/installdirs/installdirs.h"
+#include "opal/mca/threads/mutex.h"
 #include "opal/runtime/opal.h"
 #include "opal/util/argv.h"
 #include "opal/util/os_path.h"
@@ -49,6 +50,12 @@ static const char *dash_line
 static int output_stream = -1;
 static char **search_dirs = NULL;
 static bool opal_help_want_aggregate = true;
+
+/* The help file is read by a non-reentrant lexer that keeps all of its state
+   in file-scope globals (opal_show_help_yyin, the scanner buffer stack, and
+   opal_show_help_yytext).  Serialize the readers so that concurrent callers
+   cannot tear down the scanner while another one is still using it. */
+static opal_mutex_t load_array_mutex = OPAL_MUTEX_STATIC_INIT;
 
 /*
  * Local functions
@@ -379,7 +386,10 @@ static int load_array(char ***array, const char *filename, const char *topic)
 {
     int ret;
 
+    opal_mutex_lock(&load_array_mutex);
+
     if (OPAL_SUCCESS != (ret = open_file(filename, topic))) {
+        opal_mutex_unlock(&load_array_mutex);
         return ret;
     }
 
@@ -390,6 +400,8 @@ static int load_array(char ***array, const char *filename, const char *topic)
 
     fclose(opal_show_help_yyin);
     opal_show_help_yylex_destroy();
+
+    opal_mutex_unlock(&load_array_mutex);
 
     if (OPAL_SUCCESS != ret) {
         opal_argv_free(*array);


### PR DESCRIPTION
### Summary

`opal_show_help()` is not thread safe on v5.0.x. Two threads that emit help
concurrently can crash in the generated flex scanner.

The scanner keeps its state in file-scope globals — `opal_show_help_yyin`, the
buffer stack, `opal_show_help_yytext` — and `load_array()` takes no lock. One
thread's `fclose()` plus `yylex_destroy()` therefore races another thread still
inside `yylex()`, which segfaults in `opal_show_help_yylex`.

Any multi-threaded program can hit this, but it shows up most readily where a
failure path makes several threads report the same condition at once: each one
calls `opal_show_help()`, and the crash replaces the diagnostic that was about
to be printed. `mca_coll_base_comm_select()` is one such path that runs on every
communicator construction, so `MPI_Comm_dup()`/`MPI_Comm_split()` under
`MPI_THREAD_MULTIPLE` can put two threads in the lexer at once.

### The fix

A static `opal_mutex_t` serializing `load_array()`. The lexer is only used while
loading a help file, which is off any hot path, so serializing it costs nothing
measurable. Nothing inside the critical section renders help itself, so there is
no self-deadlock: the two in-section diagnostics go through `local_delivery()`,
which hands the message to PMIx.

Note the lock is taken with `opal_mutex_lock()` rather than `OPAL_THREAD_LOCK()`:
the latter is gated on `opal_using_threads()`, which is not set in a non-MPI
program, and the race is in a utility routine that any threaded caller can reach.

### Applicability — this is not a backport

There is nothing on main to cherry-pick from. `a1ac81e126` ("opal/util/show_help:
slurp help text files into C code", 2025-03-15) deleted
`opal/util/show_help_lex.{h,l}`, so main and v6.0.x have no flex scanner and no
shared scanner state to race on. That commit is in main and v6.0.x and in neither
v5.0.x nor v4.1.x, which are the two branches that still carry the lexer and the
missing lock.

Opening it here rather than on v4.1.x because v5.0.x is the newer affected
branch. **v4.1.x has the identical bug**; happy to follow up with the cherry-pick
once this lands.