### PR TITLE
communicator: fix propagation of cached information across the constructors

### DIFF
--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -336,6 +336,14 @@ int ompi_comm_set_nb (ompi_communicator_t **ncomm, ompi_communicator_t *oldcomm,
     newcomm->c_my_rank = newcomm->c_local_group->grp_my_rank;
     newcomm->c_assertions = 0;
 
+    /* Subscribe the assertions that are driven by info keys here, so that
+       every constructor honours them and so that a later MPI_Comm_set_info
+       reaches their callbacks.  Subscribing creates s_info and applies the
+       default of each key, hence it must follow the reset of c_assertions
+       just above. */
+    ompi_comm_assert_subscribe (newcomm, OMPI_COMM_ASSERT_LAZY_BARRIER);
+    ompi_comm_assert_subscribe (newcomm, OMPI_COMM_ASSERT_ACTIVE_POLL);
+
     /* Set remote group and duplicate the local comm, if applicable */
     if ((NULL == remote_group) && (NULL != remote_ranks)) {
         /* determine how the list of local_rank can be stored most
@@ -543,9 +551,8 @@ int ompi_comm_create_w_info (ompi_communicator_t *comm, ompi_group_t *group, opa
     }
 
     /* Copy info if there is one. */
-    newcomp->super.s_info = OBJ_NEW(opal_info_t);
     if (info) {
-        opal_info_dup(info, &(newcomp->super.s_info));
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&comm->instance->super, &newcomp->super, info, &type);
@@ -804,9 +811,8 @@ int ompi_comm_split_with_info( ompi_communicator_t* comm, int color, int key,
 	     ompi_comm_print_cid (newcomp), ompi_comm_print_cid (comm));
 
     /* Copy info if there is one */
-    newcomp->super.s_info = OBJ_NEW(opal_info_t);
     if (info) {
-        opal_info_dup(info, &(newcomp->super.s_info));
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&comm->instance->super, &newcomp->super, info, &type);
@@ -1367,10 +1373,8 @@ static int ompi_comm_split_type_core(ompi_communicator_t *comm,
         goto exit;
     }
 
-    ompi_comm_assert_subscribe (newcomp, OMPI_COMM_ASSERT_LAZY_BARRIER);
-    ompi_comm_assert_subscribe (newcomp, OMPI_COMM_ASSERT_ACTIVE_POLL);
     if (info) {
-        opal_infosubscribe_change_info(&newcomp->super, info);
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&comm->instance->super, &newcomp->super, info, &type);
@@ -1819,10 +1823,8 @@ int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info,
 	     ompi_comm_print_cid (newcomp), ompi_comm_print_cid (comm));
 
     // Copy info if there is one.
-    ompi_comm_assert_subscribe (newcomp, OMPI_COMM_ASSERT_LAZY_BARRIER);
-    ompi_comm_assert_subscribe (newcomp, OMPI_COMM_ASSERT_ACTIVE_POLL);
     if (info) {
-        opal_infosubscribe_change_info(&newcomp->super, info);
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&comm->instance->super, &newcomp->super, info, &type);
@@ -1915,9 +1917,8 @@ static int ompi_comm_idup_internal (ompi_communicator_t *comm, ompi_group_t *gro
     // Copy info if there is one.
     {
         ompi_communicator_t *newcomp = context->newcomp;
-        newcomp->super.s_info = OBJ_NEW(opal_info_t);
         if (info) {
-            opal_info_dup(info, &(newcomp->super.s_info));
+            opal_infosubscribe_change_info (&newcomp->super, info);
         }
 
         ompi_info_memkind_assert_type type;
@@ -2072,9 +2073,8 @@ int ompi_comm_create_from_group (ompi_group_t *group, const char *tag, opal_info
     snprintf(newcomp->c_name, OMPI_MPI_MAX_OBJECT_NAME_ABI, "MPI COMM %s FROM GROUP",
 	     ompi_comm_print_cid (newcomp));
 
-    newcomp->super.s_info = OBJ_NEW(opal_info_t);
-    if (NULL == newcomp->super.s_info) {
-        return OMPI_ERR_OUT_OF_RESOURCE;
+    if (info) {
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&group->grp_instance->super, &newcomp->super, info, &type);
@@ -2220,8 +2220,6 @@ int ompi_intercomm_create (ompi_communicator_t *local_comm, int local_leader, om
         return rc;
     }
 
-    // Copy info if there is one.
-    newcomp->super.s_info = OBJ_NEW(opal_info_t);
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&local_comm->instance->super, &newcomp->super,
                                    &ompi_mpi_info_null.info.super, &type);
@@ -2387,9 +2385,8 @@ int ompi_intercomm_create_from_groups (ompi_group_t *local_group, int local_lead
     snprintf(newcomp->c_name, OMPI_MPI_MAX_OBJECT_NAME_ABI, "MPI INTERCOMM %s FROM GROUP", ompi_comm_print_cid (newcomp));
 
     // Copy info if there is one.
-    newcomp->super.s_info = OBJ_NEW(opal_info_t);
     if (info) {
-        opal_info_dup(info, &(newcomp->super.s_info));
+        opal_infosubscribe_change_info (&newcomp->super, info);
     }
     ompi_info_memkind_assert_type type;
     ompi_info_memkind_copy_or_set (&local_group->grp_instance->super, &newcomp->super, info, &type);

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -605,7 +605,8 @@ int ompi_comm_create ( ompi_communicator_t *comm, ompi_group_t *group,
 
 int ompi_comm_split_with_info( ompi_communicator_t* comm, int color, int key,
                                opal_info_t *info,
-                               ompi_communicator_t **newcomm, bool pass_on_topo )
+                               ompi_communicator_t **newcomm,
+                               bool pass_on_topo __opal_attribute_unused__ )
 {
     int myinfo[2];
     int size, my_size;
@@ -777,7 +778,7 @@ int ompi_comm_split_with_info( ompi_communicator_t* comm, int color, int key,
                          comm->error_handler,/* error handler */
                          local_group,        /* local group */
                          remote_group,       /* remote group */
-                         pass_on_topo ? OMPI_COMM_SET_FLAG_COPY_TOPOLOGY : 0); /* flags */
+                         0);                 /* flags */
 
     if ( OMPI_SUCCESS != rc  ) {
         goto exit;

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -2021,7 +2021,7 @@ int ompi_comm_create_group (ompi_communicator_t *comm, ompi_group_t *group, int 
                           comm->error_handler,                    /* error handler */
                           group,                                  /* local group */
                           NULL,                                   /* remote group */
-                          OMPI_COMM_SET_FLAG_COPY_TOPOLOGY);      /* flags */
+                          0);                                     /* flags */
     if ( OMPI_SUCCESS != rc) {
         return rc;
     }

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1779,7 +1779,7 @@ int ompi_comm_dup ( ompi_communicator_t * comm, ompi_communicator_t **newcomm )
 /**********************************************************************/
 /**********************************************************************/
 int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info,
-                              ompi_communicator_t **newcomm, bool pass_on_topo )
+                              ompi_communicator_t **newcomm, bool inherit_cached_info )
 {
     ompi_communicator_t *newcomp = NULL;
     ompi_group_t *remote_group = NULL;
@@ -1798,11 +1798,11 @@ int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info,
                           NULL,                                   /* local_procs*/
                           0,                                      /* remote array size */
                           NULL,                                   /* remote_procs */
-                          comm->c_keyhash,                        /* attrs */
+                          inherit_cached_info ? comm->c_keyhash : NULL, /* attrs */
                           comm->error_handler,                    /* error handler */
                           comm->c_local_group,                    /* local group */
                           remote_group,                           /* remote group */
-                          pass_on_topo ? OMPI_COMM_SET_FLAG_COPY_TOPOLOGY : 0); /* flags */
+                          inherit_cached_info ? OMPI_COMM_SET_FLAG_COPY_TOPOLOGY : 0); /* flags */
     if ( OMPI_SUCCESS != rc) {
         return rc;
     }
@@ -2017,7 +2017,7 @@ int ompi_comm_create_group (ompi_communicator_t *comm, ompi_group_t *group, int 
                           NULL,                                   /* local_procs*/
                           0,                                      /* remote_size */
                           NULL,                                   /* remote_procs */
-                          comm->c_keyhash,                        /* attrs */
+                          NULL,                                   /* attrs */
                           comm->error_handler,                    /* error handler */
                           group,                                  /* local group */
                           NULL,                                   /* remote group */

--- a/ompi/communicator/comm.c
+++ b/ompi/communicator/comm.c
@@ -1772,13 +1772,14 @@ int ompi_comm_split_type (ompi_communicator_t *comm, int split_type, int key,
 /**********************************************************************/
 int ompi_comm_dup ( ompi_communicator_t * comm, ompi_communicator_t **newcomm )
 {
-    return ompi_comm_dup_with_info (comm, NULL, newcomm);
+    return ompi_comm_dup_with_info (comm, NULL, newcomm, true);
 }
 
 /**********************************************************************/
 /**********************************************************************/
 /**********************************************************************/
-int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info, ompi_communicator_t **newcomm )
+int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info,
+                              ompi_communicator_t **newcomm, bool pass_on_topo )
 {
     ompi_communicator_t *newcomp = NULL;
     ompi_group_t *remote_group = NULL;
@@ -1801,7 +1802,7 @@ int ompi_comm_dup_with_info ( ompi_communicator_t * comm, opal_info_t *info, omp
                           comm->error_handler,                    /* error handler */
                           comm->c_local_group,                    /* local group */
                           remote_group,                           /* remote group */
-                          OMPI_COMM_SET_FLAG_COPY_TOPOLOGY);      /* flags */
+                          pass_on_topo ? OMPI_COMM_SET_FLAG_COPY_TOPOLOGY : 0); /* flags */
     if ( OMPI_SUCCESS != rc) {
         return rc;
     }

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -1016,8 +1016,13 @@ OMPI_DECLSPEC int ompi_comm_idup (ompi_communicator_t *comm, ompi_communicator_t
  *
  * @param comm:      input communicator
  * @param newcomm:   the new communicator or MPI_COMM_NULL if any error is detected.
+ * @param pass_on_topo: propagate the topology of comm to newcomm. MPI_Comm_dup
+ *                   must do so, but the topology constructors dup a
+ *                   communicator only to attach a topology of their own and
+ *                   have no use for the one they would inherit.
  */
-OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, opal_info_t *info, ompi_communicator_t **newcomm);
+OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, opal_info_t *info,
+                                           ompi_communicator_t **newcomm, bool pass_on_topo);
 
 /**
  * dup a communicator (non-blocking) with info.

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -1016,13 +1016,16 @@ OMPI_DECLSPEC int ompi_comm_idup (ompi_communicator_t *comm, ompi_communicator_t
  *
  * @param comm:      input communicator
  * @param newcomm:   the new communicator or MPI_COMM_NULL if any error is detected.
- * @param pass_on_topo: propagate the topology of comm to newcomm. MPI_Comm_dup
- *                   must do so, but the topology constructors dup a
- *                   communicator only to attach a topology of their own and
- *                   have no use for the one they would inherit.
+ * @param inherit_cached_info: propagate the information cached on comm -- its
+ *                   attributes and its topology -- to newcomm. Duplication is
+ *                   the only MPI communicator constructor that does so, but
+ *                   the topology constructors duplicate a communicator merely
+ *                   to attach a topology of their own and must not inherit
+ *                   either.
  */
 OMPI_DECLSPEC int ompi_comm_dup_with_info (ompi_communicator_t *comm, opal_info_t *info,
-                                           ompi_communicator_t **newcomm, bool pass_on_topo);
+                                           ompi_communicator_t **newcomm,
+                                           bool inherit_cached_info);
 
 /**
  * dup a communicator (non-blocking) with info.

--- a/ompi/communicator/communicator.h
+++ b/ompi/communicator/communicator.h
@@ -967,12 +967,16 @@ OMPI_DECLSPEC int ompi_comm_split (ompi_communicator_t *comm, int color, int key
  * @param comm: input communicator
  * @param color
  * @param key
+ * @param pass_on_topo: ignored. Splitting a communicator does not propagate
+ *                   the topology of the parent, and no caller has ever asked
+ *                   it to; the parameter is kept only to spare the call sites.
  *
  * @
  */
 OMPI_DECLSPEC int ompi_comm_split_with_info( ompi_communicator_t* comm, int color, int key,
                                              opal_info_t *info,
-                                             ompi_communicator_t **newcomm, bool pass_on_topo );
+                                             ompi_communicator_t **newcomm,
+                                             bool pass_on_topo __opal_attribute_unused__ );
 
 /**
  * split a communicator based on type and key. Parameters

--- a/ompi/communicator/ft/comm_ft.c
+++ b/ompi/communicator/ft/comm_ft.c
@@ -311,7 +311,7 @@ int ompi_comm_shrink_internal(ompi_communicator_t* comm, ompi_communicator_t** n
                         NULL,                     /* local_ranks */
                         0,                        /* remote_size */
                         NULL,                     /* remote_ranks */
