### PR TITLE
docs: sync v6.0.x changelog with v6.1.x

### DIFF
--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -99,3 +99,60 @@ Open MPI version v6.0.0
   now validate their ``cat_index`` argument and return
   ``MPI_T_ERR_INVALID_INDEX`` for an out-of-range index, consistent
   with the other ``MPI_T_category_get_*`` query functions.
+
+- Nonblocking file I/O no longer loses data when the operating system's
+  asynchronous I/O queue fills, which on macOS it readily does: the
+  ``posix`` ``fbtl`` component sized its batch of concurrent ``aio_write``
+  calls from ``sysconf(_SC_AIO_MAX)``, which there reports the
+  machine-wide ``kern.aiomax`` (90 by default) rather than the
+  ``kern.aioprocmax`` a single process is held to (16).  The component
+  now bounds the batch by the per-process limit, defers requests the
+  queue will not accept instead of discarding them, and reaps the
+  operations it has posted before releasing their control blocks -- an
+  unreaped operation used to cost the process a queue slot permanently,
+  so one refusal disabled nonblocking file I/O for the rest of its life.
+  The new ``fbtl_posix_max_aio_reqs`` MCA parameter overrides the limit.
+  A nonblocking operation the ``fbtl`` cannot post is now reported as
+  ``MPI_ERR_IO``; previously ``MPI_File_iwrite_all`` and ``MPI_Wait``
+  both returned ``MPI_SUCCESS`` for a write that never reached the file.
+
+- Reporting an error for a failed nonblocking file operation no longer
+  crashes the process.  ``MPI_Wait`` and ``MPI_Test`` reach a file's
+  error handler through the request, and a nonblocking file request did
+  not record which file it came from, so invoking the error handler
+  dereferenced a null pointer.
+
+- ``MPI_Info_set`` now accepts a zero-length (empty) value string.  It
+  previously raised ``MPI_ERR_INFO_VALUE`` for an empty value, but
+  MPI-5.0 chapter 10 only limits the *maximum* length of an info
+  value, and gives the empty string a defined meaning for the
+  ``mpi_memory_alloc_kinds`` info key.  Empty *keys* remain invalid.
+
+- Partitioned communication fixes:
+
+  - ``MPI_Parrived`` now returns ``flag = true`` for a null request
+    (``MPI_REQUEST_NULL``) and for an inactive request, as required by
+    MPI-5.0 section 4.2.2.  It previously raised ``MPI_ERR_REQUEST`` for
+    a null request and returned ``flag = false`` for a partitioned
+    receive request that had never been started.
+
+  - ``MPI_Psend_init`` and ``MPI_Precv_init`` now accept
+    ``MPI_PROC_NULL`` as the peer rank, per MPI-5.0 section 3.10.  Such
+    a request completes as soon as it is started, ``MPI_Pready`` on it
+    has no effect, and ``MPI_Parrived`` reports every partition as
+    arrived.  Previously, ``MPI_PROC_NULL`` was passed down as if it
+    were a real peer rank, reading outside the communicator's process
+    array.
+
+  - Freeing a partitioned communication request that was never started
+    no longer leaves its internal setup receive posted.  Such a stale
+    receive could consume the setup message of the next partitioned
+    operation using the same communicator, peer, and tag, which then
+    never completed.
+
+- Implemented ``MPI_Get_hw_resource_info()`` using hwloc. The returned
+  info object now reports whether the calling process is restricted to
+  individual NUMA nodes, packages, caches, cores, and processing units.
+  The reported ``hwloc://`` resource keys can also be used with
+  ``MPI_Comm_split_type()`` for hardware- and resource-guided communicator
+  creation. Thanks to Musawer Ahmad Saqif for the contribution.


### PR DESCRIPTION
Sync some updates to v6.1.x that were cherry-picked back to v6.0.x but were not included in the changelog.