### PR TITLE
btl/tcp: do not read a discarded duplicate connection as a dead peer

### DIFF
--- a/opal/mca/btl/tcp/btl_tcp.c
+++ b/opal/mca/btl/tcp/btl_tcp.c
@@ -583,6 +583,10 @@ int mca_btl_tcp_recv_blocking(int sd, void *data, size_t size)
  * A blocking send on a non-blocking socket. Used to send the small
  * amount of connection information used during the initial handshake
  * (magic string plus process guid)
+ *
+ * An error return leaves the endpoint untouched: whoever decides it failed
+ * owns the state change and the close. Otherwise every byte is written
+ * before returning, so the count is never short.
  */
 
 int mca_btl_tcp_send_blocking(int sd, const void *data, size_t size)

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2020      Google, LLC. All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -406,23 +407,6 @@ int mca_btl_tcp_endpoint_send(mca_btl_base_endpoint_t *btl_endpoint, mca_btl_tcp
 }
 
 /*
- * A blocking send on a non-blocking socket. Used to send the small
- * amount of connection information that identifies the endpoints endpoint.
- */
-static int mca_btl_tcp_endpoint_send_blocking(mca_btl_base_endpoint_t *btl_endpoint,
-                                              const void *data, size_t size)
-{
-    int ret = mca_btl_tcp_send_blocking(btl_endpoint->endpoint_sd, data, size);
-    if (ret < 0) {
-        /* send-lock not needed because never called when the socket is in the
-         * event set. */
-        btl_endpoint->endpoint_state = MCA_BTL_TCP_FAILED;
-        mca_btl_tcp_endpoint_close(btl_endpoint);
-    }
-    return ret;
-}
-
-/*
  * Send the globally unique identifier for this process to a endpoint on
  * a newly connected socket.
  */
@@ -436,7 +420,7 @@ static int mca_btl_tcp_endpoint_send_connect_ack(mca_btl_base_endpoint_t *btl_en
     hs_msg.guid = guid;
 
     if (sizeof(hs_msg)
-        != mca_btl_tcp_endpoint_send_blocking(btl_endpoint, &hs_msg, sizeof(hs_msg))) {
+        != mca_btl_tcp_send_blocking(btl_endpoint->endpoint_sd, &hs_msg, sizeof(hs_msg))) {
         opal_show_help("help-mpi-btl-tcp.txt", "client handshake fail", true,
                        opal_process_info.nodename, sizeof(hs_msg),
                        "connect ACK failed to send magic-id and guid");
@@ -568,7 +552,7 @@ void mca_btl_tcp_endpoint_close(mca_btl_base_endpoint_t *btl_endpoint)
             .count = 0,
             .size = 0,
         };
-        mca_btl_tcp_endpoint_send_blocking(btl_endpoint, &fin_msg, sizeof(fin_msg));
+        mca_btl_tcp_send_blocking(btl_endpoint->endpoint_sd, &fin_msg, sizeof(fin_msg));
     }
 
     CLOSE_THE_SOCKET(btl_endpoint->endpoint_sd);

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -429,6 +429,51 @@ static int mca_btl_tcp_endpoint_send_connect_ack(mca_btl_base_endpoint_t *btl_en
     return OPAL_SUCCESS;
 }
 
