### PR TITLE
docs: add a blurb about MPI-5 ABI to the changelog

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -79,3 +79,9 @@ Open MPI version v6.1.0
   run-time MCA parameters), and a manifest, all indexed from
   ``llms.txt``. See the "LLM-friendly documentation artifacts" page in
   the developer documentation.
+
+- Added support for the MPI-5.0 standard ABI (Application Binary Interface)
+  as defined in Chapter 20 of the MPI-5.0 specification. This includes the
+  creation of a new ``libmpi_abi.so`` library and the ``mpicc_abi`` wrapper
+  compiler for building C applications against the MPI-5 ABI. Note that
+  Fortran ABI support is not yet included.


### PR DESCRIPTION
This was missed in PR #13280