### PR TITLE
opal/util: close TOCTOU races in os_dirpath

### DIFF
--- a/opal/util/os_dirpath.c
+++ b/opal/util/os_dirpath.c
@@ -12,6 +12,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All Rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,6 +24,7 @@
 #include "opal_config.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
@@ -47,6 +49,64 @@
 
 static const char path_sep[] = OPAL_PATH_SEP;
 
+/*
+ * The final directory in a create() already existed: make sure it
+ * really is a directory and that it carries at least the requested
+ * mode bits.
+ *
+ * The inspection and the mode change are both done through a single
+ * descriptor (open()/fstat()/fchmod()), so the object that gets
+ * inspected is the object that gets modified.  A path-based
+ * stat()/chmod() pair is the classic TOCTOU race: the name can be
+ * swapped between the two calls, redirecting the chmod onto an object
+ * that was never inspected.  The paths that reach this code are
+ * session/rendezvous directories with predictable names, frequently
+ * rooted under a world-writable /tmp, so the race is not theoretical.
+ *
+ * O_DIRECTORY: a plain file sitting at the requested name is an error
+ * rather than something we chmod and report as usable.
+ *
+ * O_NOFOLLOW: refuse a symlink planted at the final component; following
+ * one would point the chmod (and any later use) at the link's target,
+ * which an attacker gets to choose.
+ *
+ * @retval OPAL_SUCCESS       It is a directory; mode is now adequate.
+ * @retval OPAL_ERR_NOT_FOUND It does not exist (vanished under us).
+ * @retval OPAL_ERR_PERM      It exists but the mode could not be set.
+ * @retval OPAL_ERROR         It exists but is not a usable directory.
+ */
+static int dirpath_ensure_mode(const char *path, const mode_t mode)
+{
+    struct stat buf;
+    int fd;
+
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        if (ENOENT == errno) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        /* ELOOP (symlink) and ENOTDIR (plain file) land here: something
+         * that is not a directory is occupying the name. */
+        return OPAL_ERROR;
+    }
+
+    if (0 != fstat(fd, &buf)) {
+        close(fd);
+        return OPAL_ERROR;
+    }
+    if (mode == (mode & buf.st_mode)) { /* already has the requested bits */
+        close(fd);
+        return OPAL_SUCCESS;
+    }
+    if (0 != fchmod(fd, buf.st_mode | mode)) {
+        opal_show_help("help-opal-util.txt", "dir-mode", true, path, mode, strerror(errno));
+        close(fd);
+        return OPAL_ERR_PERM;
+    }
+    close(fd);
+    return OPAL_SUCCESS;
+}
+
 int opal_os_dirpath_create(const char *path, const mode_t mode)
 {
     struct stat buf;
@@ -58,15 +118,14 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
         return (OPAL_ERR_BAD_PARAM);
     }
 
-    if (0 == (ret = stat(path, &buf))) {    /* already exists */
-        if (mode == (mode & buf.st_mode)) { /* has correct mode */
-            return (OPAL_SUCCESS);
-        }
-        if (0 == (ret = chmod(path, (buf.st_mode | mode)))) { /* successfully change mode */
-            return (OPAL_SUCCESS);
-        }
-        opal_show_help("help-opal-util.txt", "dir-mode", true, path, mode, strerror(errno));
-        return (OPAL_ERR_PERM); /* can't set correct mode */
+    /* If the path already exists, make sure it is a directory and that
+     * it carries at least the requested mode.  dirpath_ensure_mode()
+     * does the check and the chmod through a single descriptor so the
+     * two cannot race (see the helper's comment).  OPAL_ERR_NOT_FOUND
+     * means nothing is there yet, so fall through and create it. */
+    ret = dirpath_ensure_mode(path, mode);
+    if (OPAL_ERR_NOT_FOUND != ret) {
+        return ret;
     }
 
     /* quick -- try to make directory */
@@ -119,12 +178,24 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
             opal_argv_free(parts);
             free(tmp);
             return OPAL_ERROR;
-        } else if (i == (len - 1) && (mode != (mode & buf.st_mode))
-                   && (0 > chmod(tmp, (buf.st_mode | mode)))) {
-            opal_show_help("help-opal-util.txt", "dir-mode", true, tmp, mode, strerror(errno));
-            opal_argv_free(parts);
-            free(tmp);
-            return (OPAL_ERR_PERM); /* can't set correct mode */
+        }
+        if (i == (len - 1)) {
+            /* This is the directory the caller is going to use, so it
+             * must carry the requested mode.  Ensure that through a
+             * descriptor rather than a second path lookup, so the check
+             * and the chmod cannot be raced against a swapped name. */
+            ret = dirpath_ensure_mode(tmp, mode);
+            if (OPAL_SUCCESS != ret) {
+                if (OPAL_ERR_NOT_FOUND == ret) {
+                    /* it vanished between the stat above and the open */
+                    opal_show_help("help-opal-util.txt", "mkdir-failed", true, tmp,
+                                   strerror(ENOENT));
+                    ret = OPAL_ERROR;
+                }
+                opal_argv_free(parts);
+                free(tmp);
+                return ret;
+            }
         }
     }
 
