### PR TITLE
accelerator/cuda: return early for host pointers in check_addr

### DIFF
--- a/opal/mca/accelerator/cuda/accelerator_cuda.c
+++ b/opal/mca/accelerator/cuda/accelerator_cuda.c
@@ -359,6 +359,15 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         return 1;
     }
 
+    /* cuPointerGetAttributes succeeds with mem_type left at 0 for a pointer
+     * CUDA recognizes but cannot classify, which is what a plain host
+     * allocation looks like once CUDA has been initialized.  Neither the VMM
+     * nor the mempool probe below can reclassify such a pointer, so return
+     * before paying for them. */
+    if (0 == mem_type) {
+        return 0;
+    }
+
     is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
     is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
 
@@ -373,9 +382,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
             /* Host memory, nothing to do here */
             return 0;
         }
-    } else if (0 == mem_type) {
-        /* This can happen when CUDA is initialized but dbuf is not valid CUDA pointer */
-        return 0;
     } else {
         if (is_vmm) {
             *dev_id = vmm_dev_id;
@@ -387,9 +393,6 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         }
     }
 #else /* OPAL_CUDA_GET_ATTRIBUTES */
-    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
-    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
-
     result = cuPointerGetAttribute(&mem_type, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, dbuf);
     if (CUDA_SUCCESS != result) {
         /* If cuda is not initialized, assume it is a host buffer. */
@@ -398,7 +401,12 @@ static int accelerator_cuda_check_addr(const void *addr, int *dev_id, uint64_t *
         } else {
             return OPAL_ERROR;
         }
-    } else if (CU_MEMORYTYPE_HOST == mem_type) {
+    }
+
+    is_vmm = accelerator_cuda_check_vmm(dbuf, &vmm_mem_type, &vmm_dev_id);
+    is_mpool_ptr = accelerator_cuda_check_mpool(dbuf, &mpool_mem_type, &mpool_dev_id);
+
+    if (CU_MEMORYTYPE_HOST == mem_type) {
         if (is_vmm && (vmm_mem_type == CU_MEMORYTYPE_DEVICE)) {
             mem_type = CU_MEMORYTYPE_DEVICE;
             *dev_id = vmm_dev_id;


### PR DESCRIPTION
accelerator_cuda_check_addr() calls accelerator_cuda_check_vmm() and accelerator_cuda_check_mpool() before it examines the memory type that cuPointerGetAttributes() reported. Each of those helpers makes a driver call cuMemRetainAllocationHandle() and cuPointerGetAttribute(CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE), so a plain host allocation pays both on every call, and the cm/ofi path calls this twice per message.

cuPointerGetAttributes() returns success with mem_type left at 0 for a pointer CUDA recognizes but cannot classify, which is what a malloc'd buffer looks like once CUDA has been initialized. Neither probe can reclassify such a pointer, so the existing "else if (0 == mem_type)" branch was only ever reached after both driver calls had already run. Hoist that test above the probes.

Restructure the !OPAL_CUDA_GET_ATTRIBUTES path the same way. There cuPointerGetAttribute(CU_POINTER_ATTRIBUTE_MEMORY_TYPE) fails outright for a pointer CUDA does not recognize, so host buffers already returned early, but the probes ran ahead of the query and were paid regardless.

Device pointers are unaffected. They return at the fast path added in open-mpi/ompi#13773, above the code this commit touches.

v5.0.x already carries an equivalent change; see open-mpi/ompi#14227.