-                        comm->c_keyhash,          /* attrs */
+                        NULL,                     /* attrs */
                         comm->error_handler,      /* error handler */
                         alive_group,              /* local group */
                         alive_rgroup,             /* remote group */
@@ -589,7 +589,7 @@ static int ompi_comm_ishrink_check_agree(ompi_comm_request_t *request) {
                            NULL,                     /* local_ranks */
                            0,                        /* remote_size */
                            NULL,                     /* remote_ranks */
-                           comm->c_keyhash,          /* attrs */
+                           NULL,                     /* attrs */
                            comm->error_handler,      /* error handler */
                            context->alive_group,     /* local group */
                            context->alive_rgroup,    /* remote group */

--- a/ompi/mca/pml/ob1/pml_ob1.c
+++ b/ompi/mca/pml/ob1/pml_ob1.c
@@ -221,7 +221,7 @@ mca_pml_ob1_set_allow_overtake(opal_infosubscriber_t* obj,
      */
     if (opal_str_to_bool(value)) {
         if (!allow_overtake_was_set) {
-            ompi_comm->c_flags |= OMPI_COMM_ASSERT_ALLOW_OVERTAKE;
+            ompi_comm->c_assertions |= OMPI_COMM_ASSERT_ALLOW_OVERTAKE;
             mca_pml_ob1_merge_cant_match(ompi_comm);
         }
         return "true";

--- a/ompi/mca/topo/base/topo_base_dist_graph_create.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create.c
@@ -292,7 +292,9 @@ int mca_topo_base_dist_graph_create(mca_topo_base_module_t* module,
 {
     int err;
 
-    if (OMPI_SUCCESS != (err = ompi_comm_dup_with_info (comm_old, info, newcomm))) {
+    /* comm_old may carry a topology of its own; it has no bearing on the
+       distributed graph we are about to attach, so do not inherit it. */
+    if (OMPI_SUCCESS != (err = ompi_comm_dup_with_info (comm_old, info, newcomm, false))) {
         OBJ_RELEASE(module);
         return err;
     }

--- a/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
@@ -109,7 +109,9 @@ int mca_topo_base_dist_graph_create_adjacent(mca_topo_base_module_t* module,
 {
     int err;
 
-    if (OMPI_SUCCESS != (err = ompi_comm_dup_with_info (comm_old, info, newcomm))) {
+    /* comm_old may carry a topology of its own; it has no bearing on the
+       distributed graph we are about to attach, so do not inherit it. */
+    if (OMPI_SUCCESS != (err = ompi_comm_dup_with_info (comm_old, info, newcomm, false))) {
         return err;
     }
 

--- a/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
+++ b/ompi/mca/topo/base/topo_base_dist_graph_create_adjacent.c
@@ -39,8 +39,7 @@ static int _mca_topo_base_dist_graph_create_adjacent (mca_topo_base_module_t* mo
 
     topo = OBJ_NEW(mca_topo_base_comm_dist_graph_2_2_0_t);
     if (NULL == topo) {
-        ompi_comm_free (newcomm);
-        return OMPI_ERR_OUT_OF_RESOURCE;
+        goto bail_out;
     }
     topo->in = topo->inw = NULL;
     topo->out = topo->outw = NULL;
@@ -93,6 +92,10 @@ static int _mca_topo_base_dist_graph_create_adjacent (mca_topo_base_module_t* mo
         OBJ_RELEASE(topo);
     }
 
+    /* The module was handed to us by mca_topo_base_comm_select() and never
+       made it onto the communicator, so releasing the latter will not
+       account for it. */
+    OBJ_RELEASE(module);
     ompi_comm_free(newcomm);
     return err;
 }
@@ -112,6 +115,7 @@ int mca_topo_base_dist_graph_create_adjacent(mca_topo_base_module_t* module,
     /* comm_old may carry a topology of its own; it has no bearing on the
        distributed graph we are about to attach, so do not inherit it. */
     if (OMPI_SUCCESS != (err = ompi_comm_dup_with_info (comm_old, info, newcomm, false))) {
+        OBJ_RELEASE(module);
         return err;
     }
 

--- a/ompi/mpi/c/comm_dup_with_info.c.in
+++ b/ompi/mpi/c/comm_dup_with_info.c.in
@@ -71,7 +71,7 @@ PROTOTYPE ERROR_CLASS comm_dup_with_info(COMM comm, INFO info, COMM_OUT newcomm)
     }
 #endif
 
-    rc = ompi_comm_dup_with_info (comm, &info->super, newcomm);
+    rc = ompi_comm_dup_with_info (comm, &info->super, newcomm, true);
     OMPI_ERRHANDLER_RETURN(rc, comm, rc, FUNC_NAME);
 }
 


### PR DESCRIPTION
The MPI standard propagates *cached information* — attributes and the topology — only through communicator duplication. Open MPI's constructors disagreed about this, and about what to do with the `info` object they are given. Auditing that turned up a leak, a misreported topology type, and an assertion recorded in the wrong bit space.

Seven independent fixes, one per commit, reviewable and bisectable separately.

### The reported bug

`MPI_Dist_graph_create` and `MPI_Dist_graph_create_adjacent` build their communicator with `ompi_comm_dup_with_info()` and then attach a distributed graph module of their own. Because duplication propagates the parent's topology, the dup had already retained `comm_old`'s module and OR'ed its type into `c_flags`; overwriting `c_topo` dropped that reference and left the inherited type bit set. 

A distributed graph communicator derived from a cartesian one therefore leaked the cartesian module and claimed both `OMPI_COMM_CART` and `OMPI_COMM_DIST_GRAPH`. `MPI_Topo_test` checks cartesian first, so it reported `MPI_CART`, after which `MPI_Cart_get` and friends read the cartesian arm of a union holding a distributed graph. Both constructors already asserted the duplicate had no topology, so debug builds aborted rather than leaking quietly.

#14420 is a solution to that case, but it copies the topology just to release it right after. But the real problem is that this is just the tip of the iceberg, OMPI has deeper issues with topology and attributes, and I try to fix them all here.

Fixed by giving `ompi_comm_dup_with_info()` the same opt-out `ompi_comm_split()` has carried for years, so nothing is copied only to be released again.

### The rest

- **`pml/ob1`: the `allow_overtaking` assertion was written to `c_flags` instead of `c_assertions`.** The two bit spaces are unrelated — `0x8` in `c_flags` is `OMPI_COMM_DYNAMIC`. Setting `mpi_assert_allow_overtaking` thus marked the communicator dynamic and left the assertion unset, so the out-of-order matching fast paths in `pml_ob1_isend.c` and `pml_ob1_recvfrag.c` never saw what the user asked for. 
- **`MPI_Dist_graph_create_adjacent` leaked the topology module on its error paths.** It owns the module until a communicator takes it; the non-adjacent counterpart already released it.
- **`MPI_Comm_create_group` propagated the parent's topology.** The `ompi_comm_set()` call was copied verbatim from `ompi_comm_dup_with_info()` when the two were introduced in the same commit. With a subgroup or a reordered group, the inherited dimensions describe a layout the new communicator does not have, and `MPI_Cart_rank`/`MPI_Cart_shift` can return ranks outside it.
- **`MPI_Comm_create_group` and the two ULFM shrink paths propagated the parent's attributes**, invoking the registered copy callbacks. Shrink is documented as equivalent to a split that succeeds despite failures, and
  split propagates nothing.
- **`info` was applied inconsistently.** Only `MPI_Comm_dup_with_info` and `MPI_Comm_split_type` subscribed the info-driven assertions and ran the user's info through `opal_infosubscribe_change_info()`; the others copied key-value pairs with `opal_info_dup()`, which runs no callback. So `ompi_assert_lazy_barrier` and `ompi_assert_active_poll` were silently ignored on `MPI_Comm_create`, `MPI_Comm_split`, `MPI_Comm_idup_with_info` (even though idup should behave as dup), `MPI_Comm_create_from_group` and `MPI_Intercomm_create_from_groups`, and a later `MPI_Comm_set_info` could not reach them either. `ompi_comm_create_from_group()` discarded the caller's info entirely. Both assertions are now subscribed once in `ompi_comm_set_nb()`, which every constructor funnels through.
- **`ompi_comm_split()`'s `pass_on_topo` argument is always `false`** at every call site, `MPI_Comm_split` included. The flag is no longer derived from it and the argument is marked unused, so the absence of topology propagation is stated by the code instead of left to the call sites.

### Notes

No user-visible interface changes and no ABI impact. The internal `ompi_comm_dup_with_info()` gains a trailing `bool inherit_cached_info`; all callers are updated in the same commit.

`MPI_Comm_get_info` output is unchanged: it dups publicly, skipping internal and unreferenced entries, and the entries `opal_info_dup()` used to produce were unreferenced.

Not addressed here: `mpi_assert_no_any_tag` and `mpi_assert_exact_length` are documented but have no consumers, and the predefined communicators are built in `comm_init.c` without passing through `ompi_comm_set_nb()`, so `MPI_Comm_set_info` on `MPI_COMM_WORLD`/`MPI_COMM_SELF` still does not reach the two assertion callbacks.