### PR TITLE
[v6.0.x] osc/rdma: correct shared-state atomics for local peers and alternate btls (backport of #14370)

### DIFF
--- a/docs/release-notes/changelog/v6.0.x.rst
+++ b/docs/release-notes/changelog/v6.0.x.rst
@@ -8,6 +8,26 @@ Open MPI version v6.0.0
 --------------------------
 :Date: ...fill me in...
 
+- Fixed wrong answers from one-sided (RMA) operations on a window
+  allocated with ``MPI_Win_allocate`` when the target is a process on the
+  same node but the operation is carried out by the underlying transport
+  rather than with CPU atomics.  In that case ``osc/rdma`` described the
+  target's memory with an address taken from the calling process's own
+  mapping of the shared segment, while pairing it with the memory
+  registration of a different process, so the transport could read or
+  write the wrong location.  ``MPI_Win_shared_query`` on such a window
+  continues to report an address that is valid in the calling process.
+
+- One-sided (RMA) windows on networks without hardware atomics --
+  ``btl/tcp``, for example -- are dramatically faster when more than one
+  MPI process shares a node.  The ``osc/rdma`` component now applies its
+  shared state optimization whenever the underlying transport guarantees
+  that CPU atomics and transport atomics are atomic with respect to each
+  other, which includes the emulated atomics used on such networks.
+  Previously the optimization was disabled for these transports, so
+  every window-state atomic issued by a process was routed to another
+  process on the same node and executed as a network round trip.
+
 - Added support for the MPI-4.0 embiggened APIs (i.e., functions with
   ``MPI_Count`` parameters).
 

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,26 +8,6 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
-- Fixed wrong answers from one-sided (RMA) operations on a window
-  allocated with ``MPI_Win_allocate`` when the target is a process on the
-  same node but the operation is carried out by the underlying transport
-  rather than with CPU atomics.  In that case ``osc/rdma`` described the
-  target's memory with an address taken from the calling process's own
-  mapping of the shared segment, while pairing it with the memory
-  registration of a different process, so the transport could read or
-  write the wrong location.  ``MPI_Win_shared_query`` on such a window
-  continues to report an address that is valid in the calling process.
-
-- One-sided (RMA) windows on networks without hardware atomics --
-  ``btl/tcp``, for example -- are dramatically faster when more than one
-  MPI process shares a node.  The ``osc/rdma`` component now applies its
-  shared state optimization whenever the underlying transport guarantees
-  that CPU atomics and transport atomics are atomic with respect to each
-  other, which includes the emulated atomics used on such networks.
-  Previously the optimization was disabled for these transports, so
-  every window-state atomic issued by a process was routed to another
-  process on the same node and executed as a network round trip.
-
 - Nonblocking file I/O no longer loses data when the operating system's
   asynchronous I/O queue fills, which on macOS it readily does: the
   ``posix`` ``fbtl`` component sized its batch of concurrent ``aio_write``

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,16 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- Fixed wrong answers from one-sided (RMA) operations on a window
+  allocated with ``MPI_Win_allocate`` when the target is a process on the
+  same node but the operation is carried out by the underlying transport
+  rather than with CPU atomics.  In that case ``osc/rdma`` described the
+  target's memory with an address taken from the calling process's own
+  mapping of the shared segment, while pairing it with the memory
+  registration of a different process, so the transport could read or
+  write the wrong location.  ``MPI_Win_shared_query`` on such a window
+  continues to report an address that is valid in the calling process.
+
 - One-sided (RMA) windows on networks without hardware atomics --
   ``btl/tcp``, for example -- are dramatically faster when more than one
   MPI process shares a node.  The ``osc/rdma`` component now applies its

--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -8,6 +8,16 @@ Open MPI version v6.1.0
 --------------------------
 :Date: ...fill me in...
 
+- One-sided (RMA) windows on networks without hardware atomics --
+  ``btl/tcp``, for example -- are dramatically faster when more than one
+  MPI process shares a node.  The ``osc/rdma`` component now applies its
+  shared state optimization whenever the underlying transport guarantees
+  that CPU atomics and transport atomics are atomic with respect to each
+  other, which includes the emulated atomics used on such networks.
+  Previously the optimization was disabled for these transports, so
+  every window-state atomic issued by a process was routed to another
+  process on the same node and executed as a network round trip.
+
 - Nonblocking file I/O no longer loses data when the operating system's
   asynchronous I/O queue fills, which on macOS it readily does: the
   ``posix`` ``fbtl`` component sized its batch of concurrent ``aio_write``

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -610,18 +610,16 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
 
     if (module->single_node) {
         use_cpu_atomics = true;
-    } else if (module->use_accelerated_btl) {
-        use_cpu_atomics = !!(module->accelerated_btl->btl_atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     } else {
-        /* using the shared state optimization that is enabled by
-         * being able to use cpu atomics was never enabled for
-         * alternate btls, due to a previous bug in the enablement
-         * logic when alternate btls were first supported.  It is
-         * likely that this optimization could work with sufficient
-         * testing, but for now, always disable to not introduce new
-         * correctness risks.
-         */
-        use_cpu_atomics = false;
+        /* the shared state optimization requires that atomics issued through
+         * the btl be atomic with respect to atomics issued by the cpu, since
+         * a peer on this node will update the state directly while a peer on
+         * another node reaches it through the btl.  module->atomic_flags
+         * reports that guarantee for both the accelerated and the alternate
+         * btl case: for alternate btls the atomics are emulated as active
+         * messages that the target's cpu applies with opal_atomic_*(), so
+         * they are cpu atomics on the same memory by construction. */
+        use_cpu_atomics = !!(module->atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     }
 
     if (1 == local_size) {

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -549,6 +549,8 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) my_peer;
 
         ex_peer->super.base = (intptr_t) *base;
+        ex_peer->super.local_base = (intptr_t) *base;
+        my_peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
 
         if (!module->same_size) {
             ex_peer->size = size;
@@ -854,23 +856,30 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
                 ex_peer->size = temp[i].size;
             }
 
-            if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor || peer_rank == my_rank) {
-                /* base is local and cpu atomics are available */
-                if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
-                    ex_peer->super.base = (uintptr_t) module->segment_base + offset;
-                } else {
-                    ex_peer->super.base = (uintptr_t) *base;
-                }
-
-                peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
-                if (use_cpu_atomics) {
-                    peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
-                } else if (module->use_memory_registration) {
-                    ex_peer->super.base_handle = (mca_btl_base_registration_handle_t *) peer_region->btl_handle_data;
-                }
+            /* the memory of a peer on this node lives in the shared segment, so
+             * we can always compute an address for it that is valid in this
+             * process, whether or not we can use cpu atomics on that peer */
+            if (MPI_WIN_FLAVOR_ALLOCATE == module->flavor) {
+                ex_peer->super.local_base = (osc_rdma_base_t) ((uintptr_t) module->segment_base + offset);
+                peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
                 offset += temp[i].size;
                 offset += OPAL_ALIGN_PAD_AMOUNT(offset, memory_alignment);
+            } else if (peer_rank == my_rank) {
+                ex_peer->super.local_base = (osc_rdma_base_t) (uintptr_t) *base;
+                peer->flags |= OMPI_OSC_RDMA_PEER_SHARED_MEM;
+            }
+
+            if (use_cpu_atomics && (MPI_WIN_FLAVOR_ALLOCATE == module->flavor || peer_rank == my_rank)) {
+                /* base is local and cpu atomics are available */
+                ex_peer->super.base = ex_peer->super.local_base;
+
+                peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
+                peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
             } else {
+                /* the peer will be reached through the btl, so base and
+                 * base_handle have to describe the same mapping.  even for a
+                 * peer on this node we must use the address the registration
+                 * was made with rather than our own mapping of the segment. */
                 ex_peer->super.base = peer_region->base;
 
                 if (module->use_memory_registration) {
@@ -1662,7 +1671,7 @@ int ompi_osc_rdma_shared_query(
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
-    if (!ompi_osc_rdma_peer_local_base(peer)) {
+    if (!ompi_osc_rdma_peer_shared_mem(peer)) {
         return OMPI_ERR_NOT_SUPPORTED;
     }
 
@@ -1671,9 +1680,9 @@ int ompi_osc_rdma_shared_query(
         for (int i = 0 ; i < ompi_comm_size(module->comm) ; ++i) {
             peer = ompi_osc_module_get_peer (module, i);
             ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
-            if (!ompi_osc_rdma_peer_local_base(peer)) {
+            if (!ompi_osc_rdma_peer_shared_mem(peer)) {
                 continue;
-            } else if (module->same_size && ex_peer->super.base) {
+            } else if (module->same_size && ex_peer->super.local_base) {
                 break;
             } else if (ex_peer->size > 0) {
                 break;
@@ -1681,17 +1690,20 @@ int ompi_osc_rdma_shared_query(
         }
     }
 
+    /* report local_base rather than base: base is the address the peer is
+     * reached at through the btl, which is only also a valid address in this
+     * process when cpu atomics are in use */
     if (module->same_size && module->same_disp_unit) {
         *size = module->size;
         *disp_unit = module->disp_unit;
         ompi_osc_rdma_peer_basic_t *ex_peer = (ompi_osc_rdma_peer_basic_t *) peer;
-        *((void**) baseptr) = (void *) (intptr_t)ex_peer->base;
+        *((void**) baseptr) = (void *) (intptr_t)ex_peer->local_base;
         rc = OMPI_SUCCESS;
     } else {
         ompi_osc_rdma_peer_extended_t *ex_peer = (ompi_osc_rdma_peer_extended_t *) peer;
-        if (ex_peer->super.base != 0) {
+        if (ex_peer->super.local_base != 0) {
             /* we know the base of the peer */
-            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.base;
+            *((void**) baseptr) = (void *) (intptr_t)ex_peer->super.local_base;
             *size = ex_peer->size;
             *disp_unit = ex_peer->disp_unit;
             rc = OMPI_SUCCESS;

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -611,7 +611,7 @@ static int allocate_state_shared (ompi_osc_rdma_module_t *module, void **base, s
     if (module->single_node) {
         use_cpu_atomics = true;
     } else if (module->use_accelerated_btl) {
-        use_cpu_atomics = !!(module->accelerated_btl->btl_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
+        use_cpu_atomics = !!(module->accelerated_btl->btl_atomic_flags & MCA_BTL_ATOMIC_SUPPORTS_GLOB);
     } else {
         /* using the shared state optimization that is enabled by
          * being able to use cpu atomics was never enabled for

--- a/ompi/mca/osc/rdma/osc_rdma_peer.h
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.h
@@ -146,6 +146,8 @@ enum {
     OMPI_OSC_RDMA_PEER_DEMAND_LOCKED        = 0x80,
     /** we can use CPU atomics on that peer */
     OMPI_OSC_RDMA_PEER_CPU_ATOMICS          = 0x100,
+    /** peer's window memory is directly accessible through local_base */
+    OMPI_OSC_RDMA_PEER_SHARED_MEM           = 0x200,
 };
 
 /**
@@ -231,6 +233,21 @@ static inline bool ompi_osc_rdma_peer_local_base (ompi_osc_rdma_peer_t *peer)
 static inline bool ompi_osc_rdma_peer_cpu_atomics (ompi_osc_rdma_peer_t *peer)
 {
     return ompi_osc_rdma_peer_local_base(peer) && !!(peer->flags & OMPI_OSC_RDMA_PEER_CPU_ATOMICS);
+}
+
+/**
+ * @brief check if the peer's window memory is mapped into this process
+ *
+ * @param[in] peer            peer object to check
+ *
+ * Unlike ompi_osc_rdma_peer_local_base(), this only says that the memory can
+ * be reached with direct loads and stores through the peer's local_base
+ * field.  It does not imply that RMA operations on the peer are performed
+ * that way, which additionally requires that cpu atomics be usable.
+ */
+static inline bool ompi_osc_rdma_peer_shared_mem (ompi_osc_rdma_peer_t *peer)
+{
+    return !!(peer->flags & OMPI_OSC_RDMA_PEER_SHARED_MEM);
 }
 
 /**

--- a/opal/mca/btl/base/btl_base_am_rdma.c
+++ b/opal/mca/btl/base/btl_base_am_rdma.c
@@ -773,11 +773,20 @@ static void am_rdma_retry_operation(am_rdma_operation_t *operation)
                                      &operation->hdr, &operation);
             break;
         case MCA_BTL_BASE_AM_ATOMIC:
-            /* atomic operation was completed */
+        case MCA_BTL_BASE_AM_CAS:
+            /* the atomic operation itself was already applied to the target
+             * when the request was first processed; all that remains is to
+             * deliver the saved result back to the initiator. */
             ret = am_rdma_respond(operation->btl, operation->endpoint,
                                   &operation->descriptor, &operation->atomic_response,
                                   &operation->hdr);
             break;
+        default:
+            /* an unhandled type here would silently drop the response and
+             * hang the initiator, so fail loudly instead. */
+            BTL_ERROR(("unexpected active-message RDMA operation type %d",
+                       operation->hdr.type));
+            abort();
         }
     } else {
         ret = am_rdma_respond(operation->btl, operation->endpoint,


### PR DESCRIPTION
### Summary

Backport of #14370 to v6.0.x: four fixes to the `osc/rdma` shared-state path,
cherry-picked with `-x` from main, plus one commit correcting the changelog file.

| commit on main | subject |
|---|---|
| `04528de286` | `btl/base`: respond to queued compare-and-swap AM RDMA operations |
| `69d3d38638` | `osc/rdma`: test the atomic flags field for global atomicity |
| `f72938c3df` | `osc/rdma`: enable the shared state optimization for alternate btls |
| `282ffacd72` | `osc/rdma`: keep a peer's `base` and `base_handle` describing one mapping |

v6.0.x needs all four. It carries `815fe8e5a1`, which is what makes a peer's
`base` and `base_handle` describe different mappings, and it has the AM RDMA
layer that the enablement newly makes reachable.

### One hunk was adapted rather than applied verbatim

`ompi_osc_rdma_shared_query()` differs structurally between main and v6.0.x: main
has since been restructured to look the peer up inside the `MPI_PROC_NULL` branch,
NULL-guard it in the loop, reset it to `NULL` when a candidate has no memory, and
do one combined check afterwards. v6.0.x still looks the peer up once at the top
and guards there.

Rather than import that unrelated restructure, the backport keeps v6.0.x's shape
and applies only what `282ffacd72` changes semantically:

- the guard becomes `!ompi_osc_rdma_peer_shared_mem(peer)`, and
- the `MPI_PROC_NULL` scan and both report sites read `local_base` instead of
  `base`.

Everything else in the four commits applied clean.

### Changelog

The two cherry-picks that carry release notes wrote them to `v6.1.x.rst`, which
is correct on main. On this branch the fixes ship in a v6.0.x release, so a final
commit moves both entries to `v6.0.x.rst` and leaves `v6.1.x.rst` untouched. No
functional change.