@@ -143,31 +214,42 @@ int opal_os_dirpath_create(const char *path, const mode_t mode)
  * removed.  If the callback returns non-zero, then no removal is
  * done.
  */
-int opal_os_dirpath_destroy(const char *path, bool recursive,
-                            opal_os_dirpath_destroy_callback_fn_t cbfunc)
+
+/*
+ * Empty out the directory that "fd" refers to (and, when recursive,
+ * any subdirectories under it).  Takes ownership of "fd": it is closed
+ * by the closedir() below before this function returns.
+ *
+ * Every entry is inspected and removed *relative to the open directory
+ * descriptor* (fstatat()/openat()/unlinkat()) rather than by rebuilding
+ * and re-resolving its path, so no entry can be swapped between the
+ * point where it is classified and the point where it is acted upon:
+ * the thing we looked at is always the thing we remove.  This is what
+ * closes the stat()/unlink() TOCTOU race of the old path-based code.
+ *
+ * AT_SYMLINK_NOFOLLOW / O_NOFOLLOW keep symlinks as entries to be
+ * unlinked rather than paths to be followed: unlinkat() removes the
+ * link itself (never its target), and an entry swapped for a symlink
+ * just before we descend into it is refused by O_NOFOLLOW instead of
+ * sending the recursion outside the tree we were asked to destroy.
+ *
+ * "path" is the printable path of this directory; it is used only for
+ * the caller's callback and for building child display paths.
+ */
+static int dirpath_destroy_at(int fd, const char *path, bool recursive,
+                              opal_os_dirpath_destroy_callback_fn_t cbfunc)
 {
-    int rc, exit_status = OPAL_SUCCESS;
-    bool is_dir = false;
+    int rc, childfd, exit_status = OPAL_SUCCESS;
+    bool is_dir;
     DIR *dp;
     struct dirent *ep;
     char *filenm;
     struct stat buf;
 
-    if (NULL == path) { /* protect against error */
-        return OPAL_ERROR;
-    }
-
-    /*
-     * Make sure we have access to the the base directory
-     */
-    if (OPAL_SUCCESS != (rc = opal_os_dirpath_access(path, 0))) {
-        exit_status = rc;
-        goto cleanup;
-    }
-
-    /* Open up the directory */
-    dp = opendir(path);
+    /* fdopendir() takes ownership of fd; closedir() will close it */
+    dp = fdopendir(fd);
     if (NULL == dp) {
+        close(fd);
         return OPAL_ERROR;
     }
 
@@ -179,23 +261,18 @@ int opal_os_dirpath_destroy(const char *path, bool recursive,
             continue;
         }
 
-        /* Check to see if it is a directory */
-        is_dir = false;
-
-        /* Create a pathname.  This is not always needed, but it makes
-         * for cleaner code just to create it here.  Note that we are
-         * allocating memory here, so we need to free it later on.
+        /* Check to see if it is a directory.  Resolve the entry
+         * relative to the descriptor we already hold, not by name, and
+         * do not follow a symlink sitting at the entry.
          */
-        filenm = opal_os_path(false, path, ep->d_name, NULL);
-
-        rc = stat(filenm, &buf);
-        if (0 > rc) {
-            /* Handle a race condition. filenm might have been deleted by an
-             * other process running on the same node. That typically occurs
-             * when one task is removing the job_session_dir and an other task
-             * is still removing its proc_session_dir.
+        is_dir = false;
+        if (0 != fstatat(dirfd(dp), ep->d_name, &buf, AT_SYMLINK_NOFOLLOW)) {
+            /* Handle a race condition. The entry might have been deleted
+             * by another process running on the same node. That
+             * typically occurs when one task is removing the
+             * job_session_dir and another task is still removing its
+             * proc_session_dir.
              */
-            free(filenm);
             continue;
         }
         if (S_ISDIR(buf.st_mode)) {
@@ -211,7 +288,6 @@ int opal_os_dirpath_destroy(const char *path, bool recursive,
              * but continue removing files
              */
             exit_status = OPAL_ERROR;
-            free(filenm);
             continue;
         }
 
@@ -222,35 +298,83 @@ int opal_os_dirpath_destroy(const char *path, bool recursive,
              * continue with the rest of the entries
              */
             if (!(cbfunc(path, ep->d_name))) {
-                free(filenm);
                 continue;
             }
         }
+
         /* Directories are recursively destroyed */
         if (is_dir) {
-            rc = opal_os_dirpath_destroy(filenm, recursive, cbfunc);
+            /* Descend through the descriptor we already hold, refusing a
+             * symlink planted at the entry. */
+            childfd = openat(dirfd(dp), ep->d_name, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+            if (0 > childfd) {
+                if (ENOENT != errno) {
+                    /* the entry is no longer an ordinary directory --
+                     * leave it alone rather than chase it */
+                    exit_status = OPAL_ERROR;
+                }
+                continue;
+            }
+            /* Build the printable child path for the callback and any
+             * error messages in the deeper level. */
+            filenm = opal_os_path(false, path, ep->d_name, NULL);
+            rc = dirpath_destroy_at(childfd, (NULL == filenm) ? ep->d_name : filenm,
+                                    recursive, cbfunc);
             free(filenm);
             if (OPAL_SUCCESS != rc) {
                 exit_status = rc;
                 closedir(dp);
-                goto cleanup;
+                return exit_status;
             }
+            /* Remove the now-empty subdirectory.  This fails harmlessly
+             * if the callback chose to preserve something inside it. */
+            unlinkat(dirfd(dp), ep->d_name, AT_REMOVEDIR);
         } else {
             /* Files are removed right here */
-            if (0 != (rc = unlink(filenm))) {
+            if (0 != unlinkat(dirfd(dp), ep->d_name, 0)) {
                 exit_status = OPAL_ERROR;
             }
-            free(filenm);
         }
     }
 
     /* Done with this directory */
     closedir(dp);
 
-cleanup:
+    return exit_status;
+}
+
+int opal_os_dirpath_destroy(const char *path, bool recursive,
+                            opal_os_dirpath_destroy_callback_fn_t cbfunc)
+{
+    int fd, exit_status;
+
+    if (NULL == path) { /* protect against error */
+        return OPAL_ERROR;
+    }
+
+    /* Open the base directory.  O_NOFOLLOW refuses to descend through a
+     * symlinked base path: the session directories sit under a
+     * world-writable root with predictable names, so a link planted
+     * there could otherwise redirect this whole recursive removal at a
+     * tree of an attacker's choosing.  Enumerating and removing through
+     * the resulting descriptor (in dirpath_destroy_at()) is what closes
+     * the check/use race. */
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (0 > fd) {
+        /* Preserve the documented contract: a directory that does not
+         * exist is reported as OPAL_ERR_NOT_FOUND; any other failure to
+         * open it (including a non-directory or a symlink at the base)
+         * is a generic error. */
+        if (ENOENT == errno) {
+            return OPAL_ERR_NOT_FOUND;
+        }
+        return OPAL_ERROR;
+    }
+
+    exit_status = dirpath_destroy_at(fd, path, recursive, cbfunc);
 
     /*
-     * If the directory is empty, them remove it
+     * If the directory is empty, then remove it
      */
     if (opal_os_dirpath_is_empty(path)) {
         rmdir(path);


### PR DESCRIPTION
CodeQL flagged three time-of-check/time-of-use filesystem races, all of the same shape: a path is inspected by name (stat) and then operated on by name (chmod or unlink), so the object checked need not be the object acted upon.

Use a single fd descriptor so the steps cannot be racy. opal_os_dirpath_create() now adjusts the final directory's mode with open(O_DIRECTORY|O_NOFOLLOW)+fstat+fchmod instead of stat+chmod on the path.  opal_os_dirpath_destroy() opens the directory O_NOFOLLOW, takes ownership of the descriptor via fdopendir(), and classifies and removes each entry relative to that descriptor with fstatat/openat/ unlinkat (AT_SYMLINK_NOFOLLOW, O_NOFOLLOW), so a symlink swapped in for an entry is unlinked rather than followed and the recursion cannot escape the tree it was told to destroy.