### PR TITLE
osc/rdma: do not claim cpu atomics for a lone local peer

### DIFF
--- a/docs/release-notes/changelog/v6.1.x.rst
+++ b/docs/release-notes/changelog/v6.1.x.rst
@@ -19,6 +19,13 @@ Open MPI version v6.1.0
   interface that holds it are now excluded when the peer is on another
   node.
 
+- Fixed wrong answers from one-sided (RMA) accumulate operations on a
+  window with one MPI process per node, when the network does not
+  guarantee that its atomics and CPU atomics are atomic with respect to
+  each other.  A process performed atomics on its own window memory
+  directly while other processes reached the same memory with network
+  atomics, which is the mixing that guarantee exists to prevent.
+
 - Fixed wrong answers from one-sided (RMA) operations on a window
   allocated with ``MPI_Win_allocate`` when the target is a process on the
   same node but the operation is carried out by the underlying transport

--- a/ompi/mca/osc/rdma/osc_rdma_component.c
+++ b/ompi/mca/osc/rdma/osc_rdma_component.c
@@ -532,7 +532,9 @@ static int allocate_state_single (ompi_osc_rdma_module_t *module, void **base, s
     module->my_peer = my_peer;
     module->free_after = module->rank_array;
     my_peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
-    my_peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
+    if (use_cpu_atomics) {
+        my_peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
+    }
     my_peer->state = (uint64_t) (uintptr_t) module->state;
 
     if (use_cpu_atomics) {

--- a/ompi/mca/osc/rdma/osc_rdma_peer.c
+++ b/ompi/mca/osc/rdma/osc_rdma_peer.c
@@ -255,7 +255,10 @@ static int ompi_osc_rdma_peer_setup (ompi_osc_rdma_module_t *module, ompi_osc_rd
     (void)disp_unit;  // silence compiler warning
 
     if (ompi_osc_rdma_peer_local_base (peer)) {
-        /* for now we store the local address in the standard place. do no overwrite it */
+        /* this peer's memory is reachable with plain loads and stores, and base
+         * already holds an address valid in this process, so leave it alone.
+         * Note that base is otherwise the address the peer is reached at through
+         * the btl; the address valid here is local_base. */
         return OMPI_SUCCESS;
     }
 


### PR DESCRIPTION
Follow-up to #14370, addressing the first item in @bosilca's post-merge review.

`allocate_state_single()` honours `use_cpu_atomics` for the window state and for
`base_handle`, but set the base flags unconditionally:

```c
    my_peer->flags |= OMPI_OSC_RDMA_PEER_LOCAL_BASE;
    my_peer->flags |= OMPI_OSC_RDMA_PEER_CPU_ATOMICS;
```

`allocate_state_shared()` gates exactly those two on `use_cpu_atomics`. The
single-local-peer path did not, so with `use_cpu_atomics` false the peer came out
self-contradictory: a `base_handle` installed for BTL access, and `CPU_ATOMICS`
claiming the memory may be touched directly.

### Reachability

With one process per node `local_size` is 1, so `allocate_state_shared()` hands
straight off to `allocate_state_single()`, and `use_cpu_atomics` is false whenever
the accelerated BTL does not advertise `MCA_BTL_ATOMIC_SUPPORTS_GLOB`.

### The failure

Under `MPI_MODE_SAME_OP` a rank skips the accumulate lock at the top of
`ompi_osc_rdma_compare_and_swap()`. A remote rank then computes `use_shared_mem`
false and issues a network atomic via `ompi_osc_rdma_cas_atomic()` *without*
holding the lock, while this rank — believing it has CPU atomics — takes
`ompi_osc_rdma_cas_local()` and touches the same memory with `opal_atomic_*()`.

The lock acquired further down, before the local path, does not serialize the
two, because the remote fast path never takes it. With the flag cleared this rank
computes `use_shared_mem` false as well and both sides use network atomics, which
is consistent.

Note this differs slightly from the mechanism in the review comment: the
`SAME_OP` shortcut skips only the *first* lock acquisition, and the one before
`cas_local()` is unconditional. The mixing comes from the remote side's unlocked
`cas_atomic()`, not from an unlocked local CAS.

### Second commit

Corrects the stale comment on the local-base early return in
`ompi_osc_rdma_peer_setup()`, the third item in the same review. `base` is now
the address the peer is reached at through the BTL; the address valid in this
process is `local_base`. No functional change.