### PR TITLE
ompi/rte: Increase job name printing buffer size

### DIFF
--- a/ompi/runtime/ompi_rte.c
+++ b/ompi/runtime/ompi_rte.c
@@ -83,12 +83,16 @@ static int _setup_proc_session_dir(char **sdir);
 #define OPAL_SCHEMA_INVALID_CHAR        '$'
 #define OPAL_SCHEMA_INVALID_STRING      "$"
 
-#define OPAL_PRINT_NAME_ARGS_MAX_SIZE   50
+/* Must hold the longest string any of the print functions below can
+ * produce, including the terminating NUL: a "<nspace>.<rank>" identity
+ * string, where nspace is a full pmix_nspace_t (PMIX_MAX_NSLEN bytes)
+ * and rank is a pmix_rank_t (uint32_t, up to 10 decimal digits). */
+#define OPAL_PRINT_NAME_ARGS_MAX_SIZE   (PMIX_MAX_NSLEN + 12)
 #define OPAL_PRINT_NAME_ARG_NUM_BUFS    16
 
 static char* opal_print_args_null = "NULL";
 typedef struct {
-    char buffers[OPAL_PRINT_NAME_ARG_NUM_BUFS][OPAL_PRINT_NAME_ARGS_MAX_SIZE + 1];
+    char buffers[OPAL_PRINT_NAME_ARG_NUM_BUFS][OPAL_PRINT_NAME_ARGS_MAX_SIZE];
     int cntr;
 } opal_print_args_buffers_t;
 


### PR DESCRIPTION
`ompi_pmix_print_id` may try to print a string longer than 50 bytes onto the print name buffer:
https://github.com/open-mpi/ompi/blob/c570a54871873002de68afd7048ae35e3b67ab51/ompi/runtime/ompi_rte.c#L246-L248

`nspace` defaults to `singleton.{hostname}.{pid}` (`hostname` alone can be as long as 64 bytes.) on singleton process, and can be as long as `PMIX_MAX_NSLEN`. A truncated id causes mismatch and resulted in `MPI_Comm_spawn` returning `MPI_ERR_UNKNOWN`.

This PR bumps the buffer size to be enough to hold any ID.

Also fix a size calculation issue:

> The functions snprintf() and vsnprintf() write at most size bytes
> (**including** the terminating null byte ('\0')) to str.

so `OPAL_PRINT_NAME_ARGS_MAX_SIZE + 1` is not needed.