+/*
+ * Tell the peer that this socket is going away on purpose, so that its
+ * end of it reads as a clean close rather than as a process that died.
+ * Best effort: a failed write means the peer has already gone, which is
+ * what the message would have told it.
+ */
+static void mca_btl_tcp_endpoint_send_fin(mca_btl_base_endpoint_t *btl_endpoint)
+{
+    mca_btl_tcp_hdr_t fin_msg = {
+        .base.tag = 0,
+        .type = MCA_BTL_TCP_HDR_TYPE_FIN,
+        .count = 0,
+        .size = 0,
+    };
+
+    (void) mca_btl_tcp_send_blocking(btl_endpoint->endpoint_sd, &fin_msg, sizeof(fin_msg));
+}
+
+/*
+ * Has the peer already abandoned this incoming connection?
+ *
+ * Between the handshake the component consumed and the ack we are about
+ * to write, a dialer says nothing: mca_btl_tcp_endpoint_send() queues
+ * fragments until MCA_BTL_TCP_CONNECTED, which is what our ack brings
+ * about. So anything readable here is the peer letting go of this socket
+ * -- its goodbye, or the bare eof of one it dropped during a
+ * simultaneous-connect duel before we taught it to say so, or a reset.
+ * Adopting one of those yields a connection that dies without ever
+ * carrying anything, which every path below reads as a failed peer.
+ */
+static bool mca_btl_tcp_endpoint_abandoned(int sd)
+{
+    char byte;
+    ssize_t rc;
+
+    do {
+        rc = recv(sd, &byte, 1, MSG_PEEK);
+    } while ((rc < 0) && (EINTR == opal_socket_errno));
+
+    if (0 <= rc) {
+        return true;
+    }
+    return (EWOULDBLOCK != opal_socket_errno) && (EAGAIN != opal_socket_errno);
+}
+
 static void *mca_btl_tcp_endpoint_complete_accept(int fd, int flags, void *context)
 {
     mca_btl_base_endpoint_t *btl_endpoint = (mca_btl_base_endpoint_t *) context;
@@ -464,6 +509,30 @@ static void *mca_btl_tcp_endpoint_complete_accept(int fd, int flags, void *conte
                                opal_proc_local_get()->proc_name);
     if ((btl_endpoint->endpoint_sd < 0)
         || (btl_endpoint->endpoint_state != MCA_BTL_TCP_CONNECTED && cmpval < 0)) {
+        if (mca_btl_tcp_endpoint_abandoned(btl_endpoint->endpoint_sd_next)) {
+            MCA_BTL_TCP_ENDPOINT_DUMP(10, btl_endpoint, true,
+                                      "discarded, peer let go [endpoint_accept]");
+            CLOSE_THE_SOCKET(btl_endpoint->endpoint_sd_next);
+            btl_endpoint->endpoint_sd_next = -1;
+            /* Discarded rather than adopted, so we may now have nothing at
+             * all. The peer is not coming back for one -- it just let go --
+             * so go back to CLOSED, and dial if we have something waiting,
+             * which is the work adopting would have restarted. */
+            if (btl_endpoint->endpoint_sd < 0) {
+                btl_endpoint->endpoint_state = MCA_BTL_TCP_CLOSED;
+                if (!opal_list_is_empty(&btl_endpoint->endpoint_frags)) {
+                    (void) mca_btl_tcp_endpoint_start_connect(btl_endpoint);
+                }
+            }
+            goto unlock_and_return;
+        }
+        if (MCA_BTL_TCP_CONNECT_ACK == btl_endpoint->endpoint_state) {
+            /* Our own dial, dropped here in the peer's favour. Our handshake
+             * is on it, so the peer may be holding it as a queued duplicate
+             * and may still adopt it; silence would read there as a process
+             * that died. */
+            mca_btl_tcp_endpoint_send_fin(btl_endpoint);
+        }
         mca_btl_tcp_endpoint_close(btl_endpoint);
         btl_endpoint->endpoint_sd = btl_endpoint->endpoint_sd_next;
         btl_endpoint->endpoint_sd_next = -1;
@@ -546,13 +615,7 @@ void mca_btl_tcp_endpoint_close(mca_btl_base_endpoint_t *btl_endpoint)
     /* send a message before closing to differentiate between failures and
      * clean disconnect during finalize */
     if (MCA_BTL_TCP_CONNECTED == btl_endpoint->endpoint_state) {
-        mca_btl_tcp_hdr_t fin_msg = {
-            .base.tag = 0,
-            .type = MCA_BTL_TCP_HDR_TYPE_FIN,
-            .count = 0,
-            .size = 0,
-        };
-        mca_btl_tcp_send_blocking(btl_endpoint->endpoint_sd, &fin_msg, sizeof(fin_msg));
+        mca_btl_tcp_endpoint_send_fin(btl_endpoint);
     }
 
     CLOSE_THE_SOCKET(btl_endpoint->endpoint_sd);

--- a/opal/mca/btl/tcp/btl_tcp_frag.c
+++ b/opal/mca/btl/tcp/btl_tcp_frag.c
@@ -16,6 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2020      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -283,8 +284,26 @@ advance_iov_position:
         }
         switch (frag->hdr.type) {
         case MCA_BTL_TCP_HDR_TYPE_FIN:
-            frag->endpoint->endpoint_state = MCA_BTL_TCP_CLOSED;
-            mca_btl_tcp_endpoint_close(frag->endpoint);
+            /* The peer let go of this socket: it is being destructed, or it
+             * dropped a duplicate dial we had already adopted. Our queue
+             * survives the close either way, with nothing to re-drive it
+             * before the next send to this peer. While CONNECTED its head
+             * is endpoint_send_frag, so that alone says whether one is
+             * outstanding.
+             *
+             * Hold the send lock across that read, the state change and the
+             * close, as the eof and error paths above do. A close entered as
+             * MCA_BTL_TCP_FAILED walks the send queue and completes it, and
+             * only the lock keeps another thread from putting us there
+             * between the two statements below. */
+            OPAL_THREAD_LOCK(&btl_endpoint->endpoint_send_lock);
+            if (NULL != btl_endpoint->endpoint_send_frag) {
+                BTL_VERBOSE(("peer %s said goodbye with sends of ours still queued for it",
+                             OPAL_NAME_PRINT(btl_endpoint->endpoint_proc->proc_opal->proc_name)));
+            }
+            btl_endpoint->endpoint_state = MCA_BTL_TCP_CLOSED;
+            mca_btl_tcp_endpoint_close(btl_endpoint);
+            OPAL_THREAD_UNLOCK(&btl_endpoint->endpoint_send_lock);
             break;
         case MCA_BTL_TCP_HDR_TYPE_SEND:
             if (frag->iov_idx == 1 && frag->hdr.size) {


### PR DESCRIPTION
A job that repeatedly spawns and disconnects aborts with

```
*** An error occurred in Socket closed
*** reported by process [XXXXXXXXXX,0]
*** on a NULL communicator
*** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort, ...)
```

while every process involved is healthy. It reproduces 100%, and it is what stops the mpi4py spawn tests.

### What happens

Two peers may dial each other at the same time, leaving two connections where one is wanted. The tie-break in `mca_btl_tcp_endpoint_complete_accept()` is name-based, so the two sides derive opposite verdicts and exactly one adopts -- that part works. The problem is the side that drops its own dial does so in `MCA_BTL_TCP_CONNECT_ACK`, where the protocol says nothing at all. Its peer is left holding an accepted-but-unexamined socket that is already a corpse, with no way to know.

Normally that socket is rejected, because the endpoint still has the surviving connection and the first term of

```c
    if ((btl_endpoint->endpoint_sd < 0)
        || (btl_endpoint->endpoint_state != MCA_BTL_TCP_CONNECTED && cmpval < 0)) {
```

is false. But after a disconnect the surviving socket is closed, and the duplicate is examined with `endpoint_sd < 0`. It is then adopted, because that term also covers the legitimate case of a peer dialing an endpoint that has no connection. The corpse's EOF arrives on a `CONNECTED` endpoint, which is by definition a peer failure, and `mca_btl_tcp_endpoint_close()` turns it into a fatal upcall. In a job that never disconnects, `sd < 0` never coincides with a queued duplicate, which is why only spawn/disconnect exposes this.

### The fix

**Announce the discard.** A healthy peer already says goodbye with an `MCA_BTL_TCP_HDR_TYPE_FIN` while `CONNECTED`; the one site that deliberately abandons a socket the peer may still be holding now does so too.

**Don't adopt an abandoned socket.** The announcement alone is not enough -- the ack we write into a closed socket can draw an RST that discards the goodbye, more readily on Linux than on macOS. So `complete_accept()` asks the socket itself, with one `MSG_PEEK` before adopting. That works because of an invariant on the dialer: between the handshake the component consumed and the ack we are about to write, it says nothing, since `mca_btl_tcp_endpoint_send()` queues fragments until `MCA_BTL_TCP_CONNECTED`. Anything readable there is the peer letting go. Such sockets are discarded rather than adopted, and if that leaves no connection the endpoint returns to `MCA_BTL_TCP_CLOSED` and re-dials if anything is queued.

No new endpoint state, no proxy for "did this ever work", and the `MCA_BTL_TCP_FAILED` verdict for an unannounced death is unchanged, idle peer or not.

### What this deliberately does not do

Reclaiming a disconnected peer's `ompi_proc_t` and endpoints, which would also have prevented the abort, is ruled out on its own merits: a batching BTL makes a binding between two *other* peers relevant to our decision, so the releasable sets differ across processes even though no pair disagrees, and reconciling them needs consensus over a membership that no longer shares a communicator. That reasoning, and the resulting rule about a partial `del_procs` set, are documented in #14377. The endpoint leak therefore stands, bounded by distinct peers ever contacted rather than by disconnect count.
